### PR TITLE
fix(controller): calm loading state for insights, retry transient kub…

### DIFF
--- a/charts/workspace-controller/controller.py
+++ b/charts/workspace-controller/controller.py
@@ -534,10 +534,16 @@ def compute_insights(window_seconds=None):
     try:
         deps = _kubectl_json(['get', 'deployments']).get('items', [])
         pods = _kubectl_json(['get', 'pods']).get('items', [])
-        pvcs = _kubectl_json(['get', 'pvc']).get('items', [])
     except KubectlError as exc:
         out['error'] = str(exc)
         return out
+    # PVC sizes are only needed for disk %-used and storage-cost tips — best
+    # effort so a missing read (or RBAC gap) degrades those tips, not all of them.
+    pvcs = []
+    try:
+        pvcs = _kubectl_json(['get', 'pvc']).get('items', [])
+    except KubectlError:
+        pass
 
     pvc_cap = {}
     for p in pvcs:

--- a/charts/workspace-controller/controller.py
+++ b/charts/workspace-controller/controller.py
@@ -94,21 +94,32 @@ class KubectlError(RuntimeError):
         self.stderr = stderr
 
 
-def _kubectl_json(args):
-    """Run `kubectl <args> -o json -n <ns>` and parse stdout."""
+def _kubectl_json(args, _attempts=2):
+    """Run `kubectl <args> -o json -n <ns>` and parse stdout.
+
+    Retries once on failure: kubectl's discovery cache is cold right after a pod
+    start and several read endpoints fire concurrently on page load, which can
+    make the first call fail transiently. These are read-only, so a retry is safe."""
     cmd = ['kubectl', *args, '-n', NAMESPACE, '-o', 'json']
-    try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=KUBECTL_TIMEOUT)
-    except FileNotFoundError:
-        raise KubectlError('kubectl not found on PATH')
-    except subprocess.TimeoutExpired:
-        raise KubectlError(f'kubectl timed out after {KUBECTL_TIMEOUT}s')
-    if proc.returncode != 0:
-        raise KubectlError(f'kubectl {args[0]} failed', proc.stderr.strip())
-    try:
-        return json.loads(proc.stdout)
-    except json.JSONDecodeError as exc:
-        raise KubectlError(f'kubectl returned non-JSON: {exc}')
+    last = None
+    for attempt in range(_attempts):
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=KUBECTL_TIMEOUT)
+        except FileNotFoundError:
+            raise KubectlError('kubectl not found on PATH')
+        except subprocess.TimeoutExpired:
+            last = KubectlError(f'kubectl timed out after {KUBECTL_TIMEOUT}s')
+        else:
+            if proc.returncode == 0:
+                try:
+                    return json.loads(proc.stdout)
+                except json.JSONDecodeError as exc:
+                    last = KubectlError(f'kubectl returned non-JSON: {exc}')
+            else:
+                last = KubectlError(f'kubectl {args[0]} failed', proc.stderr.strip())
+        if attempt + 1 < _attempts:
+            time.sleep(0.4)
+    raise last
 
 
 def _kubectl_run(args):

--- a/charts/workspace-controller/templates/serviceaccount.yaml
+++ b/charts/workspace-controller/templates/serviceaccount.yaml
@@ -34,6 +34,10 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list"]
+# Read PVC sizes for disk %-used and the storage-cost estimate / insights.
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list"]
 # Read each workspace's ingress host for a clickable link. Optional — the
 # listing degrades gracefully (no URL) if this is removed.
 - apiGroups: ["networking.k8s.io"]

