### PR TITLE
Reliable waiting-for-input detection + desktop widget; Ante persistence; tooling bump

### DIFF
--- a/charts/workspace/mcp_agent_orchestrator.py
+++ b/charts/workspace/mcp_agent_orchestrator.py
@@ -320,7 +320,20 @@ def _tool_spawn_agent(args: Dict[str, Any]) -> Dict[str, Any]:
         return {'isError': True, 'content': [{'type': 'text', 'text': 'prompt is required'}]}
 
     assistant = args.get('assistant', 'ante')
-    workdir = args.get('workdir', '/home/dev')
+    # Default the sub-agent's working directory to the SPAWNING agent's cwd.
+    # This MCP server is a stdio subprocess of the parent CLI, so os.getcwd()
+    # is the directory the parent was launched in (its project) — a far better
+    # default than a hardcoded path. Fall back to /home/dev if the requested
+    # or inherited directory doesn't exist, so a bad value can't make the
+    # sub-agent's `cd` fail and kill the session before it starts.
+    workdir = (args.get('workdir') or '').strip()
+    if not workdir:
+        try:
+            workdir = os.getcwd()
+        except OSError:
+            workdir = '/home/dev'
+    if not os.path.isdir(workdir):
+        workdir = '/home/dev'
     parent_task_id = args.get('parent_task_id') or os.environ.get('KC_TASK_ID')
 
     # Headless one-shot is the orchestration default: the agent exits when
@@ -639,7 +652,7 @@ TOOLS: Dict[str, Any] = {
                         'enum': ['headless', 'interactive'],
                         'default': 'headless',
                     },
-                    'workdir': {'type': 'string', 'description': 'Working directory', 'default': '/home/dev'},
+                    'workdir': {'type': 'string', 'description': "Working directory for the sub-agent. Defaults to the spawning agent's own working directory (its project); pass an absolute path to override."},
                     'parent_task_id': {'type': 'string', 'description': 'Parent task for lineage tracking (auto-inherited from env)'},
                 },
                 'required': ['prompt'],

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -109,57 +109,16 @@ def strip_ansi(text):
     return _ANSI_RE.sub('', text)
 
 
-def detect_waiting_for_input(output):
-    """Detect common patterns indicating waiting for human input.
-    
-    Returns:
-        tuple: (is_waiting, last_prompt_line)
-    """
-    if not output or not output.strip():
-        return False, ""
-    
-    lines = output.strip().split('\n')
-    if not lines:
-        return False, ""
-    
-    # Get the last few non-empty lines for pattern analysis
-    last_lines = []
-    for line in reversed(lines):
-        if line.strip():
-            last_lines.append(line.strip())
-        if len(last_lines) >= 3:  # Check last 3 non-empty lines
-            break
-    
-    if not last_lines:
-        return False, ""
-    
-    # Patterns that typically indicate waiting for input
-    waiting_patterns = [
-        r'.*[?]\s*$',                    # Questions ending with ?
-        r'.*>\s*$',                      # Shell-like prompts ending with >
-        r'.*:\s*$',                      # Prompts ending with :
-        r'.*Press\s+(any\s+)?key.*',     # "Press any key" messages
-        r'.*Enter\s+your\s+(choice|input|answer).*', # "Enter your choice"
-        r'.*Please\s+(provide|enter|type|input).*',  # "Please provide"
-        r'.*Waiting\s+for.*input.*',     # "Waiting for input"
-        r'.*Continue\?\s*(\(y/n\))?\s*$', # "Continue? (y/n)"
-        r'.*\(y/n\)\s*$',               # Simple (y/n) prompts
-        r'.*\[.*\]\?\s*$',              # Bracketed choice prompts like [y/N]?
-        r'.*\s+\$\s*$',                 # Command prompts ending with $
-        r'.*#\s*$',                     # Root prompts ending with #
-        r'.*Select\s+an?\s+option.*',   # "Select an option"
-        r'.*Choose\s+(from|an?).*',     # "Choose from" or "Choose an"
-        r'.*Which\s+.*\?.*',           # "Which option?" type questions
-    ]
-    
-    # Check each of the last few lines
-    for line in last_lines:
-        for pattern in waiting_patterns:
-            if re.search(pattern, line, re.IGNORECASE):
-                # Return the line that matched as the prompt
-                return True, line
-    
-    return False, ""
+# How long a task's rendered tmux screen must stay unchanged before we treat
+# it as waiting-for-input. While an agent works it streams output / animates a
+# spinner+timer, so the screen keeps changing; a static screen means it has
+# finished its turn (or hit a prompt) and is awaiting the human. This replaced
+# a regex scraper that never worked against the agents' full-screen TUIs.
+# Env-overridable for tuning.
+try:
+    IDLE_WAITING_SECONDS = float(os.environ.get('KC_IDLE_WAITING_SECONDS', '90'))
+except ValueError:
+    IDLE_WAITING_SECONDS = 90.0
 
 class MetricsCollector:
     """Collects system metrics from /proc filesystem and os.statvfs"""
