### PR TITLE
fix(dashboard): make tmux scroll mode work with touch on mobile

### DIFF
--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -3725,8 +3725,19 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             self.send_json({'error': 'Invalid JSON body'}, 400)
             return
         action = (data.get('action') or '').strip().lower()
-        if action not in ('enter', 'exit'):
-            self.send_json({'error': "action must be 'enter' or 'exit'"}, 400)
+        # enter/exit toggle copy-mode. The scroll directions drive copy-mode
+        # navigation server-side so touch clients (mobile sends no wheel events,
+        # so xterm's wheel->arrow conversion inside the ttyd iframe never fires)
+        # can scroll the scrollback by POSTing here instead.
+        SCROLL_CMDS = {
+            'up': 'scroll-up', 'down': 'scroll-down',
+            'page-up': 'page-up', 'page-down': 'page-down',
+        }
+        if action not in ('enter', 'exit') and action not in SCROLL_CMDS:
+            self.send_json(
+                {'error': "action must be 'enter', 'exit', or a scroll direction"},
+                400,
+            )
             return
         task_id = self._claude_task_id
         task = ClaudeTaskManager.get_task(task_id)
@@ -3736,8 +3747,18 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         session_name = task.get('tmux_session', f'kube-coder-{task_id}')
         if action == 'enter':
             cmd = ['tmux', 'copy-mode', '-t', session_name]
-        else:
+        elif action == 'exit':
             cmd = ['tmux', 'send-keys', '-t', session_name, '-X', 'cancel']
