### PR TITLE
fix(chart): dind + ssh-server need runAsNonRoot:false override

### DIFF
--- a/charts/workspace/templates/deployment.yaml
+++ b/charts/workspace/templates/deployment.yaml
@@ -240,7 +240,18 @@ spec:
       - name: dind
         image: docker:27-dind
         securityContext:
+          # Pod-level securityContext sets runAsNonRoot:true (cc18d99 hardening
+          # for the ide container). dind is the docker daemon — it MUST run
+          # as root to manage /var/lib/docker, namespaces, cgroups, etc.
+          # K8s admission rejects a runAsUser:0 container under a
+          # runAsNonRoot:true pod unless the container explicitly overrides
+          # with its own runAsNonRoot:false. Without this line, the dind
+          # container fails with CreateContainerConfigError on every new
+          # pod (existing pods survive until restart). See
+          # charts/workspace/tests/deployment_test.yaml for the regression
+          # guard.
           privileged: true
+          runAsNonRoot: false
           runAsUser: 0
           runAsGroup: 0
         env:
@@ -265,6 +276,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
+          # Same override as the dind sidecar: sshd needs root to bind
+          # privileged port 22 and exec into user shells, so it must opt
+          # out of the pod-level runAsNonRoot:true.
+          runAsNonRoot: false
           runAsUser: 0
           runAsGroup: 0
         command: ["/bin/bash", "/ssh-server-config/entrypoint.sh"]

--- a/charts/workspace/tests/deployment_test.yaml
+++ b/charts/workspace/tests/deployment_test.yaml
@@ -6,6 +6,7 @@ templates:
   - templates/terminal-entry-configmap.yaml
   - templates/workspace-entrypoint-configmap.yaml
   - templates/assistant-secret.yaml
+  - templates/ssh-server-configmap.yaml
 values:
   - test-values.yaml
 tests:
@@ -328,3 +329,50 @@ tests:
             configMap:
               name: workspace-entrypoint-testuser
               defaultMode: 365
+
+  # Regression guard for the cc18d99 hardening breakage: pod-level
+  # runAsNonRoot:true contradicts containers that legitimately need
+  # runAsUser:0 (dind for docker daemon, sshd for port 22 + user shells).
+  # Without an explicit container-level runAsNonRoot:false override, K8s
+  # admission rejects the pod with CreateContainerConfigError.
+  - it: dind sidecar overrides pod runAsNonRoot when buildkit is enabled
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: dind
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsNonRoot
+          value: false
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsUser
+          value: 0
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.privileged
+          value: true
+
+  - it: dind sidecar is absent in kaniko build mode
+    template: templates/deployment.yaml
+    set:
+      build.mode: kaniko
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: dind
+          any: true
+
+  - it: ssh-server sidecar overrides pod runAsNonRoot when ssh is enabled
+    template: templates/deployment.yaml
+    set:
+      ssh.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[2].name
+          value: ssh-server
+      - equal:
+          path: spec.template.spec.containers[2].securityContext.runAsNonRoot
+          value: false
+      - equal:
+          path: spec.template.spec.containers[2].securityContext.runAsUser
+          value: 0


### PR DESCRIPTION
## Summary

Commit `cc18d99` added pod-level `runAsNonRoot: true` + `runAsUser: 1000` to the workspace deployment as part of the security hardening pass, but didn't account for the **dind** and **ssh-server** sidecars that legitimately need to run as root:

- **dind** — docker daemon needs root to manage `/var/lib/docker`, namespaces, cgroups, etc.
- **ssh-server** — sshd needs root to bind privileged port 22 and exec into user shells.

Kubernetes' built-in pod admission rejects a container with `runAsUser: 0` under a pod that asserts `runAsNonRoot: true`, *unless the container explicitly opts out* with its own `runAsNonRoot: false`.

## Symptom

Every new buildkit-mode pod failed at admission with:

```
Error: container's runAsUser breaks non-root policy (container: dind)
```

CreateContainerConfigError. The breakage was **silent for ~6 days** on the shared cluster because PSA-style checks only run at admission — existing pods kept working. Three live workspaces (joediv, mjumiapp, demo) were one OOM-kill / node-drain away from downtime; ssh-enabled workspaces would have hit the same on first start.

## Fix

Add container-level `runAsNonRoot: false` to the dind and ssh-server `securityContext` blocks. Container-level overrides pod-level, so the `ide` container keeps the non-root posture while the two sidecars opt out explicitly. Inline comments document why.

## Regression coverage

Three new `helm-unittest` cases in `deployment_test.yaml`:

1. **dind sidecar overrides pod runAsNonRoot when buildkit is enabled** — asserts `runAsNonRoot: false`, `runAsUser: 0`, `privileged: true`.
2. **dind sidecar is absent in kaniko build mode** — sanity check that the kaniko escape still works.
3. **ssh-server sidecar overrides pod runAsNonRoot when ssh is enabled** — same override for sshd.

Also added `templates/ssh-server-configmap.yaml` to the suite's `templates:` list so the ssh-enabled render resolves.

Suite: **40 → 43 tests, all pass.**

## Validation

| Check | Result |
|---|---|
| `helm lint` (CI fixtures) | clean |
| `helm template` workspace (basic + oauth2 + ssh enabled) | all OK |
| `helm unittest` (workspace + workspace-controller) | 43 + 20 pass |
| python-tests on Python 3.11.14 | 148 pass |
| SPA type-check + Vitest | 94 pass |
| Live rollout: demo, joediv, mjumiapp | each 2/2 Running, dind ready, 0 restarts |

## Files

- `charts/workspace/templates/deployment.yaml` — the two `runAsNonRoot: false` overrides + comments
- `charts/workspace/tests/deployment_test.yaml` — +3 regression tests + added ssh-server-configmap template

🤖 Generated with [Claude Code](https://claude.com/claude-code)