### PR TITLE
fix(mobile): make bottom-sheet close X reliably dismiss the sheet

### DIFF
--- a/charts/workspace/web/src/components/BottomSheet.css
+++ b/charts/workspace/web/src/components/BottomSheet.css
@@ -49,13 +49,16 @@
 .sheet-title { font-size: 15px; font-weight: 600; letter-spacing: -0.01em; }
 
 /* Folded handle+close row used when there's no title — saves ~50px of
-   vertical space on mobile by avoiding a stacked handle + header. */
+   vertical space on mobile by avoiding a stacked handle + header.
+   The grab is centered in the full row; the close X is positioned at the
+   right edge so the two controls don't share a tap zone. */
 .sheet-handlerow {
   position: relative;
-  display: grid;
-  grid-template-columns: 1fr auto;
+  display: flex;
   align-items: center;
-  padding: 4px var(--size-2) 4px;
+  justify-content: center;
+  min-height: 44px;
+  padding: 4px var(--size-2);
   flex-shrink: 0;
 }
 .sheet-handle-inline {
@@ -63,10 +66,17 @@
   background: transparent;
   cursor: grab;
   touch-action: none;
-  /* iOS minimum tap target is 44px; bump padding so the swipe-to-dismiss
-     gesture works reliably without hijacking neighboring controls. */
+  /* iOS minimum tap target is 44px; constrain width so the swipe-to-dismiss
+     gesture doesn't extend into the X's tap zone on the right. */
+  width: 120px;
   padding: 14px 0;
   display: flex; align-items: center; justify-content: center;
+}
+.sheet-handlerow > .btn-icon {
+  position: absolute;
+  right: var(--size-2);
+  top: 50%;
+  transform: translateY(-50%);
 }
 .sheet-handle-inline:active { cursor: grabbing; }
 

--- a/charts/workspace/web/src/components/BottomSheet.tsx
+++ b/charts/workspace/web/src/components/BottomSheet.tsx
@@ -87,17 +87,19 @@ export function BottomSheet({ open, onClose, title, initialSnap = 'peek', childr
             </div>
           </>
         ) : (
-          <div
-            class="sheet-handlerow"
-            onTouchStart={onTouchStart}
-            onTouchMove={onTouchMove}
-            onTouchEnd={onTouchEnd}
-          >
+          // Touch handlers live on the grab button ONLY — not the outer row.
+          // Otherwise a tap on the X picks up the natural finger drift, crosses
+          // the swipe-down threshold, and collapses the sheet to peek instead
+          // of firing the X's click — which reads to the user as "X doesn't work."
+          <div class="sheet-handlerow">
             <button
               type="button"
               class="sheet-handle sheet-handle-inline"
               aria-label={snap === 'peek' ? 'Expand sheet' : 'Collapse sheet'}
               onClick={() => setSnap((s) => (s === 'peek' ? 'full' : 'peek'))}
+              onTouchStart={onTouchStart}
+              onTouchMove={onTouchMove}
+              onTouchEnd={onTouchEnd}
             >
               <span class="sheet-grab" />
             </button>


### PR DESCRIPTION
The no-title BottomSheet attached its swipe-to-dismiss touch handlers to the outer .sheet-handlerow div, which also contained the close X. On a real touch the natural finger drift crossed the dy > 60 threshold, so tapping X collapsed the sheet to peek (or canceled the click entirely) instead of firing onClose — which read as "X doesn't work."

Scope the touch handlers to the grab button only, and restyle the row so the grab is truly centered while the X sits absolutely at the right edge with its own tap zone.