@@ -843,6 +802,9 @@ class ClaudeTaskManager:
                     'status': meta.get('status', 'unknown'),
                     'created_at': meta.get('created_at'),
                     'finished_at': meta.get('finished_at') or meta.get('killed_at'),
+                    # Moment the rendered screen last changed — drives the
+                    # dashboard's idle-duration label + stale escalation.
+                    'last_activity_at': meta.get('last_activity_at'),
                     'source': meta.get('source'),
                     'kind': meta.get('kind', 'claude'),
                     'assistant': meta.get('assistant'),
@@ -1227,47 +1189,58 @@ class ClaudeTaskManager:
                     ClaudeTaskManager._fire_completion_hook(updated)
             return
         
-        # Session is still running, check for waiting-for-input patterns
-        # Capture current output to analyze for waiting patterns. -J joins
-        # wrapped lines so prompts like "Continue? (y/n)" that overflow the
-        # pane width still match the regex patterns.
+        # Session is alive — derive waiting-for-input from render *quiescence*
+        # rather than scraping prompt text (which never worked across the
+        # full-screen TUIs Claude/Ante/OpenCode render). While an agent works
+        # it streams output / animates a spinner+timer, so the captured screen
+        # keeps changing; once it finishes a turn or hits a prompt the screen
+        # goes static. Stable for >= IDLE_WAITING_SECONDS ⇒ waiting-for-input.
+        # `last_activity_at` (the moment the screen last changed) also lets the
+        # dashboard show idle duration and escalate long-idle ("stale") tasks.
         capture_cmd = subprocess.run(
-            ['tmux', 'capture-pane', '-J', '-t', session_name, '-p', '-S', '-50'],
+            ['tmux', 'capture-pane', '-t', session_name, '-p'],
             capture_output=True, text=True,
         )
-        
-        if capture_cmd.returncode == 0 and capture_cmd.stdout:
-            clean_output = strip_ansi(capture_cmd.stdout)
-            is_waiting, prompt_line = detect_waiting_for_input(clean_output)
-            
-            # Update status based on waiting detection
-            if is_waiting and current_status == 'running':
-                # Transition to waiting-for-input
+        if capture_cmd.returncode != 0:
+            return
+        screen = strip_ansi(capture_cmd.stdout or '')
+        digest = hashlib.sha1(screen.encode('utf-8', 'replace')).hexdigest()
+        now = time.time()
+
+        if digest != meta.get('pane_hash'):
+            # Screen changed → activity. Record it, reset the idle clock, and
+            # if we had flagged waiting, return to running.
+            def mutate(m):
+                m['pane_hash'] = digest
+                m['last_activity_at'] = now
+                if m.get('status') == 'waiting-for-input':
+                    m['status'] = 'running'
+                    m.pop('waiting_for_input', None)
+                    m.pop('last_input_prompt', None)
+
+            updated = ClaudeTaskManager._atomic_update_meta(task_dir, mutate)
+            if updated is not None:
+                meta['pane_hash'] = digest
+                meta['last_activity_at'] = now
+                if meta.get('status') == 'waiting-for-input':
+                    meta['status'] = 'running'
+                    meta.pop('waiting_for_input', None)
+                    meta.pop('last_input_prompt', None)
+            return
+
+        # Screen unchanged since the previous capture.
+        if current_status == 'running':
+            stable_since = meta.get('last_activity_at') or now
+            if now - stable_since >= IDLE_WAITING_SECONDS:
                 def mutate(m):
-                    if m.get('status') == 'running':  # Double-check inside lock
+                    if m.get('status') == 'running':  # re-check inside lock
                         m['status'] = 'waiting-for-input'
                         m['waiting_for_input'] = True
