### PR TITLE
Unify on the GitOps config store + controller render parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ secrets/
 # of git. See docs/NEW_USER_PROVISIONING.md → "Private workspaces".
 users-private/
 
+# Local checkout of the GitOps workspace-config repo (provision.gitops.repo),
+# synced via `make users-sync`. The single source of truth for provisioned
+# workspaces; `make deploy/ship USER=<u>` resolves config from here too.
+.users/
+
 # Ad-hoc patches / diffs produced by `git format-patch` or `git diff` for
 # local review. These shouldn't be committed; the canonical change-history
 # lives in `git log`.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile for kube-coder
-.PHONY: build push deploy-base deploy-all clean help status version deploy logs shell test rollback delete-user new-user validate-user require-user release dashboard-web dashboard-web-install dashboard-web-test dashboard-web-clean python-tests python-coverage dashboard-web-coverage coverage test-coverage local local-up local-build local-secret local-deploy local-forward local-info local-down
+.PHONY: build push deploy-base deploy-all clean help status version deploy logs shell test rollback delete-user new-user validate-user require-user release users-sync dashboard-web dashboard-web-install dashboard-web-test dashboard-web-clean python-tests python-coverage dashboard-web-coverage coverage test-coverage local local-up local-build local-secret local-deploy local-forward local-info local-down
 
 # =============================================================================
 # Generic per-user helpers
@@ -17,9 +17,14 @@
 #   make test     USER=chase
 #   make rollback USER=chase
 
-user_dir = $(firstword $(wildcard ./deployments/$(1) ./users-private/$(1)))
+# Resolve a user's config across roots, first match wins: legacy ./deployments,
+# this repo's ./users-private, then ./.users (a checkout of the GitOps repo via
+# `make users-sync`). The GitOps checkout is the unifying store — once a user is
+# migrated there and removed from ./users-private, the same `make` targets keep
+# working against the synced copy.
+user_dir = $(firstword $(wildcard ./deployments/$(1) ./users-private/$(1) ./.users/users-private/$(1)))
 values_file = $(call user_dir,$(1))/values.yaml