--- a/charts/workspace-controller/web/src/components/InsightsBar.tsx
+++ b/charts/workspace-controller/web/src/components/InsightsBar.tsx
@@ -1,52 +1,83 @@
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import { type Advisory, getInsights } from '../api/workspaces';
 import { navigate } from '../router';
 
 const ICON: Record<string, string> = { critical: '⛔', warn: '⚠', info: 'ℹ' };
 
 /** Automatic, data-driven tips shown atop the dashboard. Polls slowly (60s) —
- *  insights are derived from hours of history, so they don't change fast. */
+ *  insights are derived from hours of history, so they don't change fast.
+ *
+ *  The first request can transiently fail (the controller's kubectl discovery
+ *  cache is cold right after a pod roll, and several endpoints fire at once on
+ *  page load). Rather than flash "Insights unavailable", we show a calm loading
+ *  state and retry a few times quietly, only surfacing an error if it persists.
+ *  Once we have data, a later poll failure is ignored so the bar never flickers. */
 export function InsightsBar() {
-  const [adv, setAdv] = useState<Advisory[]>([]);
+  const [adv, setAdv] = useState<Advisory[] | null>(null); // null = never loaded
   const [err, setErr] = useState<string | null>(null);
-  const [loaded, setLoaded] = useState(false);
+  const [showError, setShowError] = useState(false);
+  const hasData = useRef(false);
+  const attempts = useRef(0);
 
   useEffect(() => {
     let alive = true;
+    let retry: number | undefined;
     async function load() {
       try {
         const r = await getInsights();
-        if (alive) {
-          setAdv(r.advisories);
-          setErr(r.error);
-        }
+        if (!alive) return;
+        hasData.current = true;
+        attempts.current = 0;
+        setAdv(r.advisories);
+        setErr(r.error);
+        setShowError(false);
       } catch (e) {
-        if (alive) setErr(e instanceof Error ? e.message : String(e));
-      } finally {
-        if (alive) setLoaded(true);
+        if (!alive) return;
+        attempts.current += 1;
+        if (!hasData.current && attempts.current < 4) {
+          retry = window.setTimeout(() => void load(), 2000); // transient — retry quietly
+        } else if (!hasData.current) {
+          setErr(e instanceof Error ? e.message : String(e));
+          setShowError(true);
+        }
+        // If we already have data, ignore a transient poll failure.
       }
     }
     void load();
-    const id = window.setInterval(() => void load(), 60000);
+    const poll = window.setInterval(() => void load(), 60000);
     return () => {
       alive = false;
-      window.clearInterval(id);
+      window.clearInterval(poll);
+      if (retry) window.clearTimeout(retry);
     };
   }, []);
 
-  if (!loaded) return null;
-  if (adv.length === 0) {
+  if (adv === null && !showError) {
+    return (
+      <div class="insights">
+        <div class="insight calm loading">Analyzing workspace usage…</div>
+      </div>
+    );
+  }
+  if (showError) {
+    return (
+      <div class="insights">
+        <div class="insight calm">Insights unavailable: {err}</div>
+      </div>
+    );
+  }
+  if (adv!.length === 0) {
     return (
       <div class="insights">
         <div class="insight calm">
-          {err ? `Insights unavailable: ${err}` : '✓ All workspaces look healthy.'}
+          {err ? `Live metrics unavailable: ${err}` : '✓ All workspaces look healthy.'}
         </div>
       </div>
     );
   }
   return (
     <div class="insights" aria-label="Insights">
-      {adv.map((a, i) => (
+      {adv!.map((a, i) => (
         <button
           key={`${a.user}-${a.kind}-${i}`}
           class={`insight sev-${a.severity}`}

--- a/charts/workspace-controller/web/src/styles.css
+++ b/charts/workspace-controller/web/src/styles.css
@@ -112,6 +112,15 @@ body {
   border-style: dashed;
 }
 
+.insight.loading {
+  animation: insight-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes insight-pulse {
+  0%, 100% { opacity: 0.45; }
+  50% { opacity: 0.85; }
+}
+
 .empty {
   color: var(--muted);
   padding: 3rem 1rem;

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -4676,6 +4676,17 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         ref = self.headers.get('Referer') or ''
         m = re.search(r'(/(?:oauth/|browser/)?api/app-proxy/(\d+))', ref)
         if not m:
+            # TEMP diagnostic: an escaped navigation/sub-resource with no
+            # usable app-proxy Referer would fall through to a 404. Log what
+            # we got so we can see why (only for likely-escaped requests).
+            dest = self.headers.get('Sec-Fetch-Dest', '')
+            if ref or dest in ('document', 'iframe', 'empty'):
+                try:
+                    self.log_message('[app-escape] %s path=%s dest=%s mode=%s referer=%r',
+                                     method, self.path, dest,
+                                     self.headers.get('Sec-Fetch-Mode', ''), ref[:160])
+                except Exception:
+                    pass
             return False
         norm = self.path.split('?', 1)[0].replace('/oauth', '').replace('/browser', '')
         if norm.startswith('/api/app-proxy/'):
@@ -5176,14 +5187,19 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
 
         body = self._ABS_ASSET_URL_RE.sub(repl, body)
 
-        # Inject the runtime shim right after <head> so it patches fetch/XHR
-        # before the app's own scripts run. If there's no <head> (rare),
-        # prepend it — a leading classic script still executes first.
+        # Inject (1) a permissive referrer policy and (2) the runtime shim,
+        # right after <head> so they take effect before the app's own scripts.
+        # The referrer meta makes the app's *navigations* carry the full iframe
+        # URL as Referer — without it, a hard navigation (window.location) that
+        # drops the app's base lands at the dashboard root with no Referer and
+        # 404s, instead of being redirected back onto the proxy path by
+        # _dispatch_referer_proxy.
+        head_inject = b'<meta name="referrer" content="unsafe-url">' + self._APP_PROXY_SHIM
         if self._HEAD_OPEN_RE.search(body):
             body = self._HEAD_OPEN_RE.sub(
-                lambda mo: mo.group(0) + self._APP_PROXY_SHIM, body, count=1)
+                lambda mo: mo.group(0) + head_inject, body, count=1)
         else:
-            body = self._APP_PROXY_SHIM + body
+            body = head_inject + body
         return body
 
     @staticmethod


### PR DESCRIPTION
…ectl

The insights bar flashed "Insights unavailable: kubectl get failed" on first load before correcting itself. The controller's kubectl discovery cache is cold right after a pod roll and several read endpoints fire at once on page load, so the first call can fail transiently.

- InsightsBar now shows a calm "Analyzing workspace usage…" loading state and retries a few times quietly, only surfacing an error if it actually persists. Once data has loaded, transient poll failures are ignored so the bar never flickers.
- _kubectl_json retries once on failure (read-only calls, safe), smoothing the cold-cache/concurrent-call case at the source for all read endpoints.