### PR TITLE
Point CLI scaffolding + validation at the GitOps store

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,17 @@ make deploy-base                  # base-infrastructure helm release
 #### Onboard a User
 
 ```bash
-# Scaffold a private workspace under users-private/<name>/ — generates
-# values.yaml, mints an OAuth2 cookie secret, and prints a checklist of
-# the manual fields you still need to fill in (DNS host, GitHub App
-# creds, optional assistant keys). See docs/NEW_USER_PROVISIONING.md.
+# Workspace config lives in one place: the private GitOps repo
+# (provision.gitops.repo). Sync a local checkout into .users/ first.
+make users-sync
+
+# Scaffold a workspace into the GitOps checkout — generates values.yaml,
+# mints an OAuth2 cookie secret, and prints a checklist of the manual
+# fields you still need to fill in (DNS host, GitHub OAuth App creds,
+# optional assistant keys). See docs/NEW_USER_PROVISIONING.md.
 make new-user USER=<name>
-$EDITOR users-private/<name>/values.yaml
+$EDITOR .users/users-private/<name>/values.yaml
+git -C .users add -A && git -C .users commit -m "add <name>" && git -C .users push
 
 # Pre-deploy sanity check (DNS, image pull, base release)
 make validate-user USER=<name>

--- a/docs/NEW_USER_PROVISIONING.md
+++ b/docs/NEW_USER_PROVISIONING.md
@@ -7,15 +7,22 @@ This guide explains how to provision a new user workspace with OAuth2 authentica
 > deploying — via a one-click setup. See [PROVISIONING.md](PROVISIONING.md).
 > The manual flow here is still the source of truth and the fallback.
 
+> **Unified store.** All workspace config now lives in one private **GitOps
+> repo** (`provision.gitops.repo`). Run `make users-sync` once to clone it into
+> a gitignored `.users/`; the controller's self-service path pushes to the same
+> repo. `new-user.sh` scaffolds there, and per-user `make` targets resolve it
+> automatically — so the console and the CLI share a single source of truth.
+
 ## TL;DR — generic per-user commands
 
 Every per-user command takes `USER=<name>` and auto-resolves the values
-file + secrets from one of two locations:
+file + secrets from the first of these that matches:
 
 | Location | When to use it | Committed? |
 |---|---|---|
 | `deployments/<user>/` + `secrets/<user>/`     | Workspaces visible in the public repo (placeholders only; real secrets stay in `secrets/`, which is gitignored). | values committed, secrets gitignored |
-| `users-private/<user>/` + `users-private/<user>/secrets/` | Private workspaces — neither values nor secrets are tracked. The whole `users-private/` tree is gitignored. | not committed |
+| `users-private/<user>/` + `users-private/<user>/secrets/` | Legacy in-repo private workspaces + the `_controller` bootstrap config. Gitignored. | not committed |
+| `.users/users-private/<user>/` | The GitOps store (`make users-sync`) — the canonical home for every provisioned workspace. Gitignored checkout. | in the GitOps repo |
 
 ```bash
 make deploy   USER=chase    # helm upgrade --install (auto-includes secrets)
@@ -34,19 +41,20 @@ sanitized examples live in `deployments/example-user/` (OAuth2) and
 Three commands provision a new private workspace end-to-end:
 
 ```bash
-make new-user      USER=<name>     # scaffold users-private/<name>/{values.yaml,secrets/oauth2.yaml}
+make users-sync                    # clone/pull the GitOps store into .users/
+make new-user      USER=<name>     # scaffold .users/users-private/<name>/{values.yaml,secrets/oauth2.yaml}
                                    # + generates a fresh cookieSecret
                                    # + prints a setup checklist (OAuth app URLs, fields to edit)
 # … now edit the "CHANGE ME" lines and drop your OAuth client_secret
-#   into users-private/<name>/secrets/oauth2.yaml.
+#   into .users/users-private/<name>/secrets/oauth2.yaml, then commit + push .users/.
 make validate-user USER=<name>     # placeholder scan + DNS + cluster prereq check (fails non-zero on issues)
 make deploy        USER=<name>     # helm upgrade --install (validate-user runs automatically first)
 ```
 