-                        m['last_input_prompt'] = prompt_line
-                
+
                 updated = ClaudeTaskManager._atomic_update_meta(task_dir, mutate)
                 if updated is not None:
                     meta['status'] = 'waiting-for-input'
                     meta['waiting_for_input'] = True
-                    meta['last_input_prompt'] = prompt_line
-                    
-            elif not is_waiting and current_status == 'waiting-for-input':
-                # Transition back to running (user provided input or prompt cleared)
-                def mutate(m):
-                    if m.get('status') == 'waiting-for-input':  # Double-check inside lock
-                        m['status'] = 'running'
-                        m.pop('waiting_for_input', None)
-                        m.pop('last_input_prompt', None)
-                
-                updated = ClaudeTaskManager._atomic_update_meta(task_dir, mutate)
-                if updated is not None:
-                    meta['status'] = 'running'
-                    meta.pop('waiting_for_input', None)
-                    meta.pop('last_input_prompt', None)
 
 
 def _shell_quote(s):

--- a/charts/workspace/start.sh
+++ b/charts/workspace/start.sh
@@ -356,6 +356,52 @@ for HOME_DIR in /home/ubuntu; do
   ln -sfn "$TARGET" "$LINK" 2>/dev/null || true
 done
 
+# Persist Ante's config across pod restarts and keep its binary on the PVC.
+# Ante stores everything (settings, sessions, versions.json) under ~/.ante,
+# which on the ephemeral /home/ubuntu home was wiped every restart. We point
+# ~/.ante at the PVC (same pattern as ~/.claude above) and seed the binary at
+# the PVC path /home/dev/.ante/bin/ante — which /usr/local/bin/ante is a
+# build-time symlink to. The image is the source of truth for the version
+# (bump ANTE_VERSION + rebuild); we refresh the PVC copy from /opt/ante/ante
+# below so a rebuild propagates and nothing strands the pod on an old binary.
+ANTE_TARGET=/home/dev/.ante
+mkdir -p "$ANTE_TARGET/bin"
+if [ -L "$ANTE_TARGET" ]; then
+  AD=$(readlink "$ANTE_TARGET")
+  if [ "$AD" = "$ANTE_TARGET" ] || [ "$AD" = ".ante" ]; then
+    rm -f "$ANTE_TARGET"; mkdir -p "$ANTE_TARGET/bin"
+  fi
+fi
+for HOME_DIR in /home/ubuntu; do
+  [ -d "$HOME_DIR" ] || continue
+  LINK="$HOME_DIR/.ante"
+  [ "$LINK" = "$ANTE_TARGET" ] && continue
+  if [ -L "$LINK" ] && [ "$(readlink "$LINK")" = "$ANTE_TARGET" ]; then
+    continue
+  fi
+  # Merge any existing ~/.ante (incl. a binary the user already updated to)
+  # into the PVC — cp -an keeps the PVC copy canonical — then replace with a
+  # symlink.
+  if [ -d "$LINK" ] && [ ! -L "$LINK" ]; then
+    cp -an "$LINK"/. "$ANTE_TARGET"/ 2>/dev/null || true
+    rm -rf "$LINK"
+  elif [ -e "$LINK" ] || [ -L "$LINK" ]; then
+    rm -f "$LINK"
+  fi
+  ln -sfn "$ANTE_TARGET" "$LINK" 2>/dev/null || true
+done
+# Seed/refresh the PVC binary from the image's copy (/opt/ante/ante). The image
+# is the source of truth, so overwrite whenever the PVC copy is missing or
+# differs — this propagates a manual ANTE_VERSION bump on rebuild and stops a
+# stale binary from stranding the pod. /usr/local/bin/ante is a build-time
+# symlink to this path, so no runtime root (sudo is blocked) is needed.
+if [ -f /opt/ante/ante ]; then
+  if [ ! -e "$ANTE_TARGET/bin/ante" ] || ! cmp -s /opt/ante/ante "$ANTE_TARGET/bin/ante"; then
+    install -m 0755 /opt/ante/ante "$ANTE_TARGET/bin/ante" 2>/dev/null \
+      || cp -p /opt/ante/ante "$ANTE_TARGET/bin/ante" 2>/dev/null || true
+  fi
+fi
+
 # The memory subsystem ships its Python package as flat configmap keys
 # (configmap keys cannot contain "/"). Unpack them into a real `memory/`
 # tree next to server.py so `from memory.manager import ...` resolves.

