### PR TITLE
harden workspace chart for shared-cluster posture

### DIFF
--- a/charts/workspace/templates/_helpers.tpl
+++ b/charts/workspace/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{{/*
+DECIDED NOT TO IMPLEMENT (kept for context):
+
+We considered stripping client-supplied identity headers
+(X-Forwarded-User / -Email / -Preferred-Username / -Groups) at each
+workspace-facing Ingress as defense-in-depth, in case some future
+in-pod code starts trusting them. The natural mechanism on
+nginx-ingress is `nginx.ingress.kubernetes.io/configuration-snippet`,
+but the cluster's ingress controller runs with `--allow-snippet-
+annotations=false` (CVE-2021-25742 hardening, cluster-wide) and its
+admission webhook rejects snippets.
+
+Re-enabling snippets would weaken posture for 20+ unrelated tenants on
+this shared DOKS cluster — not worth it for a header-strip that
+nothing currently trusts. If a future in-pod handler begins
+authorizing off these headers, revisit by adding a single shared
+ConfigMap in `ingress-nginx` and pointing each workspace ingress at it
+via the `proxy-set-headers` annotation (which is *not* a snippet and
+is allowed).
+*/}}

--- a/charts/workspace/templates/deployment.yaml
+++ b/charts/workspace/templates/deployment.yaml
@@ -174,6 +174,24 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        # Container-level hardening for the user's IDE/desktop process. The
+        # pod-level securityContext already pins UID/GID 1000; this block
+        # additionally blocks privilege escalation, drops all Linux
+        # capabilities (none of code-server / ttyd / Xvfb / x11vnc /
+        # websockify / fluxbox / Claude / Playwright need any), and pins
+        # the runtime's default seccomp profile.
+        #
+        # Playwright's Firefox sandbox falls back to unprivileged
+        # user-namespaces on modern kernels (DOKS runs 6.1+); if a future
+        # workload needs CAP_SYS_CHROOT or CAP_SYS_ADMIN, add it back
+        # narrowly via `capabilities.add` rather than removing the drop.
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
       {{- if eq .Values.build.mode "buildkit" }}
       - name: dind
         image: docker:27-dind

