### PR TITLE
fix(ci): install LibreFang from a pinned GitHub release, not the 403-ing installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,12 @@ jobs:
 
       - name: Upload Trivy Scan Results
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
+        # Upload whenever the SARIF exists, even if an earlier step failed —
+        # but skip (don't error) when it's absent, e.g. the image build or
+        # Trivy itself failed and produced no report. `always()` alone made
+        # the step fail with "Path does not exist: trivy-results.sarif",
+        # masking the real upstream failure.
+        if: always() && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: 'trivy-results.sarif'
 

--- a/devlaptop/Dockerfile
+++ b/devlaptop/Dockerfile
@@ -97,13 +97,31 @@ RUN curl -fsSL https://ante.run/install.sh | bash -s -- ${ANTE_VERSION} \
 # and /usr/local/bin/librefang is a *symlink* to the PVC-backed path
 # /home/dev/.librefang/bin/librefang, which start.sh seeds from /opt on
 # boot. ~/.librefang also holds LibreFang's own config/agents/sessions, so
-# the one PVC symlink persists data + binary together. LIBREFANG_AUTO_START=0
-# stops the installer from booting the daemon inside the build. Bump
-# LIBREFANG_VERSION (a release tag; empty = latest) + rebuild to update.
+# the one PVC symlink persists data + binary together.
+#
+# Pull the release tarball straight from GitHub Releases instead of piping
+# librefang.ai/install.sh: that host 403s GitHub Actions runner IPs, which
+# broke the CI image build (and cascaded into the Trivy SARIF upload). The
+# GitHub release CDN is reachable from CI — same as ttyd below. Prefer the
+# static musl build, fall back to glibc. The installer pulls this exact
+# tarball (librefang/librefang releases); we just skip its WAF-gated front
+# door. Bump LIBREFANG_VERSION (a release tag) + rebuild to update.
 ARG LIBREFANG_VERSION=v2026.6.10-beta.17
-RUN curl -fsSL https://librefang.ai/install.sh \
-    | LIBREFANG_INSTALL_DIR=/opt/librefang LIBREFANG_AUTO_START=0 \
-      LIBREFANG_VERSION=${LIBREFANG_VERSION} sh \
+RUN ARCH=$(dpkg --print-architecture) \
+    && case "$ARCH" in \
+         amd64) LF_ARCH=x86_64 ;; \
+         arm64) LF_ARCH=aarch64 ;; \
+         *) LF_ARCH="$ARCH" ;; \
+       esac \
+    && BASE="https://github.com/librefang/librefang/releases/download/${LIBREFANG_VERSION}" \
+    && mkdir -p /opt/librefang \
+    && ( curl -fL --retry 5 --retry-delay 5 --retry-connrefused \
+           "${BASE}/librefang-${LF_ARCH}-unknown-linux-musl.tar.gz" -o /tmp/librefang.tar.gz \
+         || curl -fL --retry 5 --retry-delay 5 --retry-connrefused \
+           "${BASE}/librefang-${LF_ARCH}-unknown-linux-gnu.tar.gz" -o /tmp/librefang.tar.gz ) \
+    && tar -xzf /tmp/librefang.tar.gz -C /opt/librefang \
+    && rm /tmp/librefang.tar.gz \
+    && chmod +x /opt/librefang/librefang* \
     && test -x /opt/librefang/librefang \
     && ln -sfn /home/dev/.librefang/bin/librefang /usr/local/bin/librefang
 


### PR DESCRIPTION
## The failure

The CI image build dies at the LibreFang step:

```
#28 [runtime 11/22] RUN curl -fsSL https://librefang.ai/install.sh | ... sh ...
#28 0.576 curl: (22) The requested URL returned error: 403
#28 ERROR: process ... did not complete successfully: exit code: 1
```

`librefang.ai/install.sh` returns **403 to GitHub Actions runner IPs** (the host's WAF blocks them — builds from un-blocked IPs still work, so it slipped past local testing). The dead build means Trivy never produces a report, so the next step cascades:

```
Upload Trivy Scan Results: ##[error]Path does not exist: trivy-results.sarif
```

…which masks the real (build) failure behind a confusing SARIF error.

> Note: the **Docker Build Smoke Test** job passes because it restores the GHA layer cache (`cache-from: type=gha`); the **Security Scanning** build has no cache, so it rebuilds fresh and hits the 403. Both build the same Dockerfile, so the Dockerfile fix covers both.

## The fix

**1. `devlaptop/Dockerfile` — pin a direct GitHub Release artifact.**
Stop piping the WAF-gated installer; download the release tarball straight from `github.com/librefang/librefang/releases/...`, which is what the installer fetches anyway and is reachable from CI (same release CDN as the existing `ttyd` step). Pinned to `LIBREFANG_VERSION`, arch-mapped (`x86_64`/`aarch64`), musl-preferred with a glibc fallback, plus curl retries — mirroring the surrounding `ttyd` pattern. Reproduces the exact `/opt/librefang/librefang` binary and keeps the existing PVC persistence symlink.

**2. `.github/workflows/ci.yml` — guard the SARIF upload.**
```yaml
if: always() && hashFiles('trivy-results.sarif') != ''
```
Uploads when a report exists (even after an earlier failure), but skips cleanly when it doesn't — so a build/Trivy failure surfaces as itself instead of a misleading "Path does not exist".

## Verification

- `musl` and `gnu` tarballs for the pinned tag return **HTTP 200**.
- End-to-end sim (download → extract → `chmod` → `test -x`) yields a `static-pie x86-64` `librefang` ELF.
- `ci.yml` parses; guard resolves to `always() && hashFiles('trivy-results.sarif') != ''`.

Independent of #54 (Makefile tag-drift) — this is the actual CI blocker affecting all PRs and the next push to `main`, so it's worth merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)