-What gets created under `users-private/<name>/`:
+What gets created under `.users/users-private/<name>/`:
 
 ```
-users-private/<name>/
+.users/users-private/<name>/
 ├── values.yaml          # CHANGE-ME-laden, cookieSecret pre-generated
 └── secrets/
     └── oauth2.yaml      # holds the GitHub OAuth client secret
@@ -75,12 +83,13 @@ they're auto-included in the helm deploy:
 
 ### Gitignored — by design
 
-The entire `users-private/` tree is excluded in `/.gitignore`. `git
-status` won't show any of it. If you want the configs versioned, point
-it at a separate private git repo:
+Both the `users-private/` tree and the `.users/` GitOps checkout are excluded
+in `/.gitignore`, so `git status` in this repo never shows workspace config or
+secrets. Versioning lives in the **GitOps repo** instead: scaffold into
+`.users/` (a checkout of it), then commit + push there.
 
 ```bash
-cd users-private && git init && git remote add origin git@github.com:you/kube-coder-private.git
+git -C .users add -A && git -C .users commit -m "add <name>" && git -C .users push
 ```
 
 ## 📋 Prerequisites

--- a/scripts/new-user.sh
+++ b/scripts/new-user.sh
@@ -20,11 +20,21 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEMPLATE_DIR="$ROOT/scripts/user-template"
-USERS_PRIVATE="$ROOT/users-private"
+# Scaffold into the GitOps checkout (.users/, synced via `make users-sync`) — the
+# single source of truth for provisioned workspaces. The operator commits+pushes
+# it, then `make deploy USER=<name>`. Override USERS_PRIVATE for legacy in-repo
+# scaffolding (e.g. the _controller bootstrap config).
+USERS_PRIVATE="${USERS_PRIVATE:-$ROOT/.users/users-private}"
 
 if [ $# -lt 1 ] || [ -z "${1:-}" ]; then
   echo "Usage: $0 <username>" >&2
   exit 2
+fi
+
+if [ ! -d "$ROOT/.users/.git" ] && [ "$USERS_PRIVATE" = "$ROOT/.users/users-private" ]; then
+  echo "ERROR: $ROOT/.users is not a GitOps checkout yet — run 'make users-sync' first" >&2
+  echo "       (or set USERS_PRIVATE=<dir> to scaffold elsewhere)." >&2
+  exit 1
 fi
 
 NAME="$1"
@@ -102,28 +112,32 @@ Files written:
 
 NEXT STEPS
 
-1. Create a GitHub OAuth app for this workspace:
+1. Create a GitHub OAuth App (NOT a GitHub App) for this workspace:
      https://github.com/settings/developers → New OAuth App
      Homepage URL:  https://$NAME.dev.scalebase.io
      Callback URL:  https://$NAME.dev.scalebase.io/oauth2/callback
+   (its Client ID starts with "Ov…"; a GitHub App "Iv…" id 404s oauth2-proxy.)
 
-2. Edit users-private/$NAME/values.yaml — fix every line with "CHANGE ME":
+2. Edit $USER_DIR/values.yaml — fix every line with "CHANGE ME":
      • user.host               (must resolve to your ingress IP via DNS)
      • user.env GIT_USER_NAME  / GIT_USER_EMAIL
      • oauth2.githubUsers      (comma-separated GH usernames to allow)
-     • oauth2.clientId         (from the OAuth app)
+     • oauth2.clientId         (from the OAuth app, "Ov…")
 
-3. Edit users-private/$NAME/secrets/oauth2.yaml:
+3. Edit $USER_DIR/secrets/oauth2.yaml:
      • oauth2.clientSecret     (from the OAuth app)
 
-4. (Optional) Drop additional secrets into users-private/$NAME/secrets/:
+4. (Optional) Drop additional secrets into $USER_DIR/secrets/:
      • claude.yaml             (API key)
      • github-app.yaml         (private-repo auth)
 
-5. Validate, then deploy:
+5. Commit + push the GitOps repo so the config is durable:
+     git -C $ROOT/.users add -A && git -C $ROOT/.users commit -m "add $NAME" && git -C $ROOT/.users push
+
+6. Validate, then deploy:
      make validate-user USER=$NAME
      make deploy        USER=$NAME
 
-Everything under users-private/ is gitignored — none of this lands in
-your public repo.
+The GitOps checkout (.users/) and this repo's users-private/ are both
+gitignored — none of this lands in the public repo.
 EOF

--- a/scripts/validate-user.sh
+++ b/scripts/validate-user.sh
@@ -35,9 +35,13 @@ fail() { echo "  [FAIL] $*"; FAIL_COUNT=$((FAIL_COUNT+1)); }
 
 echo "validate-user: $NAME"
 
-# 1. Locate values.yaml + secrets dir.
+# 1. Locate values.yaml + secrets dir. Resolve across the same roots, in the
+# same order, as the Makefile: legacy deployments/, this repo's users-private/,
+# then the GitOps checkout .users/ (synced via `make users-sync`) — the unifying
+# store that holds every provisioned workspace.
 PUBLIC_DIR="$ROOT/deployments/$NAME"
 PRIVATE_DIR="$ROOT/users-private/$NAME"
+GITOPS_DIR="$ROOT/.users/users-private/$NAME"
 USER_DIR=""
 SECRETS_DIR=""
 if [ -f "$PUBLIC_DIR/values.yaml" ]; then
@@ -46,11 +50,14 @@ if [ -f "$PUBLIC_DIR/values.yaml" ]; then
 elif [ -f "$PRIVATE_DIR/values.yaml" ]; then
   USER_DIR="$PRIVATE_DIR"
   SECRETS_DIR="$PRIVATE_DIR/secrets"
+elif [ -f "$GITOPS_DIR/values.yaml" ]; then
+  USER_DIR="$GITOPS_DIR"
+  SECRETS_DIR="$GITOPS_DIR/secrets"
 fi
 if [ -z "$USER_DIR" ]; then
-  fail "no values.yaml found under deployments/$NAME/ or users-private/$NAME/"
+  fail "no values.yaml found under deployments/$NAME/, users-private/$NAME/, or .users/users-private/$NAME/"
   echo
-  echo "Tip: run 'scripts/new-user.sh $NAME' to scaffold one."
+  echo "Tip: run 'make users-sync' to fetch GitOps config, or 'scripts/new-user.sh $NAME' to scaffold one."
   exit 1
 fi
 pass "values dir: $USER_DIR"


### PR DESCRIPTION
Follow-up to #154 (GitOps-store unification). After migrating every workspace into the `kube-coder-users` GitOps repo, the CLI scaffolding/validation paths need to point there too.

## Changes

- **`scripts/validate-user.sh`** — resolve `.users/users-private/<u>` in addition to `deployments/` and `users-private/`, matching the Makefile's resolver. **Required fix:** `make deploy` depends on `validate-user`, so without this, `make deploy USER=<gitops-user>` aborted at the validate step (`Error 1`) for any migrated user.
- **`scripts/new-user.sh`** — scaffold into the GitOps checkout (`.users/`) by default (override with `USERS_PRIVATE=` for the `_controller` bootstrap). Guards that `.users/` is a checkout (`make users-sync` first), fixes the OAuth-App hint (`Ov…`, not `Iv…`), and adds a commit+push-the-GitOps-repo step.
- **Docs** — README quickstart + `NEW_USER_PROVISIONING.md` now document `make users-sync` and the single source of truth; removed the stale "make `users-private/` its own git repo" instructions.

## Verification
- `make validate-user USER=user` (gitops-only user) → 8 ok, 0 fail.
- `make deploy USER=user` + `user` now pass the validate step and roll cleanly (applying their self-serve-update + OpenRouter backfill).
- `bash -n` clean on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)