--- a/charts/workspace/templates/networkpolicy.yaml
+++ b/charts/workspace/templates/networkpolicy.yaml
@@ -1,0 +1,45 @@
+{{/*
+NetworkPolicy: restrict ingress to this workspace's pods.
+
+By default Kubernetes lets any pod in the cluster talk to any other pod.
+On a shared multi-tenant cluster that means a compromised pod in another
+namespace (resourceloop, scalebase, drinkq, …) can reach `ws-<user>:8080`
+directly and skip the oauth2-proxy. This policy denies all ingress to
+the workspace + oauth2-proxy pods except from the nginx ingress
+controller namespace, which is the only legitimate path.
+
+Same-namespace ingress is also denied: workspaces should never talk to
+each other inside the `coder` namespace. Each workspace's pods only need
+to reach the outside world (GitHub, registries, model providers) and
+their own sidecars on localhost — neither is affected by this policy.
+
+Egress is intentionally NOT restricted here. Tightening egress requires
+a per-cluster allowlist (kube-dns, kube-apiserver, registries, model
+providers, GitHub) and is best layered in a follow-up once traffic
+patterns are confirmed in prod. CNI is Cilium so adding egress rules
+later is straightforward.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ws-{{ .Values.user.name }}-ingress
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: ws-{{ .Values.user.name }}
+spec:
+  podSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - ws-{{ .Values.user.name }}
+      {{- if eq .Values.ingress.auth.type "oauth2" }}
+      - oauth2-proxy-{{ .Values.user.name }}
+      {{- end }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx

--- a/charts/workspace/templates/serviceaccount.yaml
+++ b/charts/workspace/templates/serviceaccount.yaml
@@ -4,17 +4,20 @@ metadata:
   name: ws-{{ .Values.user.name }}
   namespace: {{ .Values.namespace }}
 ---
+# Namespace-scoped: every kubectl call from the workspace targets its own
+# namespace (CronManager reads /var/run/secrets/.../namespace and passes
+# `-n $ns` explicitly). A ClusterRole would let a workspace user list pods /
+# read logs / mutate Secrets cluster-wide, which on this shared DOKS cluster
+# means cross-tenant exposure to ~20 unrelated apps.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: ws-{{ .Values.user.name }}-build
+  namespace: {{ .Values.namespace }}
 rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["create", "get", "list", "watch", "delete"]
-# Cron triggers create/manage CronJobs + companion Secrets. Scoped here rather
-# than in a separate Role because CronManager.create_or_update also issues
-# `kubectl create job --from=cronjob/...` for the manual "Run now" button.
 - apiGroups: ["batch"]
   resources: ["cronjobs"]
   verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
@@ -26,12 +29,13 @@ rules:
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: ws-{{ .Values.user.name }}-build
+  namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: ws-{{ .Values.user.name }}-build
 subjects:
 - kind: ServiceAccount

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -39,9 +39,22 @@ resources:
     cpu: "2"
     memory: 6Gi
 
-# Build configuration
+# Build configuration.
+#
+#   mode: kaniko    (default, recommended)
+#     Image builds run as a one-shot Kaniko Job in the user's namespace,
+#     scheduled by the `docker-build` wrapper. No daemon, no privileged
+#     container. `docker run` and `docker buildx` are NOT available from
+#     the user's shell.
+#
+#   mode: buildkit
+#     Adds a `dind` sidecar to every workspace pod running with
+#     `privileged: true` + UID 0. This gives `docker buildx` and ad-hoc
+#     `docker run` from the user's shell, but a shell in either container
+#     can escape to the underlying node. On a shared multi-tenant cluster
+#     prefer `kaniko` unless `docker run` is required.
 build:
-  mode: buildkit
+  mode: kaniko
   kanikoImage: gcr.io/kaniko-project/executor:latest
   pushSecretName: regcred
   defaultDestinationRepo: registry.digitalocean.com/resourceloop/coder
@@ -119,12 +132,18 @@ memory:
 # Two ways to supply credentials:
 #  (1) Inline via appId / installationId / privateKey (the chart creates a
 #      Secret named github-app-secrets-<user>). Provide secrets via a
-#      values overlay (e.g., secrets/<user>/github-app.yaml).
+#      values overlay (e.g., secrets/<user>/github-app.yaml). RECOMMENDED.
 #  (2) Reference an existing Secret in the same namespace via
 #      `existingSecretName`. The Secret must have keys: app-id,
 #      installation-id, private-key. Set `appId: "use-existing"` (or any
 #      non-empty placeholder) to flip the deployment env-var gate; the
 #      actual values come from the referenced Secret.
+#
+# SECURITY: option (2) lets multiple workspaces share one GitHub App
+# private key. Anyone with shell access in a workspace can `cat` that
+# key and act as the App on every repo it's installed on. Use only for
+# workspaces operated by the same trusted principal — never to give
+# another developer a workspace pre-wired to your App.
 github:
   app:
     appId: ""

--- a/scripts/user-template/values.yaml.tmpl
+++ b/scripts/user-template/values.yaml.tmpl
@@ -84,6 +84,9 @@ claude:
 
 # GitHub App for repo access:
 #   Drop credentials in users-private/__USER__/secrets/github-app.yaml.
+#   Each workspace gets its OWN GitHub App, not a shared one — anyone with
+#   shell in this workspace can read the private key. Do not point this at
+#   another user's App via `existingSecretName`.
 github:
   app:
     appId: ""

--- a/scripts/validate-user.sh
+++ b/scripts/validate-user.sh
@@ -79,7 +79,12 @@ if [ ! -d "$CHART" ]; then
   fail "workspace chart missing at $CHART"
 else
   HELM_F=(-f "$VALUES")
-  for f in "${SECRET_FILES[@]}"; do HELM_F+=(-f "$f"); done
+  # Workspaces without any secrets/*.yaml (e.g. the sentinel `locked`
+  # workspace) leave SECRET_FILES empty; under `set -u`, expanding an
+  # empty array with [@] raises an error, so guard with :-.
+  for f in "${SECRET_FILES[@]:-}"; do
+    [ -n "$f" ] && HELM_F+=(-f "$f")
+  done
   RENDER_OUT=$(helm template validate-preview "$CHART" "${HELM_F[@]}" 2>&1)
   RENDER_RC=$?
   if [ "$RENDER_RC" -ne 0 ]; then


### PR DESCRIPTION
- Scope ws-{user}-build to a namespaced Role/RoleBinding; the previous ClusterRole granted cross-namespace pod/log read across ~20 unrelated tenants on this shared DOKS cluster.
- Add a NetworkPolicy that denies ingress to ws-{user} + oauth2-proxy pods except from the ingress-nginx namespace, blocking direct intra-cluster reach that would skip oauth2-proxy.
- Drop all Linux capabilities, disable privilege escalation and pin the RuntimeDefault seccomp profile on the ide container.
- Default new workspaces to build.mode: kaniko so the privileged dind sidecar is opt-in; document the tradeoff in chart + user template.
- Tried nginx configuration-snippets for identity-header stripping; the controller rejects them (CVE-2021-25742 mitigation enabled cluster-wide), so left a decision note in _helpers.tpl instead of weakening posture for other tenants.

Also rolls in the earlier validate-user.sh \`set -u\` fix for empty SECRET_FILES arrays (sentinel \`locked\` workspace).