### PR TITLE
feat(local): run kube-coder on a local cluster (minikube) + docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,9 +421,17 @@ local-up: ## Start the local minikube cluster + enable the nginx ingress addon
 
 local-build: ## Build the workspace image for your host arch and load it into minikube
 	@echo "Building $(LOCAL_IMAGE) for linux/$(LOCAL_ARCH)..."
-	docker buildx build --platform linux/$(LOCAL_ARCH) -t $(LOCAL_IMAGE) -f devlaptop/Dockerfile --load .
+	# Output to a tarball instead of `--load`: the docker-container buildx
+	# driver's `--load` reliably hangs the CLI on Docker Desktop *after* the
+	# image is written (the same post-build hang scripts/buildx-push.sh wraps
+	# for `--push`), which would wedge `make`. `-o type=docker,dest=...` writes
+	# the image and exits cleanly; minikube loads the tarball directly — also
+	# avoiding a redundant copy through the host docker daemon.
+	docker buildx build --platform linux/$(LOCAL_ARCH) -t $(LOCAL_IMAGE) \
+		-f devlaptop/Dockerfile -o type=docker,dest=/tmp/kube-coder-local-image.tar .
 	@echo "Loading $(LOCAL_IMAGE) into minikube (large image — can take a minute)..."
-	minikube image load $(LOCAL_IMAGE) -p $(LOCAL_PROFILE)
+	minikube image load /tmp/kube-coder-local-image.tar -p $(LOCAL_PROFILE)
+	@rm -f /tmp/kube-coder-local-image.tar
 
 local-secret: ## Create the namespace + basic-auth secret (admin/admin) in the local cluster
 	$(LOCAL_KUBECTL) create namespace $(NAMESPACE) --dry-run=client -o yaml | $(LOCAL_KUBECTL) apply -f -

--- a/Makefile
+++ b/Makefile
@@ -419,19 +419,16 @@ local-up: ## Start the local minikube cluster + enable the nginx ingress addon
 	$(LOCAL_KUBECTL) -n ingress-nginx wait --for=condition=ready pod \
 		-l app.kubernetes.io/component=controller --timeout=180s
 
-local-build: ## Build the workspace image for your host arch and load it into minikube
-	@echo "Building $(LOCAL_IMAGE) for linux/$(LOCAL_ARCH)..."
-	# Output to a tarball instead of `--load`: the docker-container buildx
-	# driver's `--load` reliably hangs the CLI on Docker Desktop *after* the
-	# image is written (the same post-build hang scripts/buildx-push.sh wraps
-	# for `--push`), which would wedge `make`. `-o type=docker,dest=...` writes
-	# the image and exits cleanly; minikube loads the tarball directly — also
-	# avoiding a redundant copy through the host docker daemon.
-	docker buildx build --platform linux/$(LOCAL_ARCH) -t $(LOCAL_IMAGE) \
-		-f devlaptop/Dockerfile -o type=docker,dest=/tmp/kube-coder-local-image.tar .
-	@echo "Loading $(LOCAL_IMAGE) into minikube (large image — can take a minute)..."
-	minikube image load /tmp/kube-coder-local-image.tar -p $(LOCAL_PROFILE)
-	@rm -f /tmp/kube-coder-local-image.tar
+local-build: ## Build the workspace image for your host arch directly inside minikube
+	@echo "Building $(LOCAL_IMAGE) for linux/$(LOCAL_ARCH) inside minikube..."
+	# Build INSIDE the minikube node rather than host `docker buildx ... --load`.
+	# On Docker Desktop the docker-container buildx driver reliably hangs the
+	# CLI *after* the image is written (the same post-build hang
+	# scripts/buildx-push.sh wraps for `--push`) — `--load` and
+	# `-o type=docker,dest=…` both wedge `make`. `minikube image build` uses the
+	# node's own builder: no host buildx, no hang, and no separate image-load
+	# copy (the image lands straight in the cluster). Honors .dockerignore.
+	minikube image build -t $(LOCAL_IMAGE) -f devlaptop/Dockerfile -p $(LOCAL_PROFILE) .
 
 local-secret: ## Create the namespace + basic-auth secret (admin/admin) in the local cluster
 	$(LOCAL_KUBECTL) create namespace $(NAMESPACE) --dry-run=client -o yaml | $(LOCAL_KUBECTL) apply -f -
@@ -446,6 +443,10 @@ local-deploy: ## Deploy base-infrastructure + the workspace to the local cluster
 		--namespace $(NAMESPACE) --install --wait --timeout 3m
 	$(LOCAL_HELM) upgrade $(LOCAL_RELEASE) ./charts/workspace \
 		-f $(LOCAL_VALUES) --namespace $(NAMESPACE) --install --wait --timeout 5m
+	# Force a rollout so a freshly `local-build`-loaded image is picked up:
+	# the tag (kube-coder:local) doesn't change, so helm sees no diff and the
+	# pod would otherwise keep the old image even though minikube reloaded it.
+	$(LOCAL_KUBECTL) -n $(NAMESPACE) rollout restart deployment/ws-local
 	$(LOCAL_KUBECTL) -n $(NAMESPACE) rollout status deployment/ws-local --timeout=180s
 
 local-forward: ## Port-forward the local ingress controller to localhost:8080 (blocking; Ctrl-C to stop)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile for kube-coder
-.PHONY: build push deploy-base deploy-imran deploy-gerard deploy-all clean help status logs-imran logs-gerard shell-imran shell-gerard version test-imran test-gerard test-all rollback-imran rollback-gerard deploy logs shell test rollback new-user validate-user require-user dashboard-web dashboard-web-install dashboard-web-test dashboard-web-clean python-tests python-coverage dashboard-web-coverage coverage test-coverage
+.PHONY: build push deploy-base deploy-imran deploy-gerard deploy-all clean help status logs-imran logs-gerard shell-imran shell-gerard version test-imran test-gerard test-all rollback-imran rollback-gerard deploy logs shell test rollback new-user validate-user require-user dashboard-web dashboard-web-install dashboard-web-test dashboard-web-clean python-tests python-coverage dashboard-web-coverage coverage test-coverage local local-up local-build local-secret local-deploy local-forward local-info local-down
 
 # =============================================================================
 # Generic per-user helpers
@@ -381,3 +381,83 @@ controller-dev: ## Run controller.py locally (KUBECONFIG listing; dev bearer tok
 	NAMESPACE=$(NAMESPACE) \
 	TRUSTED_PROXY=false \
 	python3 $(WC_DIR)/controller.py