--- a/charts/workspace/tests/mcp_agent_orchestrator_test.py
+++ b/charts/workspace/tests/mcp_agent_orchestrator_test.py
@@ -150,6 +150,28 @@ class SpawnGuardTests(unittest.TestCase):
         self.assertEqual(payload['mode'], 'interactive')
         thread_cls.assert_called_once()
 
+    def _spawn_workdir(self, args):
+        with mock.patch.object(orch.subprocess, 'run', side_effect=_tmux_alive), \
+             mock.patch.object(orch, '_count_live_agent_sessions', return_value=0), \
+             mock.patch.object(orch.threading, 'Thread'):
+            res = orch._tool_spawn_agent({'prompt': 'go', 'assistant': 'ante', **args})
+        meta_path = os.path.join(self.tmp, json.loads(res['content'][0]['text'])['task_id'], 'task.json')
+        with open(meta_path) as f:
+            return json.load(f)
+
+    def test_workdir_defaults_to_spawning_agent_cwd(self):
+        # No workdir passed → inherit the orchestrator's cwd (the parent's dir).
+        meta = self._spawn_workdir({})
+        self.assertEqual(meta['workdir'], os.getcwd())
+
+    def test_explicit_existing_workdir_is_used(self):
+        meta = self._spawn_workdir({'workdir': self.tmp})
+        self.assertEqual(meta['workdir'], self.tmp)
+
+    def test_nonexistent_workdir_falls_back(self):
+        meta = self._spawn_workdir({'workdir': '/no/such/dir/xyz'})
+        self.assertEqual(meta['workdir'], '/home/dev')
+
 
 class ReconcileTests(unittest.TestCase):
     def setUp(self):

--- a/charts/workspace/tests/server_test.py
+++ b/charts/workspace/tests/server_test.py
@@ -1054,5 +1054,87 @@ class TrustedProxyTests(unittest.TestCase):
             server.AUTH_MODE = orig_auth
 
 