-secrets_dir = $(firstword $(wildcard ./secrets/$(1) ./users-private/$(1)/secrets))
+secrets_dir = $(firstword $(wildcard ./secrets/$(1) ./users-private/$(1)/secrets ./.users/users-private/$(1)/secrets))
 # Build a `-f path` arg for every *.yaml inside the resolved secrets dir.
 secret_flags = $(foreach f,$(wildcard $(call secrets_dir,$(1))/*.yaml),-f $(f))
 
@@ -141,11 +146,32 @@ version: ## Show current versions and config
 require-user:
 	@if [ -z "$(USER)" ]; then echo "ERROR: pass USER=<name> (e.g. make deploy USER=chase)"; exit 1; fi
 	@if [ -z "$(call user_dir,$(USER))" ]; then \
-	  echo "ERROR: no values.yaml for '$(USER)' under deployments/ or users-private/"; exit 1; fi
+	  echo "ERROR: no values.yaml for '$(USER)' under deployments/, users-private/, or .users/ (run 'make users-sync' to fetch GitOps config)"; exit 1; fi
 
 new-user: ## Scaffold a private workspace (USER=<name>); generates values.yaml + cookieSecret + checklist
 	@if [ -z "$(USER)" ]; then echo "ERROR: pass USER=<name> (e.g. make new-user USER=chase)"; exit 1; fi
 	@./scripts/new-user.sh $(USER)
+
+# GitOps workspace-config repo (host/path, no scheme) — the unifying store the
+# controller's provisioner also pushes to. Kept out of this public Makefile:
+# resolved from the gitignored controller values, or override with KC_USERS_REPO.
+USERS_DIR := .users
+USERS_REPO ?= $(KC_USERS_REPO)
+ifeq ($(USERS_REPO),)
+USERS_REPO := $(shell awk '/^[[:space:]]*gitops:/{f=1} f&&/repo:/{print $$2; exit}' users-private/_controller/values.yaml 2>/dev/null)
+endif
+
+users-sync: ## Clone/pull the GitOps workspace-config repo into .users/ (set KC_USERS_REPO or _controller provision.gitops.repo)
+	@if [ -z "$(USERS_REPO)" ]; then \
+	  echo "ERROR: GitOps repo unknown. Set KC_USERS_REPO=github.com/<org>/<repo>.git,"; \
+	  echo "       or provision.gitops.repo in users-private/_controller/values.yaml."; exit 1; fi
+	@if [ -d $(USERS_DIR)/.git ]; then \
+	  echo "Pulling latest workspace config into $(USERS_DIR)/ ..."; \
+	  git -C $(USERS_DIR) pull --ff-only; \
+	else \
+	  echo "Cloning $(USERS_REPO) into $(USERS_DIR)/ ..."; \
+	  git clone https://$(USERS_REPO) $(USERS_DIR); \
+	fi
 
 validate-user: ## Pre-deploy sanity check (USER=<name>); placeholders, DNS, cluster prereqs
 	@if [ -z "$(USER)" ]; then echo "ERROR: pass USER=<name> (e.g. make validate-user USER=chase)"; exit 1; fi

--- a/charts/workspace-controller/controller.py
+++ b/charts/workspace-controller/controller.py
@@ -1133,6 +1133,12 @@ PROVISIONER_SA = os.environ.get('PROVISIONER_SERVICE_ACCOUNT', 'workspace-provis
 PROVISIONER_PULL_SECRET = os.environ.get('PROVISIONER_PULL_SECRET', '').strip()
 # Tag the new workspace runs; the chart prefixes it with `devlaptop-`.
 WORKSPACE_IMAGE_TAG = os.environ.get('WORKSPACE_IMAGE_TAG', '').strip()
+# Shared cluster Secret names projected into each provisioned workspace so the
+# console path matches a hand-scaffolded one (scripts/user-template): the
+# self-serve-update token (update.selfServeSecretName) and the shared OpenRouter
+# key (assistant.openrouter.sharedSecretName). Blank => that feature stays off.
+WORKSPACE_SELF_SERVE_SECRET = os.environ.get('WORKSPACE_SELF_SERVE_SECRET', '').strip()
+WORKSPACE_ASSISTANT_SECRET = os.environ.get('WORKSPACE_ASSISTANT_SECRET', '').strip()
 GITHUB_API = 'https://api.github.com'
 GITHUB_TIMEOUT = int(os.environ.get('GITHUB_TIMEOUT', '15'))
 # GitHub login: alphanumeric or single hyphens, max 39. Lowercased it is always
@@ -1321,6 +1327,13 @@ ssh:
 
 claude:
   apiKey: ""
+
+assistant:
+  openrouter:
+    sharedSecretName: {json.dumps(WORKSPACE_ASSISTANT_SECRET)}
+
+update:
+  selfServeSecretName: {json.dumps(WORKSPACE_SELF_SERVE_SECRET)}
 
 github:
   app:

--- a/charts/workspace-controller/templates/deployment.yaml
+++ b/charts/workspace-controller/templates/deployment.yaml
@@ -118,6 +118,13 @@ spec:
           value: {{ .Values.controller.image.pullSecretName | quote }}
         - name: WORKSPACE_IMAGE_TAG
           value: {{ .Values.provision.workspaceImageTag | quote }}
+        # Shared cluster Secrets projected into each provisioned workspace so the
+        # console path matches a hand-scaffolded one (self-serve updates + shared
+        # OpenRouter). Blank => that feature stays off.
+        - name: WORKSPACE_SELF_SERVE_SECRET
+          value: {{ .Values.provision.workspaceSelfServeSecret | quote }}
+        - name: WORKSPACE_ASSISTANT_SECRET
+          value: {{ .Values.provision.workspaceAssistantSecret | quote }}
         {{- if .Values.provision.image }}
         - name: PROVISIONER_IMAGE
           value: {{ .Values.provision.image | quote }}

--- a/charts/workspace-controller/tests/controller_test.py
+++ b/charts/workspace-controller/tests/controller_test.py
@@ -222,6 +222,9 @@ class ProvisionPureLogicTest(unittest.TestCase):
         opts = {'login': 'Octo', 'slug': 'octo', 'host': 'octo.dev.scalebase.io',
                 'pvcSize': '30Gi', 'gitName': 'Octo Cat', 'gitEmail': 'octo@example.com',
                 'imageTag': 'v9.9.9'}
+        # Shared-secret projection (parity with the hand-scaffolded template).
+        controller.WORKSPACE_SELF_SERVE_SECRET = 'kc-self-serve'
+        controller.WORKSPACE_ASSISTANT_SECRET = 'coder-shared-assistant'
         text = controller.render_values_yaml(opts, 'Ov23liexampleclientid', 'cookiesecret32xxxxxxxxxxxxxxxxxxx')
         # Validate it parses as YAML and carries the access gate + host.
         try:
@@ -238,11 +241,16 @@ class ProvisionPureLogicTest(unittest.TestCase):
             # values.yaml carries only the placeholder; the real secret is
             # split out into secrets/oauth2.yaml (render_oauth_secret_yaml).
             self.assertEqual(doc['oauth2']['clientSecret'], 'OVERRIDE-IN-SECRETS-OAUTH2-YAML')
+            # Parity blocks: self-serve updates + shared OpenRouter projected in.
+            self.assertEqual(doc['update']['selfServeSecretName'], 'kc-self-serve')
+            self.assertEqual(doc['assistant']['openrouter']['sharedSecretName'], 'coder-shared-assistant')
         except ImportError:
             self.assertIn('name: octo', text)
             self.assertIn('host: octo.dev.scalebase.io', text)
             self.assertIn('githubUsers: "Octo"', text)
             self.assertIn('devlaptop-v9.9.9', text)
+            self.assertIn('selfServeSecretName: "kc-self-serve"', text)
+            self.assertIn('sharedSecretName: "coder-shared-assistant"', text)
 
     def test_oauth_secret_yaml_holds_only_secret(self):
         text = controller.render_oauth_secret_yaml('supersecret')

--- a/charts/workspace-controller/values.yaml
+++ b/charts/workspace-controller/values.yaml
@@ -138,3 +138,8 @@ provision:
 
   # Default tag new workspaces run; the chart prefixes it with `devlaptop-`.
   workspaceImageTag: ""
+
+  # Shared cluster Secret names projected into every provisioned workspace so the
+  # console path matches a hand-scaffolded one. Blank => that feature stays off.
+  workspaceSelfServeSecret: ""     # self-serve update token (== update.selfServeSecretName)
+  workspaceAssistantSecret: ""     # shared OpenRouter key (== assistant.openrouter.sharedSecretName)


### PR DESCRIPTION
## Why

Workspace config currently lives in **two** stores — this repo's `users-private/` (operator `make deploy`) and the separate `kube-coder-users` GitOps repo (controller self-service). That split is what made the recent OAuth incident need fixing in two places. This unifies the **store** without losing the local `make` path (chart-dev loop + break-glass).

Separately, the controller's `render_values_yaml` was silently dropping two config blocks, so console-provisioned workspaces (rohitbhatiavc, wwmullerjr-dotcom) lacked self-serve updates and shared OpenRouter.

## What changed

**Phase 0 — single source of truth, local make preserved**
- Makefile resolves a user's config across `./deployments`, `./users-private`, and a new `./.users` checkout of the GitOps repo. Once a user is migrated to GitOps and dropped from `users-private`, the same `make deploy/ship/shell` targets keep working against the synced copy.
- New `make users-sync` clones/pulls the GitOps repo into a gitignored `.users/`. Repo URL resolves from `KC_USERS_REPO` or the gitignored controller values (kept out of this public Makefile).

**Phase 1 — controller render parity**
- `render_values_yaml` now emits `assistant:` (shared OpenRouter) and `update:` (self-serve updates, #147), env-driven via `WORKSPACE_ASSISTANT_SECRET` / `WORKSPACE_SELF_SERVE_SECRET`. Wired through `deployment.yaml` + `values.yaml`. Console-provisioned workspaces are now byte-comparable to hand-scaffolded ones.

## Tests
- Controller Python suite green (49); render test asserts both new blocks.
- `helm template` renders the new env; `make users-sync` + resolver verified against the live GitOps repo (rohit/wwmuller resolve from `./.users/...`).

## Out of scope / follow-up (not in this PR)
- **Phase 2** — migrating the existing local users into the GitOps repo (imran's own workspace last), then dropping them from `users-private`. `_controller` stays local (bootstrap).
- Applying the parity backfill to the two live pods (a brief redeploy) — their GitOps config is already updated; held back per an explicit "don't roll live workspaces" boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)