### PR TITLE
fix(spa): derive auth prefix from server-injected AUTH_MODE (oauth2 hotfix)

### DIFF
--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -3127,6 +3127,19 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         except OSError as exc:
             self.send_error(500, f'Read error: {exc}')
             return
+        # Tell the SPA which ingress auth prefix to use for API and embedded-
+        # service (terminal/vscode/vnc/metrics) URLs. In oauth2 mode only the
+        # /oauth/* ingress paths inject the x-auth-request-user header; the bare
+        # /api/* paths don't, so the SPA must call /oauth/api/*. The SPA is
+        # served at '/' in EVERY mode, so it can't infer this from the URL —
+        # AUTH_MODE here is the source of truth. client.ts authPrefix() reads
+        # window.__KC_AUTH_PREFIX__ ('/oauth' for oauth2, '' for basic/none).
+        if rel == 'index.html':
+            spa_prefix = '/oauth' if AUTH_MODE == 'oauth2' else ''
+            inject = ('<script>window.__KC_AUTH_PREFIX__=%s;</script>'
+                      % json.dumps(spa_prefix)).encode('utf-8')
+            body = (body.replace(b'</head>', inject + b'</head>', 1)
+                    if b'</head>' in body else inject + body)
         self.send_response(200)
         self.send_header('Content-Type', ctype)
         self.send_header('Content-Length', str(len(body)))

--- a/charts/workspace/web/src/api/client.test.ts
+++ b/charts/workspace/web/src/api/client.test.ts
@@ -62,8 +62,8 @@ describe('api client', () => {
     expect((calledInit?.headers as Record<string, string>)['Content-Type']).toBe('application/json');
   });
 
-  it('prepends /oauth to /api/* paths when served under the oauth2 ingress', async () => {
-    window.history.replaceState({}, '', '/oauth/tasks');
+  it('prepends /oauth to /api/* paths when the server injects the oauth2 prefix', async () => {
+    (window as { __KC_AUTH_PREFIX__?: string }).__KC_AUTH_PREFIX__ = '/oauth';
     let url = '';
     globalThis.fetch = vi.fn(async (u: string) => {
       url = u;
@@ -76,20 +76,21 @@ describe('api client', () => {
     }) as unknown as typeof fetch;
     await apiGet('/api/claude/tasks');
     expect(url).toBe('/oauth/api/claude/tasks');
-    window.history.replaceState({}, '', '/');
+    delete (window as { __KC_AUTH_PREFIX__?: string }).__KC_AUTH_PREFIX__;
   });
 
-  it('withOauthPrefix follows the served prefix (/oauth behind oauth2, none under basic auth)', () => {
-    // Behind the oauth2 ingress (URL under /oauth): prefix is added.
-    window.history.replaceState({}, '', '/oauth/tasks');
+  it('withOauthPrefix follows the server-injected prefix (/oauth for oauth2, none for basic auth)', () => {
+    // oauth2 deployment: server injects '/oauth' — prefix is added.
+    (window as { __KC_AUTH_PREFIX__?: string }).__KC_AUTH_PREFIX__ = '/oauth';
     expect(withOauthPrefix('/api/foo')).toBe('/oauth/api/foo');
     expect(withOauthPrefix('/oauth/api/foo')).toBe('/oauth/api/foo');
-    // Root / basic-auth deployment: no /oauth route, so no prefix.
-    window.history.replaceState({}, '', '/');
+    // basic-auth deployment: server injects '' — no prefix.
+    (window as { __KC_AUTH_PREFIX__?: string }).__KC_AUTH_PREFIX__ = '';
     expect(withOauthPrefix('/api/foo')).toBe('/api/foo');
     // Non-/api paths and absolute URLs are untouched in both modes.
     expect(withOauthPrefix('/health')).toBe('/health');
     expect(withOauthPrefix('https://example.com/api/x')).toBe('https://example.com/api/x');
+    delete (window as { __KC_AUTH_PREFIX__?: string }).__KC_AUTH_PREFIX__;
   });
 
   it('throws ApiError with status + body on non-2xx', async () => {

--- a/charts/workspace/web/src/api/client.ts
+++ b/charts/workspace/web/src/api/client.ts
@@ -60,8 +60,18 @@ function devToken(): string | null {
  * auth.
  */
 export function authPrefix(): string {
-  if (typeof window === 'undefined') return '';
-  return window.location.pathname.startsWith('/oauth') ? '/oauth' : '';
+  // server.py injects window.__KC_AUTH_PREFIX__ into the served index.html from
+  // the deployment's AUTH_MODE: '/oauth' behind the oauth2 ingress (only
+  // /oauth/* paths get the auth header injected), '' for a root/basic-auth
+  // deployment. The SPA is served at '/' in BOTH modes, so the URL can't tell
+  // them apart — the server is the source of truth. Default to '/oauth' (the
+  // production deployment) when the injection is absent so a stray build never
+  // silently drops the prefix and 401s every API call.
+  if (typeof window !== 'undefined') {
+    const inj = (window as { __KC_AUTH_PREFIX__?: unknown }).__KC_AUTH_PREFIX__;
+    if (typeof inj === 'string') return inj;
+  }
+  return '/oauth';
 }
 
 /**


### PR DESCRIPTION
## 🔥 Hotfix — oauth2 dashboards 401 after #56

**Impact:** every **oauth2** workspace redeployed with a post-#56 image — the SPA loads but every `/api/*` call returns 401, so the dashboard can't fetch any data (terminal/builds/etc. unusable). Basic-auth/local is unaffected. (Caught on demo-ws; older images like imran-ws aren't affected until redeployed.)

## Root cause

#56 made `authPrefix()` infer the ingress auth prefix from `window.location.pathname` (`/oauth` if the URL was under `/oauth`, else `''`). But the SPA is served at the **root `/` in both oauth2 and basic deployments** — so in oauth2 it returned `''` and the SPA called `/api/*` at the root.

In the oauth2 ingress, only **`/oauth/(api/.*)`** carries the auth annotations that inject the `x-auth-request-user` header (the bare `/` ingress has none). Confirmed live on demo:

| Path | Result |
|---|---|
| `https://demo.dev.scalebase.io/api/memory` | **404** (what the broken SPA called) |
| `https://demo.dev.scalebase.io/oauth/api/memory` | **302 → oauth login** (header-injecting path the SPA should call) |

So the URL can't distinguish the modes — both serve the SPA at `/`. The real differentiator is the deployment's `AUTH_MODE`, which only the server knows.

## Fix

- **`server.py`** injects `window.__KC_AUTH_PREFIX__` into the served `index.html` from `AUTH_MODE` — `'/oauth'` for oauth2, `''` for basic/none.
- **`client.ts` `authPrefix()`** reads that injected value, defaulting to `'/oauth'` if it's absent so a stray build can't silently drop the prefix and 401 prod.
- Keeps the terminal/vscode/vnc/metrics prefix-aware fixes working in **both** modes (they all route through `authPrefix()`).

## Verification

- Server injection renders `window.__KC_AUTH_PREFIX__="/oauth"` (oauth2) and `=""` (basic), confirmed by booting server.py in each mode.
- SPA build (tsc clean) + **104 vitest** + **181 python** tests pass; `client.test.ts` updated to drive the injected global.
- Being deployed to **demo-ws** for live oauth2 validation as this PR opens.

## Note
`server.py` ships via ConfigMap (fast) and the SPA via the image (rebuild). Existing oauth2 workspaces on the old image keep working; redeploying any of them now picks up this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)