### PR TITLE
fix: LibreFang dashboard chat + client-routed SPA preview proxy

### DIFF
--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -611,7 +611,7 @@ class ClaudeTaskManager:
         if workdir is None:
             workdir = '/home/dev'
 
-        session_name = f'claude-{task_id}'
+        session_name = f'kube-coder-{task_id}'
 
         # ── Memory auto-injection (opt-in, OFF by default) ────────────────
         # Optionally compute a <workspace_memories> block from top-K relevant
@@ -769,7 +769,7 @@ class ClaudeTaskManager:
         if workdir is None:
             workdir = '/home/dev'
 
-        session_name = f'claude-{task_id}'
+        session_name = f'kube-coder-{task_id}'
 
         meta = {
             'task_id': task_id,
@@ -869,7 +869,7 @@ class ClaudeTaskManager:
 
         # Get recent output from live tmux pane or fallback to log file
         recent_output = ''
-        session_name = meta.get('tmux_session', f'claude-{task_id}')
+        session_name = meta.get('tmux_session', f'kube-coder-{task_id}')
         result = subprocess.run(
             ['tmux', 'capture-pane', '-J', '-t', session_name, '-p', '-S', '-50'],
             capture_output=True, text=True,
@@ -890,7 +890,7 @@ class ClaudeTaskManager:
             meta = json.load(f)
 
         # For live sessions, capture the tmux pane content
-        session_name = meta.get('tmux_session', f'claude-{task_id}')
+        session_name = meta.get('tmux_session', f'kube-coder-{task_id}')
         result = subprocess.run(
             # -J joins wrapped lines, so URLs the assistant prints that
             # overflow the 220-col pane come back as one logical line —
@@ -925,7 +925,7 @@ class ClaudeTaskManager:
         with open(meta_path, 'r') as f:
             meta = json.load(f)
 
-        session_name = meta.get('tmux_session', f'claude-{task_id}')
+        session_name = meta.get('tmux_session', f'kube-coder-{task_id}')
 
         # Check if tmux session is still alive
         check = subprocess.run(
@@ -985,7 +985,7 @@ class ClaudeTaskManager:
         with open(meta_path, 'r') as f:
             meta = json.load(f)
 
-        session_name = meta.get('tmux_session', f'claude-{task_id}')
+        session_name = meta.get('tmux_session', f'kube-coder-{task_id}')
 
         # Kill the tmux session if alive
         subprocess.run(
@@ -3378,7 +3378,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         except (OSError, json.JSONDecodeError):
             self.send_json({'error': 'Task metadata unreadable'}, 500)
             return
-        session_name = meta.get('tmux_session', f'claude-{task_id}')
+        session_name = meta.get('tmux_session', f'kube-coder-{task_id}')
         output_log = os.path.join(task_dir, 'output.log')
 
         self.send_response(200)
@@ -3618,7 +3618,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         if task is None:
             self.send_json({'error': 'Task not found'}, 404)
             return
-        session_name = task.get('tmux_session', f'claude-{task_id}')
+        session_name = task.get('tmux_session', f'kube-coder-{task_id}')
         # Wait up to ~3s for the tmux session to be visible to has-session
         # before declaring ourselves ready. Without this, the SPA can load
         # the iframe and run terminal-entry.sh while the session that
@@ -3679,7 +3679,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         if task is None:
             self.send_json({'error': 'Task not found'}, 404)
             return
-        session_name = task.get('tmux_session', f'claude-{task_id}')
+        session_name = task.get('tmux_session', f'kube-coder-{task_id}')
         if action == 'enter':
             cmd = ['tmux', 'copy-mode', '-t', session_name]
         else:
@@ -4785,6 +4785,33 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         # Preserve the readyState constants apps read as WebSocket.OPEN etc.
         b'window.WebSocket.CONNECTING=W.CONNECTING;window.WebSocket.OPEN=W.OPEN;'
         b'window.WebSocket.CLOSING=W.CLOSING;window.WebSocket.CLOSED=W.CLOSED;}'
+        # Dynamically-injected <link>/<script> (modulepreload, the rel=stylesheet
+        # CSS-preload links a Vite/Rolldown SPA appends at runtime, prefetch) build
+        # their href/src from the app's absolute base (e.g. /dashboard/assets/x.css)
+        # — fetch/XHR patching doesn't cover element insertion, so those escape the
+        # proxy prefix and 404/HTML-fall-through ("Unable to preload CSS for ..."").
+        # Rewrite href/src through fix() as the node is inserted (before the browser
+        # fetches it), so the request goes through the authed proxy path.
+        # Primary: intercept the href/src *property setter* on freshly-created
+        # link/script elements. The bundler's CSS preloader does `o.href=t`
+        # (a property assignment, not setAttribute) then document.head.append —
+        # patching appendChild alone misses it. Redefining the setter on the
+        # instance catches the absolute path at the moment it is assigned.
+        b'function fxp(el,prop){try{var pr=Object.getPrototypeOf(el);'
+        b'var d=pr&&Object.getOwnPropertyDescriptor(pr,prop);'
+        b'if(d&&d.set&&d.get){Object.defineProperty(el,prop,{configurable:true,enumerable:d.enumerable,'
+        b'get:function(){return d.get.call(this)},'
+        b'set:function(v){try{v=fix(v)}catch(e){}return d.set.call(this,v)}});}}catch(e){}}'
+        b'var _ce=document.createElement;document.createElement=function(t){'
+        b'var el=_ce.apply(document,arguments);try{var tg=(""+t).toLowerCase();'
+        b'if(tg==="link")fxp(el,"href");else if(tg==="script")fxp(el,"src");}catch(e){}return el;};'
+        # Fallback: fix href/src as a node is inserted, covering elements built
+        # via innerHTML / cloneNode that bypass our createElement override.
+        b'function fxn(n){try{if(!n||!n.tagName)return;var t=n.tagName;'
+        b'if(t==="LINK"){var h=n.getAttribute&&n.getAttribute("href");if(h)n.setAttribute("href",fix(h));}'
+        b'else if(t==="SCRIPT"){var s=n.getAttribute&&n.getAttribute("src");if(s)n.setAttribute("src",fix(s));}}catch(e){}}'
+        b'var _ap=Node.prototype.appendChild;Node.prototype.appendChild=function(n){fxn(n);return _ap.call(this,n)};'
+        b'var _ib=Node.prototype.insertBefore;Node.prototype.insertBefore=function(n,r){fxn(n);return _ib.call(this,n,r)};'
         b'})();</script>'
     )
     # Hop-by-hop headers that must not be forwarded between client and
@@ -5155,6 +5182,25 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
                 if not stripped:
                     continue
                 v = stripped
+                # We inject an inline runtime shim into rewritten HTML (see
+                # _rewrite_proxied_html). A restrictive script-src — e.g.
+                # "script-src 'self'" with no 'unsafe-inline' — makes the
+                # browser silently block that inline <script> from executing,
+                # so the app's runtime asset requests stay unproxied and a
+                # Vite/Rolldown SPA's CSS preloads 404 ("Unable to preload CSS
+                # for /…"). Add 'unsafe-inline' to script-src so the shim runs.
+                # Only for responses we actually rewrote.
+                if rewritten is not None:
+                    parts = [p.strip() for p in v.split(';') if p.strip()]
+                    has_script_src = False
+                    for i, p in enumerate(parts):
+                        if p.lower().startswith('script-src'):
+                            has_script_src = True
+                            if "'unsafe-inline'" not in p.lower():
+                                parts[i] = p + " 'unsafe-inline'"
+                    if not has_script_src:
+                        parts.append("script-src 'self' 'unsafe-inline'")
+                    v = '; '.join(parts)
             if kl == 'location':
                 v = self._rewrite_location_header(v, port)
             self.send_header(k, v)

--- a/charts/workspace/start.sh
+++ b/charts/workspace/start.sh
@@ -448,6 +448,68 @@ fi
 if [ -x "$LIBREFANG_TARGET/bin/librefang" ] && [ ! -f "$LIBREFANG_TARGET/config.toml" ]; then
   HOME=/home/dev "$LIBREFANG_TARGET/bin/librefang" init --quick >/dev/null 2>&1 || true
 fi
+# Normalize the LibreFang config so the dashboard's `librefang chat` sessions
+# actually work. Runs every boot (idempotent) so it also corrects configs that
+# were already persisted on the PVC, not just freshly-init'd ones.
+#
+#   1. Auth gate. `init --quick` seeds default dashboard credentials
+#      (dashboard_user/pass = "librefang"), which auto-enable bearer auth on the
+#      daemon's API. But `librefang chat` presents no token, so the chat
+#      WebSocket is rejected and the REPL shows "No active connection". The
+#      daemon binds 127.0.0.1 only (network_enabled = false) behind
+#      oauth2-proxy, so this in-pod auth adds no security — blank the triggers.
+#
+#   2. Provider. `init --quick` picks the provider from whichever key it finds
+#      first, so a workspace that also has ANTHROPIC_API_KEY lands on Anthropic
+#      even when its funded/working key is OpenRouter (the same key Ante and the
+#      OpenCode assistant use). When OPENROUTER_API_KEY is present, pin
+#      [default_model] to OpenRouter. Model is overridable via KC_LIBREFANG_MODEL.
+LF_CFG="$LIBREFANG_TARGET/config.toml"
+if [ -f "$LF_CFG" ]; then
+  sed -i -E 's/^(api_key|dashboard_user|dashboard_pass|dashboard_pass_hash)[[:space:]]*=.*/\1 = ""/' "$LF_CFG" || true
+  if [ -n "$OPENROUTER_API_KEY" ]; then
+    LF_MODEL="openrouter/${KC_LIBREFANG_MODEL:-deepseek/deepseek-v3.2}"
+    awk -v model="$LF_MODEL" '
+      /^\[default_model\]/{inblk=1}
+      /^\[/ && $0 !~ /^\[default_model\]/{inblk=0}
+      inblk && /^provider[[:space:]]*=/{print "provider = \"openrouter\""; next}
+      inblk && /^model[[:space:]]*=/{print "model = \"" model "\""; next}
+      inblk && /^api_key_env[[:space:]]*=/{print "api_key_env = \"OPENROUTER_API_KEY\""; next}
+      {print}
+    ' "$LF_CFG" > "$LF_CFG.kc" && mv "$LF_CFG.kc" "$LF_CFG" || rm -f "$LF_CFG.kc"
+
+    # The agent the dashboard launches (KC_LIBREFANG_AGENT, default "coder")
+    # ships a template that breaks against OpenRouter in two ways:
+    #   - model = "default" (inherit [default_model]). LibreFang's *streaming*
+    #     chat path — the one the dashboard REPL uses — sends that literal
+    #     "default" to the provider instead of resolving it, so OpenRouter 400s
+    #     ("default is not a valid model ID") and the REPL shows no reply. The
+    #     non-streaming /message path resolves it, which is why headless works
+    #     but interactive chat doesn't.
+    #   - api_key_env hardcoded to GEMINI_API_KEY / GROQ_API_KEY (unset here),
+    #     which surfaces as "LLM provider authentication failed".
+    # Pin just this agent's model + key env to explicit values. Scoped to the
+    # dashboard agent only — we don't touch the user's other agents (hands,
+    # multi-agent setups), whose providers may differ.
+    LF_AGENT="${KC_LIBREFANG_AGENT:-coder}"
+    for _af in "$LIBREFANG_TARGET"/workspaces/agents/"$LF_AGENT"/agent.toml \
+               "$LIBREFANG_TARGET"/registry/agents/"$LF_AGENT"/agent.toml; do
+      [ -f "$_af" ] || continue
+      sed -i -E "s#^provider = \"default\"#provider = \"openrouter\"#; \
+                 s#^model = \"(default|openrouter/.*)\"#model = \"$LF_MODEL\"#; \
+                 s#^api_key_env = \".*\"#api_key_env = \"OPENROUTER_API_KEY\"#" "$_af" 2>/dev/null || true
+    done
+  fi
+fi
+# Pre-warm the daemon at boot. Otherwise it only starts lazily when the first
+# `librefang chat` opens, and a cold start (daemon launch + model-catalog sync
+# of ~57 files) can outlast the per-chat bootstrap's 10s poll window — so the
+# first message after opening a fresh session appears to get no reply until it
+# warms up. Backgrounded + idempotent (no-op if already running).
+if [ -x "$LIBREFANG_TARGET/bin/librefang" ]; then
+  HOME=/home/dev "$LIBREFANG_TARGET/bin/librefang" status -q >/dev/null 2>&1 \
+    || HOME=/home/dev "$LIBREFANG_TARGET/bin/librefang" start >/dev/null 2>&1 &
+fi
 
 # The memory subsystem ships its Python package as flat configmap keys
 # (configmap keys cannot contain "/"). Unpack them into a real `memory/`


### PR DESCRIPTION
Makes LibreFang fully usable from the workspace dashboard and fixes the preview proxy for client-routed SPAs.

## `start.sh` — LibreFang runtime config
`librefang init --quick` leaves a config that breaks dashboard chat. Normalized on every boot (idempotent; also corrects existing PVC configs):
- **Auth gate** — default dashboard creds auto-enable bearer auth on the loopback daemon, but `librefang chat` sends no token → "No active connection". Blank the auth triggers (daemon is 127.0.0.1-only behind oauth2-proxy).
- **Provider** — init auto-picks Anthropic when an Anthropic key is present; pin `[default_model]` to OpenRouter (`KC_LIBREFANG_MODEL` override).
- **Agent template** — coder ships `model="default"` (streaming chat sends it literally → OpenRouter 400, silent no-reply) and `api_key_env` pointing at unset GEMINI/GROQ keys; pin to the real model + `OPENROUTER_API_KEY`.
- **Pre-warm** the daemon at boot so the first chat doesn't wait on a cold start.

## `server.py` — preview app-proxy
A Vite/Rolldown SPA (the LibreFang dashboard) failed with `Unable to preload CSS`:
- Its CSP (`script-src 'self'`, no `'unsafe-inline'`) silently blocked the injected runtime shim from executing → relax `script-src` on responses we rewrite.
- The shim only patched `fetch`/`XHR`/`WebSocket`, not dynamically-created `<link>`/`<script>` preloads → intercept the `href`/`src` property setter at `createElement` (with an `appendChild` fallback).

Also renames task/chat tmux sessions `claude-<id>` → `kube-coder-<id>` so the status bar isn't mislabeled when the session runs ante/librefang/opencode (`.claude-tasks` data dir unchanged).

Deployed and verified on demo + imran (chat returns responses; key/config validated). The LibreFang dashboard CSS fix still wants a browser confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)