### PR TITLE
Mobile: one-tap public-demo connection (+ EAS project pin)

### DIFF
--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -22,6 +22,10 @@
   },
   "submit": {
     "production": {
+      // iOS submit credentials (Apple ID, ascAppId, appleTeamId) are personal
+      // and must NOT be committed to this open-source repo. EAS prompts for them
+      // interactively and auto-detects the ascAppId once you pick the app. To
+      // pin them locally, create an untracked eas.json override or pass flags.
       "android": {
         "serviceAccountKeyPath": "./play-service-account.json",
         "track": "internal"

--- a/mobile/src/screens/OnboardingScreen.tsx
+++ b/mobile/src/screens/OnboardingScreen.tsx
@@ -16,6 +16,10 @@ import { ping } from '../api/client';
 import { getConfig, saveConnection } from '../store/config';
 import { colors, font, gradients, radius, space } from '../theme';
 
+// The project's public, read-only demo workspace (AUTH_MODE=none) — open without
+// an account. Override for a fork via EXPO_PUBLIC_DEMO_HOST.
+const DEMO_HOST = process.env.EXPO_PUBLIC_DEMO_HOST || 'https://demo-public.dev.scalebase.io';
+
 export default function OnboardingScreen() {
   const [host, setHost] = useState('');
   const [token, setToken] = useState('');
@@ -48,6 +52,22 @@ export default function OnboardingScreen() {
       setBusy(false);
       // keep fields populated if we rolled back
       if (getConfig().host) return;
+    }
+  }
+
+  async function connectDemo() {
+    setError(null);
+    setBusy(true);
+    // The public demo is read-only (AUTH_MODE=none), so the token is ignored —
+    // a placeholder satisfies the client's "configured" check.
+    await saveConnection(DEMO_HOST, 'public-demo');
+    try {
+      await ping();
+    } catch (e) {
+      setError(`Couldn't reach the demo: ${(e as Error).message}`);
+      await saveConnection('', '');
+    } finally {
+      setBusy(false);
     }
   }
 
@@ -100,6 +120,20 @@ export default function OnboardingScreen() {
 
             <Button title="Connect" onPress={connect} loading={busy} style={{ marginTop: space.xl }} />
 
+            <View style={styles.divider}>
+              <View style={styles.dividerLine} />
+              <Text style={styles.dividerText}>or</Text>
+              <View style={styles.dividerLine} />
+            </View>
+
+            <Button
+              title="Explore the public demo"
+              variant="secondary"
+              onPress={connectDemo}
+              disabled={busy}
+            />
+            <Text style={styles.demoNote}>Read-only · no account or token needed</Text>
+
             <Text style={styles.hint}>
               Point this at any kube-coder workspace: a cloud host
               (https://you.example.com) or a local one (http://localhost:6080 via
@@ -141,5 +175,9 @@ const styles = StyleSheet.create({
     height: 50,
   },
   error: { color: colors.danger, fontSize: font.size.sm, marginTop: space.md },
+  divider: { flexDirection: 'row', alignItems: 'center', gap: space.md, marginVertical: space.lg },
+  dividerLine: { flex: 1, height: 1, backgroundColor: colors.border },
+  dividerText: { color: colors.textFaint, fontSize: font.size.sm },
+  demoNote: { color: colors.textFaint, fontSize: font.size.xs, textAlign: 'center', marginTop: space.sm },
   hint: { color: colors.textFaint, fontSize: font.size.sm, marginTop: space.xl, lineHeight: 19 },
 });

--- a/mobile/src/screens/OnboardingScreen.tsx
+++ b/mobile/src/screens/OnboardingScreen.tsx
@@ -13,12 +13,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Button, Label } from '../components/ui';
 import { ping } from '../api/client';
-import { getConfig, saveConnection } from '../store/config';
+import { DEMO_HOST, getConfig, saveConnection } from '../store/config';
 import { colors, font, gradients, radius, space } from '../theme';
-
-// The project's public, read-only demo workspace (AUTH_MODE=none) — open without
-// an account. Override for a fork via EXPO_PUBLIC_DEMO_HOST.
-const DEMO_HOST = process.env.EXPO_PUBLIC_DEMO_HOST || 'https://demo-public.dev.scalebase.io';
 
 export default function OnboardingScreen() {
   const [host, setHost] = useState('');

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Card, Label, ScreenHeader } from '../components/ui';
-import { clearConnection } from '../store/config';
+import { clearConnection, isDemoHost } from '../store/config';
 import { useConfig } from '../store/useConfig';
 import { colors, font, space } from '../theme';
 import { confirmAction } from '../util/confirm';
@@ -11,12 +11,15 @@ import { confirmAction } from '../util/confirm';
 export default function SettingsScreen() {
   const cfg = useConfig();
   const masked = cfg.token ? cfg.token.slice(0, 4) + '••••••••' + cfg.token.slice(-2) : '';
+  const isDemo = isDemoHost(cfg.host);
 
   function disconnect() {
     confirmAction({
-      title: 'Disconnect this workspace?',
-      message: 'Your saved host and API token will be removed from this device.',
-      confirmLabel: 'Disconnect',
+      title: isDemo ? 'Leave the public demo?' : 'Disconnect this workspace?',
+      message: isDemo
+        ? "You'll return to the connect screen, where you can enter your own workspace host and token."
+        : 'Your saved host and API token will be removed from this device.',
+      confirmLabel: isDemo ? 'Leave demo' : 'Disconnect',
       destructive: true,
       onConfirm: clearConnection,
     });
@@ -35,16 +38,18 @@ export default function SettingsScreen() {
             <Label>API token</Label>
             <Text style={[styles.value, { fontFamily: font.mono }]}>{masked || '—'}</Text>
           </View>
-          {cfg.mock ? (
+          {cfg.mock || isDemo ? (
             <View style={styles.demoBadge}>
-              <Text style={styles.demoText}>DEMO MODE — showing mock data</Text>
+              <Text style={styles.demoText}>
+                {cfg.mock ? 'DEMO MODE — showing mock data' : 'PUBLIC DEMO — read-only'}
+              </Text>
             </View>
           ) : null}
         </Card>
 
         {!cfg.mock ? (
           <Button
-            title="Disconnect"
+            title={isDemo ? 'Leave demo' : 'Disconnect'}
             icon="log-out-outline"
             variant="danger"
             onPress={disconnect}

--- a/mobile/src/store/config.ts
+++ b/mobile/src/store/config.ts
@@ -11,6 +11,19 @@ import { getItem, getSecret, setItem, setSecret, deleteSecret } from './storage'
 const HOST_KEY = 'kc.apiBase';
 const TOKEN_KEY = 'kc.devToken';
 
+// The project's public, read-only demo workspace (AUTH_MODE=none) — reached via
+// the "Explore the public demo" button on onboarding. Override for a fork with
+// EXPO_PUBLIC_DEMO_HOST. Shared so onboarding can connect to it and Settings can
+// recognise a demo connection (and offer a clear way back to host/token entry).
+export const DEMO_HOST = (
+  process.env.EXPO_PUBLIC_DEMO_HOST || 'https://demo-public.dev.scalebase.io'
+).replace(/\/+$/, '');
+
+/** True when the given host is the public demo (saveConnection strips the trailing slash). */
+export function isDemoHost(host: string): boolean {
+  return !!host && host.replace(/\/+$/, '') === DEMO_HOST;
+}
+
 export interface Config {
   host: string; // e.g. https://imran.kube-coder.example.com  ('' when unset)
   token: string; // Bearer token ('' when unset)


### PR DESCRIPTION
## What
The mobile onboarding screen now offers **two ways in**:
1. Enter a **host + API token** (existing), or
2. Tap **"Explore the public demo"** → connects to the project's read-only public workspace (`demo-public.dev.scalebase.io`) with **no account or token**.

`demo-public` runs `AUTH_MODE=none` (read-only; writes 403), and every API path returns 200 unauthenticated — verified. The app sends a placeholder token just to satisfy its "configured" check; the backend ignores it. Demo host is overridable via `EXPO_PUBLIC_DEMO_HOST` for forks.

Also: `eas init` wiring — `extra.eas.projectId` + `owner` pinned (env-overridable), and the personal iOS submit placeholders removed from `eas.json`.

## Notes
- Mobile-only; ships via EAS, independent of the workspace image.
- On the demo, write actions (create/message/kill) and the key bar are inert (read-only) — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)