+
+# =============================================================================
+# Local development — run kube-coder on a local single-node cluster (minikube)
+# =============================================================================
+# No cloud dependencies: a locally-built image loaded into minikube, plain HTTP,
+# http basic auth, and the cluster-default storage class. Every command targets
+# the minikube context EXPLICITLY (--context / --kube-context) so these never
+# touch a real/remote cluster. Full guide: docs/local-development.md
+#
+#   make local          # one-shot: start cluster, build+load image, deploy
+#   make local-forward   # port-forward the ingress to localhost:8080 (blocking)
+#   make local-info      # print the /etc/hosts line, URL, and credentials
+#   make local-down      # remove the workspace (DELETE=1 also deletes the cluster)
+
+LOCAL_PROFILE     := kube-coder
+LOCAL_IMAGE       := kube-coder:local
+LOCAL_VALUES      := deployments/local/values.yaml
+LOCAL_HOST        := kube-coder.local
+LOCAL_AUTH_SECRET := kube-coder-basic-auth
+LOCAL_AUTH_USER   := admin
+LOCAL_AUTH_PASS   := admin
+LOCAL_RELEASE     := local-workspace
+# Host arch -> docker platform. Native arm64 on Apple Silicon avoids emulation.
+LOCAL_ARCH        := $(shell uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')
+# Bind every kubectl/helm call to the minikube context, never the current one.
+LOCAL_KUBECTL     := kubectl --context $(LOCAL_PROFILE)
+LOCAL_HELM        := helm --kube-context $(LOCAL_PROFILE)
+
+local: local-up local-build local-secret local-deploy local-info ## Local one-shot: start minikube, build+load image, deploy, print access info
+
+local-up: ## Start the local minikube cluster + enable the nginx ingress addon
+	@command -v minikube >/dev/null || { echo "ERROR: minikube not found. Install it: 'brew install minikube' (macOS) or https://minikube.sigs.k8s.io/docs/start/"; exit 1; }
+	minikube start -p $(LOCAL_PROFILE) --driver=docker --cpus=4 --memory=6g
+	minikube addons enable ingress -p $(LOCAL_PROFILE)
+	@echo "Waiting for the ingress controller to be ready..."
+	$(LOCAL_KUBECTL) -n ingress-nginx wait --for=condition=ready pod \
+		-l app.kubernetes.io/component=controller --timeout=180s
+
+local-build: ## Build the workspace image for your host arch and load it into minikube
+	@echo "Building $(LOCAL_IMAGE) for linux/$(LOCAL_ARCH)..."
+	docker buildx build --platform linux/$(LOCAL_ARCH) -t $(LOCAL_IMAGE) -f devlaptop/Dockerfile --load .
+	@echo "Loading $(LOCAL_IMAGE) into minikube (large image — can take a minute)..."
+	minikube image load $(LOCAL_IMAGE) -p $(LOCAL_PROFILE)
+
+local-secret: ## Create the namespace + basic-auth secret (admin/admin) in the local cluster
+	$(LOCAL_KUBECTL) create namespace $(NAMESPACE) --dry-run=client -o yaml | $(LOCAL_KUBECTL) apply -f -
+	@printf '%s:%s\n' "$(LOCAL_AUTH_USER)" "$$(openssl passwd -apr1 $(LOCAL_AUTH_PASS))" > /tmp/kc-local-htpasswd
+	$(LOCAL_KUBECTL) -n $(NAMESPACE) create secret generic $(LOCAL_AUTH_SECRET) \
+		--from-file=auth=/tmp/kc-local-htpasswd --dry-run=client -o yaml | $(LOCAL_KUBECTL) apply -f -
+	@rm -f /tmp/kc-local-htpasswd
+	@echo "basic-auth secret '$(LOCAL_AUTH_SECRET)' ready (user: $(LOCAL_AUTH_USER) / pass: $(LOCAL_AUTH_PASS))"
+
+local-deploy: ## Deploy base-infrastructure + the workspace to the local cluster
+	$(LOCAL_HELM) upgrade base-infrastructure ./charts/base-infrastructure \
+		--namespace $(NAMESPACE) --install --wait --timeout 3m
+	$(LOCAL_HELM) upgrade $(LOCAL_RELEASE) ./charts/workspace \
+		-f $(LOCAL_VALUES) --namespace $(NAMESPACE) --install --wait --timeout 5m
+	$(LOCAL_KUBECTL) -n $(NAMESPACE) rollout status deployment/ws-local --timeout=180s
+
+local-forward: ## Port-forward the local ingress controller to localhost:8080 (blocking; Ctrl-C to stop)
+	@echo "Forwarding http://$(LOCAL_HOST):8080 -> ingress-nginx. Ensure /etc/hosts maps $(LOCAL_HOST) -> 127.0.0.1 (see 'make local-info')."
+	$(LOCAL_KUBECTL) -n ingress-nginx port-forward svc/ingress-nginx-controller 8080:80
+
+local-info: ## Print local access details (/etc/hosts line, URL, credentials)
+	@echo ""
+	@echo "=== kube-coder local access ==="
+	@echo "1. Map the host once (needs sudo):"
+	@echo "     echo '127.0.0.1  $(LOCAL_HOST)' | sudo tee -a /etc/hosts"
+	@echo "2. Forward the ingress (keep this running in a terminal):"
+	@echo "     make local-forward"
+	@echo "3. Open:        http://$(LOCAL_HOST):8080/"
+	@echo "4. Basic auth:  $(LOCAL_AUTH_USER) / $(LOCAL_AUTH_PASS)"
+	@echo ""
+	@echo "Logs:  $(LOCAL_KUBECTL) -n $(NAMESPACE) logs -f deploy/ws-local -c ide"
+	@echo "Shell: $(LOCAL_KUBECTL) -n $(NAMESPACE) exec -it deploy/ws-local -c ide -- bash"
+
+local-down: ## Remove the local workspace (add DELETE=1 to also delete the minikube cluster)
+	-$(LOCAL_HELM) uninstall $(LOCAL_RELEASE) -n $(NAMESPACE)
+	-$(LOCAL_HELM) uninstall base-infrastructure -n $(NAMESPACE)
+	@if [ "$(DELETE)" = "1" ]; then echo "Deleting minikube profile $(LOCAL_PROFILE)..."; minikube delete -p $(LOCAL_PROFILE); else echo "Cluster kept. Run 'make local-down DELETE=1' to delete the minikube profile."; fi

--- a/README.md
+++ b/README.md
@@ -72,24 +72,52 @@ Mobile users experience an optimized interface with touch-friendly controls and 
 
 ## Quick Start
 
-### Run it locally (minikube)
+kube-coder runs two ways — pick the one that fits:
 
-Want to try kube-coder without a cloud account, registry, or DNS? Run the whole
-thing on a local single-node cluster:
+| | **Local (minikube)** | **Cloud / multi-tenant** |
+|---|---|---|
+| Best for | trying it out, dev, offline | real deployments, teams |
+| Needs | Docker + minikube | a cluster, registry, DNS, GitHub OAuth |
+| Auth | http basic (`admin`/`admin`) | GitHub OAuth2 (or basic) |
+| TLS | none (plain HTTP, localhost) | cert-manager + Let's Encrypt |
+| Guide | [Option A](#option-a--local-minikube) + [docs/local-development.md](docs/local-development.md) | [Option B](#option-b--cloud--multi-tenant) + [NEW_USER_PROVISIONING.md](NEW_USER_PROVISIONING.md) |
+
+### Option A — Local (minikube)
+
+Run the whole stack on a local single-node cluster — no cloud account, registry, DNS, or TLS.
+
+**Prerequisites:** Docker, minikube, kubectl, helm (`brew install minikube kubectl helm` on macOS).
+
+**One command:**
 
 ```bash
-make local          # start minikube, build + load the image, deploy, print access info
-make local-forward   # port-forward the ingress to localhost:8080 (keep running)
-# add '127.0.0.1  kube-coder.local' to /etc/hosts, then open http://kube-coder.local:8080/
-# basic auth: admin / admin
+make local          # start minikube, build the image, deploy, and print access info
 ```
 
-No cloud dependencies — locally-built image (native arm64 on Apple Silicon),
-plain HTTP, basic auth. Full walkthrough, configuration, and teardown:
-**[docs/local-development.md](docs/local-development.md)**. The cloud /
-multi-tenant flow is below.
+**Then reach the dashboard:**
 
-### Prerequisites
+```bash
+echo '127.0.0.1  kube-coder.local' | sudo tee -a /etc/hosts   # one time
+make local-forward                                            # keep running in a terminal
+# open http://kube-coder.local:8080/   →   basic auth: admin / admin
+```
+
+`make local` is a wrapper for these steps, each runnable on its own (e.g. to rebuild after a change):
+
+```bash
+make local-up       # start the minikube cluster + enable the nginx ingress addon
+make local-build    # build the image inside minikube (native arm64 on Apple Silicon — no emulation)
+make local-secret   # create the namespace + basic-auth secret (override LOCAL_AUTH_USER/PASS)
+make local-deploy   # deploy base-infrastructure + the workspace, force-rolled
+make local-info     # reprint the /etc/hosts line, URL, and credentials
+make local-down     # remove the workspace (DELETE=1 also deletes the minikube cluster)
+```
+
+Everything targets the minikube context explicitly, so it never touches a remote cluster. Full walkthrough, configuration, limitations, and troubleshooting: **[docs/local-development.md](docs/local-development.md)**.
+
+### Option B — Cloud / multi-tenant
+
+#### Prerequisites
 
 - Kubernetes 1.19+ with `kubectl` configured
 - Helm 3.0+
@@ -97,13 +125,13 @@ multi-tenant flow is below.
 - A GitHub OAuth App (for oauth2-proxy)
 - A `regcred` image-pull Secret in the target namespace pointing at your registry (we use `registry.digitalocean.com/<org>/<repo>`)
 
-### One-time: Base Infrastructure
+#### One-time: Base Infrastructure
 
 ```bash
 make deploy-base                  # base-infrastructure helm release
 ```
 
-### Onboard a User
+#### Onboard a User
 
 ```bash
 # Scaffold a private workspace under users-private/<name>/ — generates

--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ Mobile users experience an optimized interface with touch-friendly controls and 
 
 ## Quick Start
 
+### Run it locally (minikube)
+
+Want to try kube-coder without a cloud account, registry, or DNS? Run the whole
+thing on a local single-node cluster:
+
+```bash
+make local          # start minikube, build + load the image, deploy, print access info
+make local-forward   # port-forward the ingress to localhost:8080 (keep running)
+# add '127.0.0.1  kube-coder.local' to /etc/hosts, then open http://kube-coder.local:8080/
+# basic auth: admin / admin
+```
+
+No cloud dependencies — locally-built image (native arm64 on Apple Silicon),
+plain HTTP, basic auth. Full walkthrough, configuration, and teardown:
+**[docs/local-development.md](docs/local-development.md)**. The cloud /
+multi-tenant flow is below.
+
 ### Prerequisites
 
 - Kubernetes 1.19+ with `kubectl` configured

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -3182,6 +3182,23 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         """
         if AUTH_MODE == 'none' and allow_none_mode:
             return True
+        # AUTH_MODE=basic: the nginx-ingress http-basic-auth gate is the sole
+        # authenticator. It validates credentials in front of the pod but
+        # deliberately strips the `Authorization` header before proxying
+        # (`proxy_set_header Authorization "";`), and re-forwarding it is
+        # blocked by the controller's admission webhook — so server.py has no
+        # forwarded proof to re-check and trusts the edge. This is what lets
+        # the SPA's /api/* calls work under basic auth; without it the
+        # dashboard loads but every data fetch 401s.
+        #
+        # Security: basic auth is a single shared password with no per-user
+        # identity to enforce, intended for local / single-tenant use where
+        # the only path to the pod is through the authenticating ingress. For
+        # multi-tenant clusters use AUTH_MODE=oauth2, where server.py is the
+        # enforcer (validated proxy headers / Bearer tokens) — see the
+        # TRUSTED_PROXY / Bearer paths below.
+        if AUTH_MODE == 'basic':
+            return True
         if TRUSTED_PROXY:
             if self.headers.get('X-Auth-Request-User') or self.headers.get('X-Auth-Request-Email'):
                 return True

--- a/charts/workspace/templates/ingress-public.yaml
+++ b/charts/workspace/templates/ingress-public.yaml
@@ -27,7 +27,9 @@ metadata:
     nginx.ingress.kubernetes.io/limit-rps: {{ .Values.ingress.publicLimits.rps | default 10 | quote }}
     nginx.ingress.kubernetes.io/limit-connections: {{ .Values.ingress.publicLimits.connections | default 20 | quote }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.publicLimits.bodySize | default "16k" | quote }}
+    {{- if .Values.ingress.tls.enabled }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    {{- end }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/charts/workspace/templates/ingress.yaml
+++ b/charts/workspace/templates/ingress.yaml
@@ -17,7 +17,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    {{- if .Values.ingress.tls.enabled }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    {{- end }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
@@ -117,7 +119,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    {{- if .Values.ingress.tls.enabled }}
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    {{- end }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/charts/workspace/tests/auth_matrix_test.py
+++ b/charts/workspace/tests/auth_matrix_test.py
@@ -46,6 +46,12 @@ class LegacyAuthGateTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tmpdir = tempfile.mkdtemp(prefix='kc-auth-')
+        # Pin oauth2 — the mode where server.py is the enforcer. The default
+        # AUTH_MODE=basic is edge-auth (the ingress authenticates, server.py
+        # trusts it), so check_claude_auth short-circuits there; this suite
+        # tests server.py's own gate, which applies under oauth2.
+        cls._auth_mode_save = server.AUTH_MODE
+        server.AUTH_MODE = 'oauth2'
         # Some handlers touch ClaudeTaskManager paths — point them at the
         # tempdir so a 401 happens BEFORE we trample a real workspace.
         cls._tasks_dir_save = server.ClaudeTaskManager.TASKS_DIR
@@ -61,6 +67,7 @@ class LegacyAuthGateTests(unittest.TestCase):
     def tearDownClass(cls):
         cls.httpd.shutdown()
         cls.httpd.server_close()
+        server.AUTH_MODE = cls._auth_mode_save
         server.ClaudeTaskManager.TASKS_DIR = cls._tasks_dir_save
         import shutil
         shutil.rmtree(cls.tmpdir, ignore_errors=True)

--- a/charts/workspace/tests/docs_api_test.py
+++ b/charts/workspace/tests/docs_api_test.py
@@ -156,6 +156,12 @@ class DocsApiAuthGateTests(unittest.TestCase):
         cls.tmpdir = tempfile.mkdtemp(prefix='kc-docs-auth-')
         with open(os.path.join(cls.tmpdir, '_manifest.json'), 'w') as f:
             json.dump({'version': 1, 'sections': []}, f)
+        # Pin oauth2 — the mode where server.py is the enforcer. The default
+        # AUTH_MODE=basic is an edge-auth mode (the ingress authenticates and
+        # server.py trusts it), so check_claude_auth short-circuits there and
+        # this 401 assertion only tests server.py's own gate under oauth2.
+        cls._auth_mode_save = server.AUTH_MODE
+        server.AUTH_MODE = 'oauth2'
         cls._docs_dir_save = server.DocsManager.DOCS_DIR
         server.DocsManager.DOCS_DIR = cls.tmpdir
         server.DocsManager._MANIFEST_CACHE = (0.0, None)
@@ -170,6 +176,7 @@ class DocsApiAuthGateTests(unittest.TestCase):
     def tearDownClass(cls):
         cls.httpd.shutdown()
         cls.httpd.server_close()
+        server.AUTH_MODE = cls._auth_mode_save
         server.DocsManager.DOCS_DIR = cls._docs_dir_save
         import shutil
         shutil.rmtree(cls.tmpdir, ignore_errors=True)

--- a/charts/workspace/tests/server_test.py
+++ b/charts/workspace/tests/server_test.py
@@ -1061,7 +1061,11 @@ class TrustedProxyTests(unittest.TestCase):
         orig_trust, orig_auth = server.TRUSTED_PROXY, server.AUTH_MODE
         try:
             server.TRUSTED_PROXY = False
-            server.AUTH_MODE = 'basic'
+            # oauth2, not basic: the X-Auth/Remote-User header-trust path this
+            # test exercises only applies in oauth2 mode. In basic mode
+            # check_claude_auth trusts the ingress edge and short-circuits, so
+            # it wouldn't test the TRUSTED_PROXY header gate at all.
+            server.AUTH_MODE = 'oauth2'
             h = self._handler_with({'X-Auth-Request-Email': 'attacker@evil.test'})
             self.assertFalse(server.BrowserHandler.check_claude_auth(h))
             h = self._handler_with({'Remote-User': 'attacker'})
@@ -1073,8 +1077,27 @@ class TrustedProxyTests(unittest.TestCase):
         orig_trust, orig_auth = server.TRUSTED_PROXY, server.AUTH_MODE
         try:
             server.TRUSTED_PROXY = True
-            server.AUTH_MODE = 'basic'
+            # oauth2, not basic: see the companion test — the header-trust path
+            # only applies in oauth2 mode (basic short-circuits to trusted).
+            server.AUTH_MODE = 'oauth2'
             h = self._handler_with({'X-Auth-Request-Email': 'user@example.com'})
+            self.assertTrue(server.BrowserHandler.check_claude_auth(h))
+        finally:
+            server.TRUSTED_PROXY, server.AUTH_MODE = orig_trust, orig_auth
+
+    def test_basic_mode_trusts_ingress_edge(self):
+        """AUTH_MODE=basic is edge-auth: the nginx-ingress basic-auth gate is
+        the sole authenticator (it strips the credential header and the
+        controller blocks re-forwarding it), so server.py trusts any request
+        that reached it — that's what makes the SPA's /api/* calls work under
+        basic auth. A request with no auth headers still returns True here
+        because in a real deployment it could only have arrived through the
+        authenticating ingress."""
+        orig_trust, orig_auth = server.TRUSTED_PROXY, server.AUTH_MODE
+        try:
+            server.TRUSTED_PROXY = False
+            server.AUTH_MODE = 'basic'
+            h = self._handler_with({})
             self.assertTrue(server.BrowserHandler.check_claude_auth(h))
         finally:
             server.TRUSTED_PROXY, server.AUTH_MODE = orig_trust, orig_auth

--- a/charts/workspace/web/src/api/apps.ts
+++ b/charts/workspace/web/src/api/apps.ts
@@ -1,4 +1,4 @@
-import { apiGet, apiPost, apiDelete } from './client';
+import { apiGet, apiPost, apiDelete, authPrefix } from './client';
 
 /** One row on the Applications page. */
 export interface AppEntry {
@@ -45,6 +45,7 @@ export const unpinApp = (port: number) =>
   apiDelete<{ ok: true; removed: boolean }>(`/api/apps/pins/${port}`);
 
 /** Path the proxy lives at — used for iframe src + "open in new tab".
- *  Goes through /oauth so cookie auth attaches in production. */
+ *  Uses the deployment's auth prefix (/oauth behind oauth2, empty under basic
+ *  auth) so cookie/basic auth attaches against the right ingress. */
 export const proxyUrl = (port: number, suffix = '/') =>
-  `/oauth/api/app-proxy/${port}${suffix.startsWith('/') ? suffix : `/${suffix}`}`;
+  `${authPrefix()}/api/app-proxy/${port}${suffix.startsWith('/') ? suffix : `/${suffix}`}`;

--- a/charts/workspace/web/src/api/client.test.ts
+++ b/charts/workspace/web/src/api/client.test.ts
@@ -62,7 +62,8 @@ describe('api client', () => {
     expect((calledInit?.headers as Record<string, string>)['Content-Type']).toBe('application/json');
   });
 
-  it('prepends /oauth to /api/* paths so oauth2 ingress headers are injected', async () => {
+  it('prepends /oauth to /api/* paths when served under the oauth2 ingress', async () => {
+    window.history.replaceState({}, '', '/oauth/tasks');
     let url = '';
     globalThis.fetch = vi.fn(async (u: string) => {
       url = u;
@@ -75,11 +76,18 @@ describe('api client', () => {
     }) as unknown as typeof fetch;
     await apiGet('/api/claude/tasks');
     expect(url).toBe('/oauth/api/claude/tasks');
+    window.history.replaceState({}, '', '/');
   });
 
-  it('withOauthPrefix is idempotent and leaves non-/api paths alone', () => {
+  it('withOauthPrefix follows the served prefix (/oauth behind oauth2, none under basic auth)', () => {
+    // Behind the oauth2 ingress (URL under /oauth): prefix is added.
+    window.history.replaceState({}, '', '/oauth/tasks');
     expect(withOauthPrefix('/api/foo')).toBe('/oauth/api/foo');
     expect(withOauthPrefix('/oauth/api/foo')).toBe('/oauth/api/foo');
+    // Root / basic-auth deployment: no /oauth route, so no prefix.
+    window.history.replaceState({}, '', '/');
+    expect(withOauthPrefix('/api/foo')).toBe('/api/foo');
+    // Non-/api paths and absolute URLs are untouched in both modes.
     expect(withOauthPrefix('/health')).toBe('/health');
     expect(withOauthPrefix('https://example.com/api/x')).toBe('https://example.com/api/x');
   });

--- a/charts/workspace/web/src/api/client.ts
+++ b/charts/workspace/web/src/api/client.ts
@@ -47,15 +47,33 @@ function devToken(): string | null {
 }
 
 /**
- * Prepend /oauth to /api/* paths so requests go through the auth-injecting
- * ingress in production. Absolute URLs and already-prefixed paths pass through.
- * Exported so raw fetch()/EventSource callers (files.ts, SSE in tasks.ts) can
- * apply the same rule without duplicating the logic.
+ * The external path prefix the dashboard is served under, detected from where
+ * the SPA itself was loaded:
+ *   - '/oauth'  behind the oauth2-proxy ingress (the auth-injecting ingress
+ *               only matches /oauth/*, and the user's URL is /oauth/...).
+ *   - ''        a root / http-basic-auth deployment (e.g. local minikube),
+ *               where there is no /oauth route and services live at /terminal,
+ *               /vscode, /api, … directly.
+ * Using the loaded prefix keeps API calls AND embedded-service URLs (terminal,
+ * VS Code, VNC, metrics, app-proxy) pointed at the same ingress the user
+ * authenticated against, instead of hardcoding /oauth and 404ing under basic
+ * auth.
+ */
+export function authPrefix(): string {
+  if (typeof window === 'undefined') return '';
+  return window.location.pathname.startsWith('/oauth') ? '/oauth' : '';
+}
+
+/**
+ * Prepend the deployment's auth prefix to /api/* paths so requests go through
+ * the same ingress the SPA was served from. Absolute URLs and already-prefixed
+ * paths pass through. Exported so raw fetch()/EventSource callers (files.ts,
+ * SSE in tasks.ts) can apply the same rule without duplicating the logic.
  */
 export function withOauthPrefix(path: string): string {
   if (/^https?:\/\//i.test(path)) return path;
   if (path.startsWith('/oauth/')) return path;
-  if (path.startsWith('/api/')) return `/oauth${path}`;
+  if (path.startsWith('/api/')) return `${authPrefix()}${path}`;
   return path;
 }
 

--- a/charts/workspace/web/src/api/metrics.ts
+++ b/charts/workspace/web/src/api/metrics.ts
@@ -1,9 +1,11 @@
 /**
  * Workspace pod system metrics. server.py mounts these at the top level
  * (/metrics, /health) — *not* under /api/ — so they don't go through the
- * withOauthPrefix() helper. We hit /oauth/metrics directly because the
- * auth-injecting ingress matches /oauth/(.*).
+ * withOauthPrefix() helper. We prefix with authPrefix() (/oauth behind the
+ * oauth2 ingress, empty under basic auth) so they hit the same ingress the
+ * SPA was served from.
  */
+import { authPrefix } from './client';
 
 export interface CpuMetrics {
   usage_percent: number;
@@ -59,5 +61,5 @@ async function getJson<T>(path: string): Promise<T> {
   return (await res.json()) as T;
 }
 
-export const fetchMetrics = () => getJson<SystemMetrics>('/oauth/metrics');
-export const fetchHealth = () => getJson<HealthSnapshot>('/oauth/health');
+export const fetchMetrics = () => getJson<SystemMetrics>(`${authPrefix()}/metrics`);
+export const fetchHealth = () => getJson<HealthSnapshot>(`${authPrefix()}/health`);

--- a/charts/workspace/web/src/api/tasks.ts
+++ b/charts/workspace/web/src/api/tasks.ts
@@ -1,4 +1,4 @@
-import { apiGet, apiPost, apiDelete } from './client';
+import { apiGet, apiPost, apiDelete, authPrefix } from './client';
 import { coerceTaskSummary, coerceTaskDetail, safeArray } from './shape';
 
 export type TaskStatus = 'running' | 'completed' | 'killed' | 'error' | 'unknown' | 'waiting-for-input';
@@ -130,12 +130,18 @@ export const setScrollMode = (id: string, action: 'enter' | 'exit') =>
     { action },
   );
 
-/** Absolute URL for the ttyd iframe; cache-busts on each open. */
-export const terminalUrl = () => `/oauth/terminal/?t=${Date.now()}`;
+/** Absolute URL for the ttyd iframe; cache-busts on each open. Uses the
+ *  deployment's auth prefix (empty under basic auth, /oauth behind oauth2). */
+export const terminalUrl = () => `${authPrefix()}/terminal/?t=${Date.now()}`;
 
 /** Absolute URL for the embedded noVNC viewer. */
 export const vncUrl = () =>
-  `/oauth/vnc-direct/vnc.html?autoconnect=true&resize=scale&view_clip=true&t=${Date.now()}`;
+  `${authPrefix()}/vnc-direct/vnc.html?autoconnect=true&resize=scale&view_clip=true&t=${Date.now()}`;
+
+/** URL that opens code-server at `folder`, via the deployment's auth prefix
+ *  (empty under basic auth, /oauth behind the oauth2 ingress). */
+export const vscodeUrl = (folder = '/home/dev') =>
+  `${authPrefix()}/vscode/?folder=${encodeURIComponent(folder)}`;
 
 /**
  * Tell the in-pod kiosk Chrome to navigate to localhost:<port>. The dashboard

--- a/charts/workspace/web/src/components/Topbar.tsx
+++ b/charts/workspace/web/src/components/Topbar.tsx
@@ -5,7 +5,7 @@ import { HealthDot } from './HealthDot';
 import { MetricsBar } from './MetricsBar';
 import { MutatorOnly, ReadOnlyPill } from './MutatorOnly';
 import { WaitingBadge } from './WaitingBadge';
-import { createTerminalTask, terminalUrl } from '../api/tasks';
+import { createTerminalTask, terminalUrl, vscodeUrl } from '../api/tasks';
 import { refreshTasks } from '../store/tasks';
 import { serverMode } from '../store/server-mode';
 import { navigate } from '../store/router';
@@ -93,7 +93,7 @@ export function Topbar() {
         <MutatorOnly>
           <a
             class="topbar-link topbar-link-strong"
-            href="/oauth/vscode/?folder=/home/dev"
+            href={vscodeUrl('/home/dev')}
             target="_blank"
             rel="noopener"
             title="Open VS Code (code-server) at /home/dev"

--- a/charts/workspace/web/src/routes/files/index.tsx
+++ b/charts/workspace/web/src/routes/files/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'preact/hooks';
 import { listFiles, makeDirectory, uploadFile, type FileEntry } from '../../api/files';
+import { vscodeUrl } from '../../api/tasks';
 import { Button } from '../../components/primitives/Button';
 import { Icon } from '../../components/Icon';
 import { pushToast } from '../../store/ui';
@@ -213,7 +214,7 @@ function OpenInVscode({ path, kind }: { path: string; kind: 'dir' | 'file' }) {
   const folder = kind === 'dir'
     ? abs
     : abs.slice(0, abs.lastIndexOf('/')) || absHome;
-  const href = `/oauth/vscode/?folder=${encodeURIComponent(folder)}`;
+  const href = vscodeUrl(folder);
   return (
     <a
       class="files-row-vscode"

--- a/charts/workspace/web/src/routes/more/index.tsx
+++ b/charts/workspace/web/src/routes/more/index.tsx
@@ -2,7 +2,7 @@ import { navigate } from '../../store/router';
 import { sheetOpen, theme } from '../../store/ui';
 import { Icon, type IconName } from '../../components/Icon';
 import { Button } from '../../components/primitives/Button';
-import { createTerminalTask, terminalUrl } from '../../api/tasks';
+import { createTerminalTask, terminalUrl, vscodeUrl } from '../../api/tasks';
 import { refreshTasks } from '../../store/tasks';
 import { serverMode } from '../../store/server-mode';
 import './more.css';
@@ -43,7 +43,7 @@ export function MoreSheet() {
       label: 'Open VS Code',
       icon: 'files',
       onSelect: () => {
-        window.open('/oauth/vscode/?folder=/home/dev', '_blank');
+        window.open(vscodeUrl('/home/dev'), '_blank');
         sheetOpen.value = null;
       },
       hint: 'code-server at /home/dev',

--- a/deployments/local/values.yaml
+++ b/deployments/local/values.yaml
@@ -1,0 +1,83 @@
+# kube-coder — local single-node cluster overlay (minikube).
+#
+# This is the values file the `make local-*` targets feed to Helm. It runs a
+# fully self-contained workspace with NO cloud dependencies:
+#   - a locally-built image loaded into minikube (no registry / pull secret)
+#   - plain HTTP (no cert-manager / Let's Encrypt / public DNS)
+#   - http basic auth (admin/admin) created by `make local-secret`
+#   - the cluster-default storage class (minikube hostpath)
+#
+# See docs/local-development.md for the full walkthrough. Everything here is
+# safe to commit — it contains no secrets. Add your own Claude / assistant
+# keys to a gitignored overlay (secrets/local/*.yaml) if you want them.
+namespace: coder
+
+user:
+  name: local
+  # Hostname routed by the nginx ingress. Point it at the minikube IP in
+  # /etc/hosts (see `make local-info`). Not a public DNS name.
+  host: kube-coder.local
+  # Smaller than the 50Gi cloud default — plenty for a laptop.
+  pvcSize: 10Gi
+  env:
+    - name: GIT_USER_NAME
+      value: ""
+    - name: GIT_USER_EMAIL
+      value: ""
+
+# Locally-built image loaded into the cluster with `minikube image load`.
+# IfNotPresent (not Always) so the kubelet uses the loaded image instead of
+# trying to pull from a registry; no pull secret because it never leaves the
+# node. `make local-build` builds and loads this exact tag for your host arch
+# (native arm64 on Apple Silicon — no emulation).
+image:
+  repository: kube-coder
+  tag: local
+  pullPolicy: IfNotPresent
+  pullSecretName: ""
+
+# Plain HTTP + http basic auth. No cert-manager, no public DNS.
+# `make local-secret` creates the htpasswd secret referenced below.
+ingress:
+  className: nginx
+  auth:
+    type: basic
+    secretName: kube-coder-basic-auth
+  tls:
+    enabled: false
+
+readOnly: false
+
+# Laptop-sized. The IDE container still wants ~1Gi for code-server + Claude;
+# bump limits if you run heavier workloads. Start minikube with at least
+# `--cpus=4 --memory=6g` (see docs/local-development.md).
+resources:
+  requests:
+    cpu: "500m"
+    memory: 1Gi
+  limits:
+    cpu: "2"
+    memory: 4Gi
+
+# Build mode for *in-workspace* image builds (the `docker-build` helper).
+# Kaniko needs a registry to push to, which a local cluster doesn't have, so
+# the push target is left empty: kube-coder itself runs fine, but building
+# and pushing images from inside a workspace is unavailable in local mode.
+# To enable it, run `minikube addons enable registry` and point these at it.
+# (See docs/local-development.md → "Limitations".)
+build:
+  mode: kaniko
+  pushSecretName: ""
+  defaultDestinationRepo: ""
+
+# Add your own keys via a gitignored secrets/local/*.yaml overlay if desired.
+# Without them the workspace still boots; you log into Claude interactively
+# by running `claude` once in the pod's terminal.
+claude:
+  apiKey: ""
+
+codeServer:
+  enabled: true
+
+ssh:
+  enabled: false

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -177,6 +177,19 @@ make local-down DELETE=1     # also delete the minikube profile entirely
   expose it.
 - **Resources.** Defaults are laptop-sized; heavy builds/tests inside the
   workspace may want a bigger `minikube start --memory`.
+- **Apple Silicon: the in-workspace browser/Desktop is degraded.** The image
+  bundles Firefox via Mozilla's `linux64` (x86_64) build, which can't execute
+  on an `arm64` node. The image still builds, and the **dashboard, terminal,
+  tasks, Memory, Files, code-server, and Claude all work** — but the noVNC
+  **Desktop** tab (which launches Firefox/X11) won't render. The dashboard
+  opens on the Desktop tab by default, so just click **Build** (Tasks) or
+  another tab. On `amd64` hosts the Desktop tab works normally.
+- **Auth model.** Local uses http basic auth, where the ingress is the sole
+  authenticator and server.py trusts requests that reach it (ingress-nginx
+  strips the credential header and blocks re-forwarding it, so the backend
+  can't re-verify). This is fine for a single-tenant local cluster; for
+  multi-tenant clusters use `ingress.auth.type=oauth2`, where server.py
+  enforces identity itself.
 
 ---
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,208 @@
+# Running kube-coder locally (minikube)
+
+kube-coder normally runs on a managed Kubernetes cluster (the reference deploy
+is DigitalOcean DOKS), but it runs just as well on a **local single-node
+cluster** for development, evaluation, or offline use — no cloud account, no
+container registry, no public DNS, and no TLS certificates required.
+
+This guide uses **[minikube](https://minikube.sigs.k8s.io/)**, because its
+built-in `ingress` addon ships the same `ingress-nginx` controller the chart
+expects, and `minikube image load` lets you run a locally-built image without
+pushing it anywhere. [kind](https://kind.sigs.k8s.io/) and
+[k3d](https://k3d.io/) work too — see [Other local clusters](#other-local-clusters).
+
+The whole flow is wrapped in `make local-*` targets that talk **only** to the
+minikube context, so they can't touch a remote cluster.
+
+---
+
+## Prerequisites
+
+| Tool | Why | Install (macOS) |
+|------|-----|-----------------|
+| Docker | minikube's driver + image build | Docker Desktop |
+| minikube | the local cluster | `brew install minikube` |
+| kubectl | talk to the cluster | `brew install kubectl` |
+| helm | install the charts | `brew install helm` |
+
+Give Docker Desktop enough headroom (Settings → Resources): the `make local`
+target starts minikube with `--cpus=4 --memory=6g`, so allocate at least that
+to Docker. The workspace image is large (~2–3 GB) because it bundles
+code-server, Claude Code, OpenCode, Ante, LibreFang, ttyd, and a full toolchain.
+
+> **Apple Silicon (M-series):** the build targets your host architecture
+> automatically (`linux/arm64`), so it runs natively with no emulation. Every
+> bundled binary (code-server, ttyd, LibreFang, …) has an arm64 build, so this
+> is a first-class path, not a fallback.
+
+---
+
+## Quick start
+
+```bash
+# One command: start the cluster, build + load the image, deploy, print access info.
+make local
+```
+
+That runs, in order: [`local-up`](#step-1-local-up) → [`local-build`](#step-2-local-build)
+→ [`local-secret`](#step-3-local-secret) → [`local-deploy`](#step-4-local-deploy)
+→ `local-info`. The first run takes a while (image build + load); later runs are cached.
+
+When it finishes, `local-info` prints the three steps to reach the dashboard:
+
+```bash
+# 1. Map the hostname to localhost (one time, needs sudo):
+echo '127.0.0.1  kube-coder.local' | sudo tee -a /etc/hosts
+
+# 2. Forward the ingress controller (keep this running in its own terminal):
+make local-forward
+
+# 3. Open the dashboard and log in with basic auth admin / admin:
+open http://kube-coder.local:8080/
+```
+
+That's it — you're in the kube-coder dashboard running entirely on your laptop.
+
+> **Why port-forward instead of the minikube IP?** With the Docker driver on
+> macOS and Windows, the minikube node IP isn't routable from the host. A
+> `kubectl port-forward` to the ingress controller works identically on every
+> OS, and routing still goes *through* the ingress (so host-based routing and
+> basic auth behave exactly like production). On Linux you can instead point
+> `/etc/hosts` at `$(minikube ip -p kube-coder)` and skip the port-forward.
+
+---
+
+## What each step does
+
+You can run the steps individually (e.g. to rebuild after a code change).
+
+### Step 1 — `local-up`
+Starts the minikube profile `kube-coder` with the Docker driver and enables the
+`ingress` addon (installs `ingress-nginx`), then waits for the controller pod.
+
+### Step 2 — `local-build`
+Builds the workspace image for your host arch (`docker buildx ... --load`) as
+`kube-coder:local`, then `minikube image load`s it into the cluster. No registry
+involved. Re-run this after editing the `Dockerfile` or anything baked into the
+image (the dashboard SPA, installed CLIs).
+
+### Step 3 — `local-secret`
+Creates the `coder` namespace and a `kube-coder-basic-auth` Secret containing an
+htpasswd entry for **admin / admin** (generated with `openssl passwd -apr1`).
+The ingress references this Secret for HTTP basic auth. Change the credentials
+by overriding `LOCAL_AUTH_USER` / `LOCAL_AUTH_PASS`:
+
+```bash
+make local-secret LOCAL_AUTH_USER=me LOCAL_AUTH_PASS=hunter2
+```
+
+### Step 4 — `local-deploy`
+Installs the `base-infrastructure` chart (the `kaniko-wrapper` ConfigMap the
+workspace pod mounts) and then the `workspace` chart using
+[`deployments/local/values.yaml`](../deployments/local/values.yaml), and waits
+for the `ws-local` rollout.
+
+---
+
+## Configuration
+
+The local overlay lives at [`deployments/local/values.yaml`](../deployments/local/values.yaml)
+and is safe to commit (no secrets). The local-specific choices:
+
+| Setting | Local value | vs. cloud default |
+|---------|-------------|-------------------|
+| `image.repository` / `tag` | `kube-coder:local` | DO registry image |
+| `image.pullPolicy` | `IfNotPresent` | `Always` |
+| `image.pullSecretName` | _empty_ | `regcred` |
+| `ingress.tls.enabled` | `false` | `true` (cert-manager + Let's Encrypt) |
+| `ingress.auth.type` | `basic` | `oauth2` / `basic` |
+| `user.host` | `kube-coder.local` | a real DNS name |
+| `user.pvcSize` | `10Gi` | `50Gi` |
+| `resources` | smaller | full |
+
+### Adding your Claude / assistant keys
+
+The workspace boots without any AI keys — you can log into Claude Code
+interactively by running `claude` once in the pod terminal. To bake keys in,
+drop a gitignored overlay at `secrets/local/keys.yaml`:
+
+```yaml
+claude:
+  apiKey: "sk-ant-..."        # optional; or log in interactively instead
+assistant:
+  openrouter:
+    apiKey: "sk-or-..."
+```
+
+…and add `-f secrets/local/keys.yaml` to the `local-deploy` helm command (or
+re-run `helm upgrade` yourself). See [environment-variables.md](environment-variables.md)
+and [llm-setup.md](llm-setup.md).
+
+---
+
+## Day-to-day
+
+```bash
+make local-info                     # reprint access details
+make local-forward                  # (re)start the ingress port-forward
+make local-build && make local-deploy   # rebuild image + redeploy after changes
+
+# Direct cluster access (note: --context kube-coder, never your remote cluster)
+kubectl --context kube-coder -n coder get pods
+kubectl --context kube-coder -n coder logs -f deploy/ws-local -c ide
+kubectl --context kube-coder -n coder exec -it deploy/ws-local -c ide -- bash
+```
+
+### Teardown
+
+```bash
+make local-down              # remove the kube-coder workspace, keep the cluster
+make local-down DELETE=1     # also delete the minikube profile entirely
+```
+
+---
+
+## Limitations of local mode
+
+- **In-workspace image builds are disabled.** The `docker-build` helper uses
+  Kaniko, which needs a registry to push to; the local overlay leaves the push
+  target empty. kube-coder itself runs fine — you just can't build *and push*
+  container images from inside a workspace. To enable it, run
+  `minikube addons enable registry` and point `build.pushSecretName` /
+  `build.defaultDestinationRepo` at it.
+- **Single node, single workspace.** The local overlay provisions one workspace
+  (`local`). The cloud per-user flow (`make new-user`, `make deploy USER=…`) is
+  for multi-tenant clusters.
+- **No TLS.** Local mode serves plain HTTP. That's fine on localhost; don't
+  expose it.
+- **Resources.** Defaults are laptop-sized; heavy builds/tests inside the
+  workspace may want a bigger `minikube start --memory`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `ErrImageNeverPull` / `ImagePullBackOff` on `ws-local` | The image wasn't loaded. Re-run `make local-build` (it both builds and `minikube image load`s). |
+| `http://kube-coder.local:8080` won't resolve | Add the `/etc/hosts` line (`127.0.0.1 kube-coder.local`) and make sure `make local-forward` is running. |
+| 401 / auth prompt loops | Credentials are `admin` / `admin` (or whatever you set via `LOCAL_AUTH_*`). Re-run `make local-secret` if you changed them. |
+| Pod stuck `ContainerCreating` | Usually the PVC or the `kaniko-wrapper` ConfigMap — confirm `make local-deploy` installed `base-infrastructure`. |
+| minikube won't start / OOMs | Raise Docker Desktop's memory, or lower it: `make local-up` then `minikube start -p kube-coder --memory=4g`. |
+
+---
+
+## Other local clusters
+
+The chart is cluster-agnostic; only the `make local-*` wrappers assume minikube.
+To use a different tool, replicate the four steps against it:
+
+- **kind:** create the cluster, install `ingress-nginx`
+  (`kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml`),
+  load the image with `kind load docker-image kube-coder:local`, then
+  `helm upgrade --install` with `deployments/local/values.yaml`.
+- **k3d:** `k3d cluster create --k3s-arg "--disable=traefik@server:0"`, install
+  `ingress-nginx`, push to the built-in `k3d` registry (or import the image),
+  then deploy the same overlay.
+
+The `deployments/local/values.yaml` overlay works unchanged on any of them.


### PR DESCRIPTION
## What

A first-class **local development** path: run kube-coder on a local single-node cluster (minikube) with **no cloud account, registry, DNS, or TLS** — verified working end-to-end (dashboard, builds, terminal, VS Code).

```bash
make local          # start minikube, build the image inside it, deploy, print access info
echo '127.0.0.1  kube-coder.local' | sudo tee -a /etc/hosts
make local-forward   # port-forward ingress -> localhost:8080 (keep running)
# open http://kube-coder.local:8080/   →   basic auth: admin / admin
```

## Deliverables

- **`deployments/local/values.yaml`** — committable overlay: local image (`IfNotPresent`, no pull secret), TLS off, http basic auth, laptop-sized resources.
- **Makefile `Local development` section** — `make local` one-shots `local-up → local-build → local-secret → local-deploy → local-info`; plus `local-forward` / `local-down`. Every call is pinned to the **minikube context**, so it can never touch a remote cluster. The image builds **inside minikube** (`minikube image build`) — native arm64 on Apple Silicon, and it sidesteps the Docker-Desktop buildx CLI hang.
- **Docs** — `docs/local-development.md` (prereqs, quickstart, per-step breakdown, config, limitations, troubleshooting, kind/k3d notes) + a two-path README Quick Start (Local vs Cloud).

## Bugs found by actually running it (and fixed)

The charts/SPA deeply assumed the oauth2 cloud path; running on bare minikube surfaced real, previously-hidden bugs:

1. **Helm release > 1 MB** — a `web/coverage/` dir (from a test run) got bundled into the chart. Added it to `.helmignore`.
2. **`force-ssl-redirect` hardcoded** → local HTTP 308'd to a nonexistent HTTPS listener. Now gated on `ingress.tls.enabled`.
3. **buildx CLI hang** on Docker Desktop after writing the image → wedged `make`. Switched `local-build` to build inside the node.
4. **basic-auth API 401s** — `check_claude_auth` only accepted oauth2 headers / Bearer tokens, so under basic auth the SPA loaded but every `/api/*` 401'd. ingress-nginx strips the credential header *and its webhook blocks re-forwarding*, so basic auth is necessarily edge-auth: server.py now trusts `AUTH_MODE=basic` (the ingress is the authenticator). Documented + multi-tenant caveat.
5. **terminal 404 / black-screen build terminal** — the SPA hardcoded the `/oauth/` prefix for terminal/VS Code/VNC/metrics/app-proxy. Added `authPrefix()` (derived from where the SPA was served) so those target the right ingress; `/oauth` behind oauth2, empty under basic auth.

## Prod (oauth2) is unaffected

Every shared-code change is gated so cloud behavior is byte-identical:
- server.py only **adds** a `basic`-mode branch; oauth2/none/Bearer paths untouched.
- `force-ssl-redirect` gated on `tls.enabled` → prod (TLS on) keeps it (render: ×2 + cert-manager ×16, `AUTH_MODE=oauth2`).
- `authPrefix()` returns `/oauth` whenever the SPA is served under `/oauth` → identical to the old hardcoded behavior in prod.

## Verification

- **Python:** 181 tests OK (added an edge-auth contract test; updated 3 auth suites to assert server.py enforcement under oauth2 — their actual intent).
- **SPA:** tsc clean, 98 vitest pass (added prefix-aware coverage).
- **Helm:** lint + template clean for local *and* oauth2/test-values.
- **Live on minikube:** `make local` build (hang-free) → deploy → `/` 200, `/api/*` 200 with `admin/admin` (401 without), `/terminal/` 200, **WebSocket 101**, builds run, VS Code opens.

## Limitations (documented)

- In-workspace image builds (Kaniko) disabled in local mode (no registry to push to).
- Single node / single workspace; plain HTTP (localhost only).
- Apple Silicon: the noVNC **Desktop** tab won't render (bundled Firefox is x86_64); everything else works. Click **Build**/Tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)