### PR TITLE
fix: mitigate workspace memory leaks in code-server

### DIFF
--- a/charts/workspace/templates/workspace-entrypoint-configmap.yaml
+++ b/charts/workspace/templates/workspace-entrypoint-configmap.yaml
@@ -50,8 +50,28 @@ data:
       python3 /github-app/github-app-token.py --daemon &
     fi
 
+    log_stage "seeding default code-server settings (first run only)"
+    CS_USER_DIR=/home/dev/.local/share/code-server/User
+    mkdir -p "$CS_USER_DIR"
+    if [ ! -f "$CS_USER_DIR/settings.json" ]; then
+      cat > "$CS_USER_DIR/settings.json" <<'JSON'
+    {
+      "terminal.integrated.scrollback": 2000,
+      "files.watcherExclude": {
+        "**/node_modules/**": true,
+        "**/.git/**": true,
+        "**/dist/**": true,
+        "**/build/**": true,
+        "**/.next/**": true,
+        "**/target/**": true
+      }
+    }
+    JSON
+    fi
+
     log_stage "starting code-server"
-    code-server --bind-addr 0.0.0.0:8080 --auth none \
+    NODE_OPTIONS="--max-old-space-size=1536" \
+      code-server --bind-addr 0.0.0.0:8080 --auth none \
       --user-data-dir /home/dev/.local/share/code-server \
       --extensions-dir /home/dev/.local/share/code-server/extensions \
       /home/dev > /tmp/code-server.log 2>&1 &
@@ -176,8 +196,11 @@ data:
         ( cd /tmp/browser && python3 server.py & )
       fi
       if ! netstat -tln 2>/dev/null | grep -q :8080; then
-        log_stage "restarting code-server"
-        code-server --bind-addr 0.0.0.0:8080 --auth none \
+        log_stage "restarting code-server (killing stale processes first)"
+        pkill -f "code-server" 2>/dev/null || true
+        sleep 1
+        NODE_OPTIONS="--max-old-space-size=1536" \
+          code-server --bind-addr 0.0.0.0:8080 --auth none \
           --user-data-dir /home/dev/.local/share/code-server \
           --extensions-dir /home/dev/.local/share/code-server/extensions \
           /home/dev >> /tmp/code-server.log 2>&1 &


### PR DESCRIPTION
Three changes to charts/workspace/templates/workspace-entrypoint-configmap.yaml addressing OOMKills we've seen in long-running workspaces:

1. Cap V8 old-generation heap at 1.5GB per code-server node process via NODE_OPTIONS. Default cgroup-aware behavior lets each of code-server's ~4 node processes grow to ~25% of the container limit, which means a 4Gi cgroup can be entirely consumed by code-server alone over time.

2. Watchdog respawn now pkills stale code-server processes before relaunching. Previously the loop only checked port :8080 — if the listener crashed but worker processes lingered, restart added another full code-server tree on top of the dead one. Mirrors the existing pattern used for websockify.

3. Seed a default settings.json on first run with a bounded terminal scrollback and watcher excludes for node_modules / build dirs. Prevents the file watcher from indexing dependency trees, which is the most common silent memory growth source over multi-day sessions.

The seed only runs if the user has no existing settings.json, so it respects any customizations users make later.