### PR TITLE
fix(provision): copy shared assistant secret into new workspace namespaces (#103)

### DIFF
--- a/scripts/ensure-workspace-namespace.sh
+++ b/scripts/ensure-workspace-namespace.sh
@@ -58,3 +58,9 @@ copy_secret "$REGCRED_NAME" 1
 # set update.selfServeSecretName mount it; without a per-namespace copy the pod
 # dies with CreateContainerConfigError. Optional: skip silently if absent.
 copy_secret "${SELF_SERVE_SECRET_NAME:-kc-self-serve}" 0
+# Shared assistant secret (openrouter key). Provisioned workspaces reference it
+# via assistant.openrouter.sharedSecretName (default coder-shared-assistant) as
+# a pre-existing shared Secret the chart does NOT create; per-namespace isolation
+# (#103) means it must be copied in or the ide container hits
+# CreateContainerConfigError. Optional: skip silently if absent.
+copy_secret "${ASSISTANT_SHARED_SECRET_NAME:-coder-shared-assistant}" 0


### PR DESCRIPTION
## Problem
Provisioning a new workspace through the controller dashboard left the `ide` container stuck in `CreateContainerConfigError: secret "coder-shared-assistant" not found`.

A provisioned workspace references `assistant.openrouter.sharedSecretName` (default `coder-shared-assistant`) as a **pre-existing** shared Secret the chart does not create. Before #103 every workspace shared the `coder` namespace where that secret lives; with per-workspace namespaces the secret isn't there, so the pod can't start.

## Fix
`ensure-workspace-namespace.sh` now copies `coder-shared-assistant` into the tenant namespace alongside `regcred` and `kc-self-serve` — the complete set of shared secrets the provisioner projects (`controller.py`: `PROVISIONER_PULL_SECRET` / `WORKSPACE_SELF_SERVE_SECRET` / `WORKSPACE_ASSISTANT_SECRET`). Name overridable via `ASSISTANT_SHARED_SECRET_NAME`; skipped silently if absent.

## Verified
Ran the (idempotent) script against a live stuck `ws-likhith-root`: secret copied, pod rolled to `2/2 Running`, `https://likhith-root.dev.scalebase.io/` → 200 with valid TLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)