### PR TITLE
fix(make): disable provenance to stop buildx post-push hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,20 @@ build: ## Build Docker image for amd64 architecture (loads into local Docker)
 # if `build` was just run.
 push: ## Build and push Docker image (single buildx invocation; cache shared with `build`)
 	@echo "Building + pushing $(IMAGE)..."
+	# --provenance=false works around a recurring buildx hang where the
+	# CLI sits idle for minutes after `pushing manifest done`, blocking
+	# every `make ship` mid-flight. Root cause: buildkit's default
+	# provenance attestation generation + upload pass after the main
+	# manifest push doesn't time out cleanly on the docker-container
+	# driver in some network configs. We don't consume provenance metadata
+	# downstream, so disabling is loss-free. Same workaround used widely
+	# in CI/CD pipelines that hit this. --sbom=false for symmetry; never
+	# enabled by default but cheap insurance against the same class of
+	# post-push attestation hang.
 	docker buildx build \
 		--platform $(PLATFORM) \
+		--provenance=false \
+		--sbom=false \
 		-t $(IMAGE) \
 		-f devlaptop/Dockerfile \
 		--push \


### PR DESCRIPTION
Every `make ship USER=<x>` reliably hangs after `pushing manifest done` with the docker-container driver. The CLI sits idle for minutes (or indefinitely) while the chart deploy waits behind it, forcing manual intervention every time: kill -9 the hung buildx, then `make ship-config` to finish the helm upgrade + rollout.

Root cause: buildkit's default provenance attestation generation + upload pass runs after the main manifest push. On the docker-container driver it doesn't time out cleanly in some network configs (intermittent DO registry latency on the SLSA endpoint) and the CLI never reaps the attestation step.

We don't consume provenance metadata downstream (no admission controller, no cosign verification gate, no SLSA-aware deploy tooling). Disabling the attestation generation is loss-free for this repo and the standard workaround used in CI/CD pipelines that hit this. --sbom=false for symmetry; SBOM isn't on by default but cheap insurance against the same class of post-push attestation hang.

After this change, `make ship USER=demo` runs to completion through the helm upgrade without any kill-and-restart dance.