### PR TITLE
test(workspace): fix ResourceQuota helm-unittest for bumped dind quota (#103)

### DIFF
--- a/charts/workspace/tests/resourcequota_test.yaml
+++ b/charts/workspace/tests/resourcequota_test.yaml
@@ -18,10 +18,13 @@ tests:
           value: ws-alice
       - equal:
           path: spec.hard["requests.cpu"]
-          value: "1"
+          value: "2"
+      - equal:
+          path: spec.hard["limits.cpu"]
+          value: "8"
       - equal:
           path: spec.hard["limits.memory"]
-          value: 8Gi
+          value: 12Gi
       - equal:
           path: spec.hard.pods
           value: "20"
@@ -48,16 +51,18 @@ tests:
     set:
       user.name: alice
       namespace: ws-alice
-      quota.limitsCpu: "8"
-      quota.requestsMemory: 4Gi
+      # Distinct from the chart defaults (8 / 3Gi) so this actually proves the
+      # override path, not just a coincidental match.
+      quota.limitsCpu: "16"
+      quota.requestsMemory: 6Gi
     documentIndex: 0
     asserts:
       - equal:
           path: spec.hard["limits.cpu"]
-          value: "8"
+          value: "16"
       - equal:
           path: spec.hard["requests.memory"]
-          value: 4Gi
+          value: 6Gi
 
   - it: renders nothing when quota is disabled
     set:


### PR DESCRIPTION
PR #162 raised the workspace chart's default ResourceQuota to 8 CPU / 12Gi (requests 2 / 3Gi) so a workspace running the `dind` build sidecar fits, but `charts/workspace/tests/resourcequota_test.yaml` still asserted the old 1 / 8Gi — so `helm unittest charts/workspace/` fails on main.

This updates the expected defaults and changes the override case to values distinct from the new defaults (16 / 6Gi) so it still proves the override path rather than coincidentally matching.

Verified locally: `helm unittest charts/workspace` → 69 passed, and `helm unittest charts/workspace-controller` → 38 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)