+class WaitingQuiescenceTests(unittest.TestCase):
+    """Quiescence-based waiting-for-input detection in _reconcile_status.
+
+    A live session whose rendered screen stops changing for >= the idle
+    threshold flips to waiting-for-input; any screen change flips it back to
+    running and resets the idle clock.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self._orig_tasks_dir = server.ClaudeTaskManager.TASKS_DIR
+        server.ClaudeTaskManager.TASKS_DIR = self.tmpdir
+
+    def tearDown(self):
+        server.ClaudeTaskManager.TASKS_DIR = self._orig_tasks_dir
+
+    def _make_task(self, **meta_extra):
+        task_dir = os.path.join(self.tmpdir, 'tq-1')
+        os.makedirs(task_dir, exist_ok=True)
+        meta = {'task_id': 'tq-1', 'status': 'running', 'tmux_session': 'claude-tq-1'}
+        meta.update(meta_extra)
+        with open(os.path.join(task_dir, 'task.json'), 'w') as f:
+            json.dump(meta, f)
+        return meta, task_dir
+
+    @staticmethod
+    def _digest(screen):
+        return hashlib.sha1(server.strip_ansi(screen).encode('utf-8', 'replace')).hexdigest()
+
+    def _tmux(self, screen):
+        """subprocess.run stub: session alive; capture-pane returns `screen`."""
+        def run(args, *a, **k):
+            if 'has-session' in args:
+                return mock.Mock(returncode=0, stdout='', stderr='')
+            if 'capture-pane' in args:
+                return mock.Mock(returncode=0, stdout=screen, stderr='')
+            return mock.Mock(returncode=0, stdout='', stderr='')
+        return run
+
+    def test_stable_screen_past_threshold_flags_waiting(self):
+        screen = 'idle input box\n> '
+        meta, task_dir = self._make_task(
+            pane_hash=self._digest(screen),
+            last_activity_at=time.time() - (server.IDLE_WAITING_SECONDS + 5),
+        )
+        with mock.patch('server.subprocess.run', side_effect=self._tmux(screen)):
+            server.ClaudeTaskManager._reconcile_status(meta, task_dir)
+        self.assertEqual(meta['status'], 'waiting-for-input')
+        self.assertTrue(meta.get('waiting_for_input'))
+
+    def test_stable_screen_within_threshold_stays_running(self):
+        screen = 'idle input box\n> '
+        meta, task_dir = self._make_task(
+            pane_hash=self._digest(screen),
+            last_activity_at=time.time() - 5,  # only briefly idle
+        )
+        with mock.patch('server.subprocess.run', side_effect=self._tmux(screen)):
+            server.ClaudeTaskManager._reconcile_status(meta, task_dir)
+        self.assertEqual(meta['status'], 'running')
+
+    def test_changed_screen_clears_waiting(self):
+        meta, task_dir = self._make_task(
+            status='waiting-for-input', waiting_for_input=True,
+            pane_hash='stale-hash', last_activity_at=time.time() - 1000,
+        )
+        with mock.patch('server.subprocess.run', side_effect=self._tmux('fresh agent output\n')):
+            server.ClaudeTaskManager._reconcile_status(meta, task_dir)
+        self.assertEqual(meta['status'], 'running')
+        self.assertNotIn('waiting_for_input', meta)
+        self.assertIn('last_activity_at', meta)
+
+    def test_changed_screen_running_resets_idle_clock(self):
+        meta, task_dir = self._make_task(
+            pane_hash='stale-hash', last_activity_at=time.time() - 1000,
+        )
+        before = meta['last_activity_at']
+        with mock.patch('server.subprocess.run', side_effect=self._tmux('spinner frame 2\n')):
+            server.ClaudeTaskManager._reconcile_status(meta, task_dir)
+        self.assertEqual(meta['status'], 'running')
+        self.assertGreater(meta['last_activity_at'], before)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/charts/workspace/web/src/api/shape.ts
+++ b/charts/workspace/web/src/api/shape.ts
@@ -82,6 +82,7 @@ export function coerceTaskSummary(raw: unknown): TaskSummary {
     memory_injection_disabled: r.memory_injection_disabled === true,
     waiting_for_input: r.waiting_for_input === true,
     last_input_prompt: typeof r.last_input_prompt === 'string' ? r.last_input_prompt : undefined,
+    last_activity_at: typeof r.last_activity_at === 'number' ? r.last_activity_at : null,
   };
 }
 

--- a/charts/workspace/web/src/api/tasks.ts
+++ b/charts/workspace/web/src/api/tasks.ts
@@ -27,6 +27,37 @@ export interface TaskSummary {
   waiting_for_input?: boolean;
   /** Last prompt or question that triggered waiting state */
   last_input_prompt?: string;
+  /** Unix seconds the rendered screen last changed (drives idle/stale UI). */
+  last_activity_at?: number | null;
+}
+
+/**
+ * A waiting task is "stale" once it's been idle this long — escalated in the
+ * UI from a gentle "your turn" amber to a stronger "needs attention" cue.
+ */
+export const STALE_AFTER_SECONDS = 20 * 60;
+
+/** Seconds the task's screen has been idle, or null if unknown. */
+export function idleSeconds(t: TaskSummary): number | null {
+  if (typeof t.last_activity_at !== 'number') return null;
+  return Math.max(0, Math.floor(Date.now() / 1000 - t.last_activity_at));
+}
+
+/** True when the task is waiting AND has been idle past the stale threshold. */
+export function isStaleWaiting(t: TaskSummary): boolean {
+  if (t.status !== 'waiting-for-input') return false;
+  const s = idleSeconds(t);
+  return s !== null && s >= STALE_AFTER_SECONDS;
+}
+
+/** Short idle-duration label like "3m" / "1h" / "2d", or '' if unknown. */
+export function idleLabel(t: TaskSummary): string {
+  const s = idleSeconds(t);
+  if (s === null) return '';
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h`;
+  return `${Math.floor(s / 86400)}d`;
 }
 
 export interface TaskDetail extends TaskSummary {

--- a/charts/workspace/web/src/routes/desktop/DesktopBulletin.tsx
+++ b/charts/workspace/web/src/routes/desktop/DesktopBulletin.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'preact/hooks';
-import { listTasks, type TaskSummary } from '../../api/tasks';
+import { listTasks, isStaleWaiting, type TaskSummary } from '../../api/tasks';
 import { navigate } from '../../store/router';
 
 interface BulletinEntry {
@@ -9,6 +9,15 @@ interface BulletinEntry {
   snippet: string;
   ts: number;            // unix seconds
   status: 'running' | 'waiting-for-input';
+  stale: boolean;        // waiting + idle past the stale threshold
+}
+
+// Sort key: stale-waiting first, then waiting, then running — so the
+// sessions that need the user's input are always surfaced before busy ones.
+function attentionRank(e: BulletinEntry): number {
+  if (e.stale) return 0;
+  if (e.status === 'waiting-for-input') return 1;
+  return 2;
 }
 
 const STATUS_LABEL: Record<BulletinEntry['status'], string> = {
@@ -50,8 +59,12 @@ export function DesktopBulletin() {
             snippet: (t.prompt || '').slice(0, 140),
             ts: t.created_at ?? 0,
             status: t.status as BulletinEntry['status'],
+            stale: isStaleWaiting(t),
           }))
-          .sort((a: BulletinEntry, b: BulletinEntry) => b.ts - a.ts)
+          // Waiting/stale first (needs input), then most-recent within group.
+          .sort((a: BulletinEntry, b: BulletinEntry) =>
+            attentionRank(a) - attentionRank(b) || b.ts - a.ts,
+          )
           .slice(0, 3);
         setEntries(live);
       } catch {
@@ -103,11 +116,11 @@ export function DesktopBulletin() {
                 onClick={() => navigateToEntry(e)}
                 title={e.snippet || e.title}
               >
-                <span class={`dt-bulletin-tag dt-bulletin-tag-${e.status === 'waiting-for-input' ? 'waiting' : 'running'}`}>
+                <span class={`dt-bulletin-tag dt-bulletin-tag-${e.stale ? 'stale' : e.status === 'waiting-for-input' ? 'waiting' : 'running'}`}>
                   {e.status === 'running' && (
                     <span class="dt-bulletin-running" aria-hidden="true" />
                   )}
-                  {STATUS_LABEL[e.status]}
+                  {e.stale ? 'Needs you' : STATUS_LABEL[e.status]}
                 </span>
                 <span class="dt-bulletin-row-body">
                   <span class="dt-bulletin-title-text">{e.title}</span>

--- a/charts/workspace/web/src/routes/desktop/desktop.css
+++ b/charts/workspace/web/src/routes/desktop/desktop.css
@@ -515,6 +515,10 @@
   background: color-mix(in srgb, var(--warn) 18%, var(--surface-2));
   color: var(--warn);
 }
+.dt-bulletin-tag-stale {
+  background: color-mix(in srgb, #ef4444 20%, var(--surface-2));
+  color: #ef4444;
+}
 :root[data-theme="light"] .dt-bulletin-tag-running {
   background: color-mix(in srgb, #047857 14%, var(--surface-2));
   color: #047857;

--- a/charts/workspace/web/src/routes/tasks/TaskList.tsx
+++ b/charts/workspace/web/src/routes/tasks/TaskList.tsx
@@ -22,6 +22,7 @@ import { Icon } from '../../components/Icon';
 import { useIsMobile } from '../../hooks/useMediaQuery';
 import { EmptyState } from '../../components/primitives/EmptyState';
 import type { TaskStatus, TaskSummary } from '../../api/tasks';
+import { isStaleWaiting, idleLabel } from '../../api/tasks';
 import './tasks.css';
 
 const STATUS_TONE: Record<TaskStatus, 'success' | 'warn' | 'danger' | 'neutral' | 'accent'> = {
@@ -159,13 +160,16 @@ export function TaskList() {
           {list.map((t) => (
             <li key={t.task_id} data-task-id={t.task_id}>
               <button
-                class={`tl-row ${activeId === t.task_id ? 'tl-row-active' : ''} ${t.status === 'waiting-for-input' ? 'tl-row-waiting' : ''}`}
+                class={`tl-row ${activeId === t.task_id ? 'tl-row-active' : ''} ${t.status === 'waiting-for-input' ? 'tl-row-waiting' : ''} ${isStaleWaiting(t) ? 'tl-row-stale' : ''}`}
                 onClick={() => onRowClick(t)}
                 aria-current={activeId === t.task_id ? 'true' : 'false'}
               >
                 <div class="tl-row-head">
                   <div class="tl-row-status-container">
                     <Pill tone={STATUS_TONE[t.status]} mono>{STATUS_LABEL[t.status]}</Pill>
+                    {isStaleWaiting(t) && (
+                      <Pill tone="danger" mono>stale</Pill>
+                    )}
                     {t.parent_task_id && (
                       <Pill tone="neutral" mono>sub-agent</Pill>
                     )}
@@ -181,10 +185,12 @@ export function TaskList() {
                   </span>
                 </div>
                 {t.name && t.prompt && <div class="tl-row-sub muted">{t.prompt}</div>}
-                {t.status === 'waiting-for-input' && t.last_input_prompt && (
-                  <div class="tl-row-prompt">
-                    <span class="tl-row-prompt-label">Waiting for input:</span>
-                    <span class="tl-row-prompt-text">{t.last_input_prompt}</span>
+                {t.status === 'waiting-for-input' && (
+                  <div class={`tl-row-prompt ${isStaleWaiting(t) ? 'tl-row-prompt-stale' : ''}`}>
+                    <span class="tl-row-prompt-label">
+                      {isStaleWaiting(t) ? 'Needs attention' : 'Waiting for input'}
+                    </span>
+                    <span class="tl-row-prompt-text">idle {idleLabel(t)}</span>
                   </div>
                 )}
                 <div class="tl-row-meta muted">

--- a/charts/workspace/web/src/routes/tasks/tasks.css
+++ b/charts/workspace/web/src/routes/tasks/tasks.css
@@ -141,6 +141,23 @@
   background: var(--warning-soft, color-mix(in srgb, #fbbf24 12%, var(--surface)));
 }
 
+/* Stale escalation — a waiting task that's been idle past the stale
+   threshold (~20m). Overrides the amber with a stronger red "needs you" cue
+   and a more urgent pulse. */
+.tl-row-stale {
+  border-color: color-mix(in srgb, #ef4444 45%, var(--border));
+  background: color-mix(in srgb, #ef4444 10%, var(--surface));
+  animation: tl-stale-pulse 1.4s ease-in-out infinite;
+}
+.tl-row-stale:hover {
+  background: color-mix(in srgb, #ef4444 15%, var(--surface-2));
+  border-color: color-mix(in srgb, #ef4444 60%, var(--border-2));
+}
+.tl-row-stale.tl-row-active {
+  border-color: #ef4444;
+  background: color-mix(in srgb, #ef4444 14%, var(--surface));
+}
+
 .tl-row-status-container {
   display: flex;
   align-items: center;
@@ -172,6 +189,24 @@
   font-family: var(--font-mono);
   color: var(--text);
   word-break: break-word;
+}
+
+/* Stale variant of the prompt strip — red-tinted to match .tl-row-stale. */
+.tl-row-prompt-stale {
+  background: color-mix(in srgb, #ef4444 8%, var(--surface-2));
+  border-color: color-mix(in srgb, #ef4444 30%, var(--border));
+}
+.tl-row-prompt-stale .tl-row-prompt-label {
+  color: #ef4444;
+}
+
+@keyframes tl-stale-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, #ef4444 45%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 5px color-mix(in srgb, #ef4444 12%, transparent);
+  }
 }
 
 @keyframes tl-waiting-pulse {

--- a/devlaptop/Dockerfile
+++ b/devlaptop/Dockerfile
@@ -63,7 +63,7 @@ RUN ARCH=$(dpkg --print-architecture) \
 # https://docs.anthropic.com/en/docs/claude-code/setup
 # Version is pinned for reproducible builds. To bump: update CLAUDE_CODE_VERSION,
 # rebuild the image (`make push`), and roll out the new image tag via Helm.
-ARG CLAUDE_CODE_VERSION=2.1.143
+ARG CLAUDE_CODE_VERSION=2.1.167
 RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
 # OpenCode CLI — alternative AI coding assistant. Selected per-workspace via
@@ -75,17 +75,21 @@ ARG OPENCODE_VERSION=1.15.3
 RUN npm install -g opencode-ai@${OPENCODE_VERSION}
 
 # Ante CLI — terminal-native AI coding agent from Antigma Labs.
-# Distributed as a single ~15MB self-contained binary. install.sh detects
-# the platform, downloads the matching binary, and installs it to
-# $HOME/.ante/bin (i.e. /root/.ante/bin in this root build stage), adding
-# that dir to shell rc files only. That location is NOT on the `dev` user's
-# PATH, so we relocate the binary to /usr/local/bin (on every shell's PATH,
-# including non-login `kubectl exec` and the orchestrator's `bash -lc`).
+# Distributed as a single self-contained binary. install.sh installs it to
+# $HOME/.ante/bin (/root/.ante/bin in this root build stage). We keep the real
+# binary at /opt/ante/ante and make /usr/local/bin/ante a *symlink* to the
+# PVC-backed path /home/dev/.ante/bin/ante. start.sh seeds that PVC path from
+# /opt/ante/ante on boot — this gives a writable, persistent binary location
+# (the pod blocks runtime sudo, so we can't repoint /usr/local/bin at runtime),
+# while the image stays the source of truth: bump ANTE_VERSION + rebuild to
+# update. Version is pinned to the `stable` channel for reproducible builds.
 # https://docs.antigma.ai
-ARG ANTE_VERSION=latest
+ARG ANTE_VERSION=stable
 RUN curl -fsSL https://ante.run/install.sh | bash -s -- ${ANTE_VERSION} \
-    && install -m 0755 "$HOME/.ante/bin/ante" /usr/local/bin/ante \
-    && test -x /usr/local/bin/ante
+    && mkdir -p /opt/ante \
+    && install -m 0755 "$HOME/.ante/bin/ante" /opt/ante/ante \
+    && test -x /opt/ante/ante \
+    && ln -sfn /home/dev/.ante/bin/ante /usr/local/bin/ante
 
 # Install ttyd for mobile-friendly terminal access.
 # Pinned to a known-good version so transient 502s from GitHub's release CDN


### PR DESCRIPTION
## Summary
Makes the dashboard's "session needs your input" highlight actually work, surfaces it in the desktop widget, fixes sub-agent working directories, and fixes the perpetual Ante "update" prompt (plus a Claude/Ante version bump).

## Waiting-for-input — tiered, quiescence-based
The frontend (amber row + ⏳ + WaitingBadge + tab-title count) was already built and correct; the **backend signal** was broken — `detect_waiting_for_input` regex-scraped the last few pane lines, which is meaningless against the full-screen TUIs Claude/Ante/OpenCode render.

- **New mechanism:** hash the tmux screen each reconcile, persist `pane_hash` + `last_activity_at`. Agents stream output/animate a spinner while working, so a screen static for ≥ `IDLE_WAITING_SECONDS` (default 90, env-tunable) ⇒ `waiting-for-input`; any change ⇒ `running`. App-agnostic, no per-CLI patterns.
- **Tier 1 ("your turn"):** existing amber treatment, now actually fires.
- **Tier 2 ("stale / needs attention"):** red escalation once idle ≥ `STALE_AFTER_SECONDS` (20m), with an "idle Xm" label replacing the never-populated `last_input_prompt`.
- **Desktop "Live builds" widget:** sorts waiting/stale first, badges stale ones "Needs you".

## Sub-agent working directory
`spawn_agent` now defaults `workdir` to the **spawning agent's own cwd** (the orchestrator is the parent CLI's subprocess) with a `/home/dev` fallback, instead of a hardcoded path — so sub-agents operate in the parent's project.

## Ante persistence + tooling
- Persist `~/.ante` on the PVC; `/usr/local/bin/ante` is a **build-time symlink** to a PVC path seeded/refreshed from `/opt/ante/ante` each boot (the pod blocks runtime `sudo`). This ends the perpetual update prompt — the **image is the source of truth**; bump `ANTE_VERSION`/`CLAUDE_CODE_VERSION` + rebuild to update.
- Bump **Claude Code 2.1.143 → 2.1.167** and **Ante → `stable`** (0.preview.33).

## Tests
- `WaitingQuiescenceTests`: stable→waiting, within-threshold-stays-running, activity-clears-waiting, clock-reset.
- Sub-agent workdir: default-to-cwd, explicit override, nonexistent fallback.
- Full suite + SPA tsc/build/vitest green locally.

## Deploy notes
Touches the SPA + Dockerfile, so a full `make ship` (rebuild) is required. Already built as `devlaptop-v1.13.0-ante-persist` and **deployed + verified on imran and mjumiapp** (ante 0.preview.33, claude 2.1.167, `/usr/local/bin/ante` → PVC symlink). Per-user image pins are intentionally not included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)