### PR TITLE
fix(ci): grant SARIF upload permission, drop Node 20 actions, fix SCA scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,24 @@ on:
   pull_request:
     branches: [main]
 
+# Default to a read-only token for every job. The security-scan job widens
+# this to upload SARIF (see its own permissions block). Without an explicit
+# block the workflow inherited the repo's read-only default, so the
+# upload-sarif step failed on pushes to main with "Resource not accessible
+# by integration" (PR runs happened to get a writable token and passed).
+permissions:
+  contents: read
+
 jobs:
   helm-lint:
     name: Helm Lint & Template
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.14.0
 
@@ -54,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.14.0
 
@@ -75,10 +83,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -90,10 +98,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'yarn'
@@ -113,13 +121,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: devlaptop/Dockerfile
@@ -140,9 +148,12 @@ jobs:
     name: Security Scanning
     runs-on: ubuntu-latest
     needs: docker-build  # Wait for docker-build to complete
+    permissions:
+      contents: read          # checkout + trufflehog
+      security-events: write  # upload-sarif -> GitHub code scanning
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@main
@@ -150,10 +161,10 @@ jobs:
           extra_args: --only-verified
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image for scanning
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: devlaptop/Dockerfile
@@ -173,15 +184,19 @@ jobs:
           scanners: 'vuln'
 
       - name: Upload Trivy Scan Results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
 
       - name: SCA Scanning (JavaScript/TypeScript)
         run: |
+          # The SPA uses yarn classic (yarn.lock, no package-lock.json), so
+          # `npm audit` aborted with ENOLOCK and scanned nothing. yarn audit
+          # reads yarn.lock directly. It exits non-zero when advisories exist,
+          # so keep the `|| echo` to stay non-blocking.
           cd charts/workspace/web
-          npm audit --audit-level=high || echo "Vulnerabilities found"
+          yarn audit --level high || echo "Vulnerabilities found"
         if: success() || failure()
 
       - name: SCA Scanning (Python)


### PR DESCRIPTION
## Why

CI has been **failing on every push to `main`** (the last 3 pushes are red) at the **Security Scanning → Upload Trivy Scan Results** step:

```
##[error]Resource not accessible by integration
```

The workflow had **no `permissions:` block**, so it inherited the repo's read-only `GITHUB_TOKEN`. Uploading SARIF to GitHub code scanning requires `security-events: write`. PR runs happened to receive a writable token (so they passed), which is exactly why frontend/CI regressions shipped green and only the `main` push event went red.

## Changes

- **Permissions:** add a top-level least-privilege `permissions: contents: read` default, and widen just the `security-scan` job with `security-events: write` so the SARIF upload works deterministically on both PRs and pushes.
- **Node 20 deprecation:** every pinned action was on the deprecated `node20` runtime (forced migration **June 16, 2026**). Bumped each to its latest Node 24 major, verified against each action's `action.yml`:
  | Action | Before → After |
  |---|---|
  | actions/checkout | v4 → **v6** |
  | actions/setup-node | v4 → **v6** |
  | actions/setup-python | v5 → **v6** |
  | docker/setup-buildx-action | v3 → **v4** |
  | docker/build-push-action | v6 → **v7** |
  | github/codeql-action/upload-sarif | v3 → **v4** |
  | azure/setup-helm | v4 → **v5** |
- **SCA scan was a no-op:** the JS/TS step ran `npm audit` in `charts/workspace/web`, but that dir uses **yarn classic** (`yarn.lock`, no `package-lock.json`), so npm aborted with `ENOLOCK` and scanned nothing. Switched to `yarn audit --level high` (kept non-blocking via `|| echo`).

`trufflesecurity/trufflehog@main` and `aquasecurity/trivy-action@master` are left as branch pins — they're Docker-based actions, so the Node 20 runner deprecation doesn't apply.

## Note

CI keys the security scan off the `push` event, so the permissions fix won't show green until this lands on `main`. The PR run here will exercise the action bumps and the `yarn audit` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)