+        else:
+            # Repeat the copy-mode motion `lines` times so one touch gesture can
+            # scroll several lines. Clamp so a fling can't send a runaway count.
+            try:
+                lines = int(data.get('lines') or 1)
+            except (TypeError, ValueError):
+                lines = 1
+            lines = max(1, min(lines, 40))
+            cmd = ['tmux', 'send-keys', '-t', session_name,
+                   '-X', '-N', str(lines), SCROLL_CMDS[action]]
         result = subprocess.run(cmd, capture_output=True, text=True)
         if result.returncode != 0:
             self.send_json({

--- a/charts/workspace/tests/scroll_mode_test.py
+++ b/charts/workspace/tests/scroll_mode_test.py
@@ -1,0 +1,107 @@
+"""Scroll-mode endpoint: copy-mode toggle + touch scroll directions.
+
+The scroll directions back the mobile scroll overlay (TerminalPane.tsx): touch
+emits no wheel events, so the ttyd iframe never scrolls in copy-mode and the
+overlay POSTs a direction here, which we translate to a tmux copy-mode motion.
+
+Run with:
+    cd charts/workspace && python3 -m unittest tests.scroll_mode_test
+"""
+
+import http.server
+import json
+import os
+import sys
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+import server  # noqa: E402
+
+
+def _free_port():
+    import socket
+    s = socket.socket()
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _post(url, body):
+    req = urllib.request.Request(url, data=json.dumps(body).encode(), method='POST')
+    req.add_header('Content-Type', 'application/json')
+    return urllib.request.urlopen(req, timeout=5)
+
+
+class ScrollModeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.port = _free_port()
+        cls.httpd = http.server.ThreadingHTTPServer(
+            ('127.0.0.1', cls.port), server.BrowserHandler,
+        )
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+
+    def _call(self, body):
+        """POST the body and return (status, the tmux argv that was run)."""
+        captured = {}
+
+        def fake_run(cmd, *a, **k):
+            captured['cmd'] = cmd
+            return mock.Mock(returncode=0, stdout='', stderr='')
+
+        with mock.patch('server.subprocess.run', side_effect=fake_run), \
+             mock.patch.object(server.ClaudeTaskManager, 'get_task',
+                               return_value={'tmux_session': 'sess-T'}):
+            with _post(f'http://127.0.0.1:{self.port}/api/claude/tasks/T/scroll-mode',
+                       body) as r:
+                return r.status, captured.get('cmd')
+
+    def test_enter_uses_copy_mode(self):
+        st, cmd = self._call({'action': 'enter'})
+        self.assertEqual(st, 200)
+        self.assertEqual(cmd, ['tmux', 'copy-mode', '-t', 'sess-T'])
+
+    def test_exit_cancels_copy_mode(self):
+        st, cmd = self._call({'action': 'exit'})
+        self.assertEqual(st, 200)
+        self.assertEqual(cmd, ['tmux', 'send-keys', '-t', 'sess-T', '-X', 'cancel'])
+
+    def test_scroll_up_sends_copy_mode_motion_with_count(self):
+        st, cmd = self._call({'action': 'up', 'lines': 3})
+        self.assertEqual(st, 200)
+        self.assertEqual(
+            cmd, ['tmux', 'send-keys', '-t', 'sess-T', '-X', '-N', '3', 'scroll-up'])
+
+    def test_scroll_down_defaults_to_one_line(self):
+        st, cmd = self._call({'action': 'down'})
+        self.assertEqual(st, 200)
+        self.assertEqual(
+            cmd, ['tmux', 'send-keys', '-t', 'sess-T', '-X', '-N', '1', 'scroll-down'])
+
+    def test_line_count_is_clamped(self):
+        _, cmd = self._call({'action': 'up', 'lines': 9999})
+        self.assertEqual(cmd[-2:], ['40', 'scroll-up'])
+
+    def test_invalid_action_rejected(self):
+        try:
+            with _post(f'http://127.0.0.1:{self.port}/api/claude/tasks/T/scroll-mode',
+                       {'action': 'sideways'}) as r:
+                self.fail(f'expected 400, got {r.status}')
+        except urllib.error.HTTPError as e:
+            self.assertEqual(e.code, 400)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/web/src/api/tasks.ts
+++ b/charts/workspace/web/src/api/tasks.ts
@@ -132,6 +132,21 @@ export const setScrollMode = (id: string, action: 'enter' | 'exit') =>
     { action },
   );
 
+// Drive copy-mode scrolling server-side. Touch clients (mobile) emit no wheel
+// events, so xterm's wheel->arrow conversion inside the ttyd iframe never
+// fires; instead the mobile scroll overlay POSTs a direction here. Requires
+// scroll mode (copy-mode) to already be active. `lines` scrolls multiple lines
+// per gesture.
+export const scrollTerminal = (
+  id: string,
+  direction: 'up' | 'down' | 'page-up' | 'page-down',
+  lines = 1,
+) =>
+  apiPost<{ ok: true }>(`/api/claude/tasks/${id}/scroll-mode`, {
+    action: direction,
+    lines,
+  });
+
 /** Absolute URL for the ttyd iframe; cache-busts on each open. Uses the
  *  deployment's auth prefix (empty under basic auth, /oauth behind oauth2). */
 export const terminalUrl = () => `${authPrefix()}/terminal/?t=${Date.now()}`;

--- a/charts/workspace/web/src/routes/tasks/TerminalPane.tsx
+++ b/charts/workspace/web/src/routes/tasks/TerminalPane.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
-import { prepareTerminal, terminalUrl, vncUrl, openLocalhostPort, getTaskOutput } from '../../api/tasks';
+import { prepareTerminal, terminalUrl, vncUrl, openLocalhostPort, getTaskOutput, scrollTerminal } from '../../api/tasks';
 import { proxyUrl } from '../../api/apps';
 import { isErrorResponse } from '../../api/client';
 import { Button } from '../../components/primitives/Button';
@@ -106,6 +106,36 @@ export function TerminalPane({ taskId, withVnc = false }: TerminalPaneProps) {
   // on what they came to see. Desktop keeps the split.
   const isMobile = useIsMobile();
   const [mobilePane, setMobilePane] = useState<'session' | 'preview'>('preview');
+
+  // Mobile scroll: in scroll mode (tmux copy-mode) touch can't wheel-scroll the
+  // ttyd iframe — mobile emits no wheel events, so xterm's wheel->arrow
+  // conversion never fires. A transparent overlay (rendered only in scroll mode)
+  // captures finger drags here and drives copy-mode server-side. Drag is
+  // accumulated and flushed throttled so we don't POST per pixel.
+  const scrollMode = sessionSignals.scrollMode.value;
+  const scrollTouch = useRef({ lastY: 0, accum: 0, lastSent: 0 });
+  const SCROLL_LINE_PX = 16; // px of finger travel per scrolled line
+  const SCROLL_SEND_MS = 70; // min gap between scroll POSTs
+  const onScrollTouchStart = (e: TouchEvent) => {
+    scrollTouch.current.lastY = e.touches[0]?.clientY ?? 0;
+    scrollTouch.current.accum = 0;
+  };
+  const onScrollTouchMove = (e: TouchEvent) => {
+    if (!e.touches[0]) return;
+    e.preventDefault(); // we own the gesture; don't let the page scroll/zoom
+    const st = scrollTouch.current;
+    const y = e.touches[0].clientY;
+    st.accum += y - st.lastY; // finger down (+) reveals older history => scroll up
+    st.lastY = y;
+    const now = Date.now();
+    if (now - st.lastSent < SCROLL_SEND_MS) return;
+    const lines = Math.trunc(st.accum / SCROLL_LINE_PX);
+    if (lines === 0) return;
+    st.accum -= lines * SCROLL_LINE_PX;
+    st.lastSent = now;
+    scrollTerminal(taskId, lines > 0 ? 'up' : 'down', Math.min(Math.abs(lines), 40))
+      .catch(() => { /* transient — the next gesture retries */ });
+  };
 
   // Persist the preview-source choice per workspace.
   useEffect(() => {
@@ -475,6 +505,20 @@ export function TerminalPane({ taskId, withVnc = false }: TerminalPaneProps) {
               title="Task terminal"
               allow="clipboard-read; clipboard-write"
             />
+          )}
+          {/* Mobile + scroll mode: a transparent overlay turns finger drags into
+              tmux copy-mode scrolling (the ttyd iframe ignores touch). Only
+              present in scroll mode, so normal taps/typing reach the terminal
+              the rest of the time. */}
+          {termSrc && isMobile && scrollMode && (!withVnc || mobilePane === 'session') && (
+            <div
+              class="term-pane-scroll-overlay"
+              onTouchStart={onScrollTouchStart}
+              onTouchMove={onScrollTouchMove}
+              aria-hidden="true"
+            >
+              <span class="term-pane-scroll-hint">Drag to scroll · Exit scroll mode to type</span>
+            </div>
           )}
           {withVnc && showApp && (
             <iframe

--- a/charts/workspace/web/src/routes/tasks/detail.css
+++ b/charts/workspace/web/src/routes/tasks/detail.css
@@ -361,6 +361,29 @@
   display: flex;
   min-height: 0;
   background: #000;
+  position: relative; /* positioning context for the mobile scroll overlay */
+}
+/* Mobile scroll-mode overlay: transparent capture layer over the ttyd iframe
+   that turns finger drags into tmux copy-mode scrolling (see TerminalPane). */
+.term-pane-scroll-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  touch-action: none; /* we handle the drag; suppress native page scroll/zoom */
+  background: transparent;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+.term-pane-scroll-hint {
+  margin-top: 8px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.6);
+  pointer-events: none;
+  user-select: none;
 }
 .term-pane-frames-split {
   display: grid;


### PR DESCRIPTION
## Problem

"Scroll mode" puts tmux into copy-mode server-side, then the user scrolls the ttyd iframe with the **mouse wheel** (xterm converts wheel→arrows into copy-mode). **Mobile emits no wheel events**, so touch never scrolled — scroll mode was effectively desktop-only.

## Fix

- **server.py** — the `/scroll-mode` endpoint now accepts scroll directions (`up`/`down`/`page-up`/`page-down`, with a clamped `lines` count) and drives copy-mode server-side via `tmux send-keys -X scroll-up/down`, alongside the existing `enter`/`exit` toggle.
- **TerminalPane.tsx** — while scroll mode is active **on mobile**, a transparent overlay over the terminal captures finger drags and translates them into those scroll calls (drag accumulated + throttled so we don't POST per pixel). The overlay only exists in scroll mode, so normal taps/typing reach the terminal otherwise. Drag down = older history, drag up = toward the prompt.
- **tasks.ts** — `scrollTerminal(id, direction, lines)` helper.
- **scroll_mode_test.py** — covers the copy-mode commands (enter/exit/up/down), the repeat count, line clamping, and invalid-action rejection.

## Verification

- Verified live on a phone (imran-ws): scroll mode + finger drag scrolls the tmux scrollback.
- SPA build (tsc clean) + 113 vitest + 187 python tests pass.

Desktop behavior is unchanged (overlay is mobile-only; wheel scrolling still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)