### PR TITLE
chore(imran): pin workspace to shared devlaptop-v1.0.0 image tag

### DIFF
--- a/deployments/imran/values.yaml
+++ b/deployments/imran/values.yaml
@@ -12,7 +12,7 @@ user:
 
 image:
   repository: registry.digitalocean.com/resourceloop/coder
-  tag: devlaptop-v1.13.0-ante-persist
+  tag: devlaptop-v1.0.0
   pullPolicy: Always
   pullSecretName: regcred
 


### PR DESCRIPTION
Pins imran-workspace to the canonical `devlaptop-v1.0.0` image tag (was `devlaptop-v1.13.0-ante-persist`), part of consolidating all workspaces onto one shared image instead of divergent per-feature tags. imran is already running this image in the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)