### PR TITLE
fix(controller): stop dashboard OOM 502s — lazy-load metrics behind a summary page

### DIFF
--- a/charts/workspace-controller/controller.py
+++ b/charts/workspace-controller/controller.py
@@ -1256,6 +1256,61 @@ def cluster_capacity(range_seconds=3600, step=300):
     return out
 
 
+def _health_status(*blocks):
+    """Overall traffic-light from the worst cluster-usage percentage across the
+    given rollups: ok < 75% <= warn < 90% <= crit. 'unknown' when no rollup has
+    a percentage (allocatable missing)."""
+    worst = None
+    for b in blocks:
+        p = (b or {}).get('clusterPct')
+        if p is not None:
+            worst = p if worst is None else max(worst, p)
+    if worst is None:
+        return 'unknown'
+    if worst >= 90:
+        return 'crit'
+    if worst >= 75:
+        return 'warn'
+    return 'ok'
+
+
+def cluster_health():
+    """Cheap cluster-health summary for the dashboard landing page: cluster CPU +
+    memory rollups and an overall traffic-light status, from a handful of INSTANT
+    Prometheus queries.
+
+    Deliberately does NOT run the per-node breakdown or the range-history queries
+    that cluster_capacity does — those are the memory/latency-heavy part and now
+    load only on the /capacity drill-down. Keeping the landing page down to these
+    ~7 instant scalars is what stops the burst of heavy queries (and the OOM/502s)
+    on every dashboard load. Prometheus failures degrade to metricsError."""
+    out = {
+        'generatedAt': int(time.time()),
+        'namespace': NAMESPACE,
+        'cluster': None,
+        'status': 'unknown',
+        'metricsError': None,
+    }
+    ws_sel = f'{_ws_prom_ns_selector()},pod=~"ws-.*"'
+    ws_cpu_inner = f'avg by (namespace, pod, container) (rate(container_cpu_usage_seconds_total{{{ws_sel},container!=""}}[5m]))'
+    ws_mem_inner = f'avg by (namespace, pod, container) (container_memory_working_set_bytes{{{ws_sel},container!=""}})'
+    all_cpu_inner = 'avg by (namespace, pod, container) (rate(container_cpu_usage_seconds_total{container!="",pod!=""}[5m]))'
+    all_mem_inner = 'avg by (namespace, pod, container) (container_memory_working_set_bytes{container!="",pod!=""})'
+    try:
+        alloc_cpu = prom_scalar('sum(avg by (node) (kube_node_status_allocatable{resource="cpu"}))')
+        alloc_mem = prom_scalar('sum(avg by (node) (kube_node_status_allocatable{resource="memory"}))')
+        node_count = prom_scalar('count(count by (node) (kube_node_status_allocatable))')
+        cpu = _resource_block(alloc_cpu, prom_scalar(f'sum({ws_cpu_inner})') or 0.0,
+                              prom_scalar(f'sum({all_cpu_inner})') or 0.0)
+        mem = _resource_block(alloc_mem, prom_scalar(f'sum({ws_mem_inner})') or 0.0,
+                              prom_scalar(f'sum({all_mem_inner})') or 0.0)
+        out['cluster'] = {'nodeCount': int(node_count or 0), 'cpu': cpu, 'memory': mem}
+        out['status'] = _health_status(cpu, mem)
+    except PromError as exc:
+        out['metricsError'] = str(exc)
+    return out
+
+
 # --- Provisioning ------------------------------------------------------------
 #
 # Self-service onboarding: an admin types a GitHub username, creates a GitHub
@@ -1879,6 +1934,15 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             except KubectlError as exc:
                 sys.stderr.write(f'[controller] {exc}: {exc.stderr}\n')
                 self.send_json({'error': str(exc)}, 502)
+            return
+        if path == '/api/capacity/summary':
+            if not self.check_admin():
+                self.send_json({'error': 'unauthorized'}, 401)
+                return
+            # Cheap instant-only rollup for the landing page — no range history,
+            # no per-node. Prometheus-only, so any outage lands in metricsError
+            # and this still returns 200.
+            self.send_json(cluster_health())
             return
         if path == '/api/capacity':
             if not self.check_admin():

--- a/charts/workspace-controller/tests/controller_test.py
+++ b/charts/workspace-controller/tests/controller_test.py
@@ -174,6 +174,70 @@ class ClusterCapacityTest(unittest.TestCase):
         self.assertEqual(cap['nodes'], [])
 
 
+class HealthStatusTest(unittest.TestCase):
+    def test_worst_percentage_drives_the_light(self):
+        ok, warn, crit = {'clusterPct': 50.0}, {'clusterPct': 80.0}, {'clusterPct': 95.0}
+        self.assertEqual(controller._health_status(ok, ok), 'ok')
+        self.assertEqual(controller._health_status(ok, warn), 'warn')   # worst wins
+        self.assertEqual(controller._health_status(warn, crit), 'crit')
+
+    def test_boundaries(self):
+        self.assertEqual(controller._health_status({'clusterPct': 74.9}), 'ok')
+        self.assertEqual(controller._health_status({'clusterPct': 75.0}), 'warn')
+        self.assertEqual(controller._health_status({'clusterPct': 89.9}), 'warn')
+        self.assertEqual(controller._health_status({'clusterPct': 90.0}), 'crit')
+
+    def test_unknown_when_no_percentage(self):
+        self.assertEqual(controller._health_status({'clusterPct': None}, None), 'unknown')
+
+
+class ClusterHealthTest(unittest.TestCase):
+    """The cheap landing-page summary: instant scalars only, no range/per-node."""
+
+    def setUp(self):
+        self._scalar = controller.prom_scalar
+
+    def tearDown(self):
+        controller.prom_scalar = self._scalar
+
+    def test_summary_shape_is_cheap(self):
+        def fake_scalar(expr):
+            if 'kube_node_status_allocatable{resource="cpu"}' in expr:
+                return 4.0
+            if 'kube_node_status_allocatable{resource="memory"}' in expr:
+                return 8e9
+            if 'count by (node) (kube_node_status_allocatable)' in expr:
+                return 1.0
+            if 'pod=~"ws-.*"' in expr and 'container_cpu' in expr:
+                return 1.0
+            if 'pod=~"ws-.*"' in expr:
+                return 2e9
+            if 'container_cpu' in expr:
+                return 2.0
+            return 4e9
+
+        controller.prom_scalar = fake_scalar
+        h = controller.cluster_health()
+        self.assertIsNone(h['metricsError'])
+        self.assertEqual(h['cluster']['nodeCount'], 1)
+        self.assertEqual(h['cluster']['cpu']['allocatable'], 4.0)
+        self.assertEqual(h['cluster']['cpu']['clusterPct'], 50.0)  # 2.0 / 4.0
+        self.assertEqual(h['cluster']['memory']['clusterPct'], 50.0)
+        self.assertEqual(h['status'], 'ok')
+        # The whole point: no range history and no per-node breakdown.
+        self.assertNotIn('history', h)
+        self.assertNotIn('nodes', h)
+
+    def test_prom_error_captured_not_raised(self):
+        def boom(expr):
+            raise controller.PromError('prometheus unreachable')
+        controller.prom_scalar = boom
+        h = controller.cluster_health()
+        self.assertEqual(h['metricsError'], 'prometheus unreachable')
+        self.assertIsNone(h['cluster'])
+        self.assertEqual(h['status'], 'unknown')
+
+
 class ProvisionPureLogicTest(unittest.TestCase):
     """Pure-logic provisioning helpers: OAuth-cred validation, cookie-secret
     shape, and values rendering. No network, no cluster."""

--- a/charts/workspace-controller/values.yaml
+++ b/charts/workspace-controller/values.yaml
@@ -49,13 +49,18 @@ controller:
     # self-serve off; admins still update any workspace from this dashboard.
     selfServeSecretName: ""
 
+  # The controller buffers Prometheus range-query results in memory (capacity
+  # history + per-workspace insights over hours) across concurrent request
+  # threads, so 256Mi OOM-killed it under dashboard load (intermittent 502s).
+  # Bumped for headroom; the lazy-loading dashboard (summary page + drill-downs)
+  # keeps steady-state well under this.
   resources:
     requests:
-      cpu: 50m
-      memory: 64Mi
+      cpu: 100m
+      memory: 128Mi
     limits:
-      cpu: 200m
-      memory: 256Mi
+      cpu: 500m
+      memory: 512Mi
 
   # Per-workspace usage metrics come from the in-cluster Prometheus (this
   # cluster has no metrics-server). Empty disables the metrics panel cleanly.

--- a/charts/workspace-controller/web/src/api/capacity.ts
+++ b/charts/workspace-controller/web/src/api/capacity.ts
@@ -61,3 +61,20 @@ export interface CapacityResponse {
 
 export const getCapacity = (rangeSeconds = 3600) =>
   apiGet<CapacityResponse>('/api/capacity', { range: rangeSeconds });
+
+/** Overall cluster traffic-light for the landing page. */
+export type HealthStatus = 'ok' | 'warn' | 'crit' | 'unknown';
+
+/** Cheap cluster-health summary (controller.py:cluster_health) — cluster CPU +
+ *  memory rollups and a status from a handful of instant queries, with no
+ *  per-node breakdown or range history. Backs the summary page so it doesn't
+ *  fire the heavy capacity/insights queries on every load. */
+export interface ClusterHealthResponse {
+  generatedAt: number;
+  namespace: string;
+  cluster: { nodeCount: number; cpu: ResourceRollup; memory: ResourceRollup } | null;
+  status: HealthStatus;
+  metricsError: string | null;
+}
+
+export const getCapacitySummary = () => apiGet<ClusterHealthResponse>('/api/capacity/summary');

--- a/charts/workspace-controller/web/src/app.tsx
+++ b/charts/workspace-controller/web/src/app.tsx
@@ -12,11 +12,12 @@ import {
   provisionConfig,
   loadProvisionConfig,
 } from './store';
-import { route, detailUser, isProvisionRoute, navigate } from './router';
+import { route, detailUser, isProvisionRoute, isCapacityRoute, navigate } from './router';
 import { MetricsPanel } from './components/MetricsPanel';
 import { WorkspaceDetail } from './components/WorkspaceDetail';
 import { InsightsBar } from './components/InsightsBar';
 import { CapacityPanel } from './components/CapacityPanel';
+import { HealthSummary } from './components/HealthSummary';
 import { ProvisionForm } from './components/ProvisionForm';
 
 // The single workspace whose inline metrics panel is expanded (null = collapsed).
@@ -33,8 +34,31 @@ export function App() {
 
   const path = route.value;
   if (isProvisionRoute(path)) return <ProvisionForm />;
+  if (isCapacityRoute(path)) return <CapacityView />;
   const user = detailUser(path);
   return user ? <WorkspaceDetail user={user} /> : <WorkspaceList />;
+}
+
+// The cluster-resources drill-down: the full capacity panel (per-node + range
+// history) and the insights advisories. These run the heavy Prometheus queries,
+// so they live here — reached from the summary page's health card — instead of
+// firing on every dashboard load.
+function CapacityView() {
+  return (
+    <div class="app">
+      <header class="hdr">
+        <div>
+          <button class="crumb" onClick={() => navigate('/')}>← Workspaces</button>
+          <h1>Cluster resources</h1>
+          <p class="sub">
+            Live capacity across all nodes, usage history, and per-workspace advisories.
+          </p>
+        </div>
+      </header>
+      <InsightsBar />
+      <CapacityPanel />
+    </div>
+  );
 }
 
 function WorkspaceList() {
@@ -61,9 +85,7 @@ function WorkspaceList() {
         </div>
       </header>
 
-      <InsightsBar />
-
-      <CapacityPanel />
+      <HealthSummary />
 
       {error.value && (
         <div class="banner err" role="alert">

--- a/charts/workspace-controller/web/src/components/HealthSummary.tsx
+++ b/charts/workspace-controller/web/src/components/HealthSummary.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'preact/hooks';
+import { type ClusterHealthResponse, type HealthStatus, getCapacitySummary } from '../api/capacity';
+import { navigate } from '../router';
+import { fmtPct } from '../format';
+
+const LABEL: Record<HealthStatus, string> = {
+  ok: 'Healthy',
+  warn: 'Under pressure',
+  crit: 'Near capacity',
+  unknown: 'Metrics unavailable',
+};
+
+/** Lightweight cluster-health card for the landing page. Backed by the cheap
+ *  /api/capacity/summary (instant queries only), so it can poll without the
+ *  heavy range-history/per-node/insights load that the full capacity view runs.
+ *  Polls every 30s and keeps the last good reading through a transient failure
+ *  so it never flickers. The whole card links through to the full drill-down. */
+export function HealthSummary() {
+  const [h, setH] = useState<ClusterHealthResponse | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    async function load() {
+      try {
+        const r = await getCapacitySummary();
+        if (!alive) return;
+        setH(r);
+        setErr(null);
+      } catch (e) {
+        if (alive && !h) setErr(e instanceof Error ? e.message : String(e));
+      }
+    }
+    void load();
+    const id = window.setInterval(() => void load(), 30000);
+    return () => {
+      alive = false;
+      window.clearInterval(id);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const status: HealthStatus = h?.metricsError ? 'unknown' : (h?.status ?? 'unknown');
+  const c = h?.cluster ?? null;
+  const open = () => navigate('/capacity');
+
+  return (
+    <button class={`health health-${status}`} onClick={open} title="Open cluster resources">
+      <span class="health-main">
+        <span class={`health-dot dot-${status}`} aria-hidden="true" />
+        <span class="health-label">Cluster: {LABEL[status]}</span>
+      </span>
+      <span class="health-stats">
+        {!h && !err && <span class="health-stat muted">Loading…</span>}
+        {err && !h && <span class="health-stat muted">unavailable</span>}
+        {c && (
+          <>
+            <span class="health-stat">CPU {fmtPct(c.cpu.clusterPct)}</span>
+            <span class="health-stat">Mem {fmtPct(c.memory.clusterPct)}</span>
+            <span class="health-stat muted">
+              {c.nodeCount} node{c.nodeCount === 1 ? '' : 's'}
+            </span>
+          </>
+        )}
+        <span class="health-cta">Cluster resources →</span>
+      </span>
+    </button>
+  );
+}

--- a/charts/workspace-controller/web/src/router.ts
+++ b/charts/workspace-controller/web/src/router.ts
@@ -23,6 +23,11 @@ export function detailUser(path: string): string | null {
   return m ? m[1] : null;
 }
 
+/** The full cluster-resources drill-down (capacity history + per-node + insights). */
+export function isCapacityRoute(path: string): boolean {
+  return path === '/capacity';
+}
+
 /** True for the provision form/status routes (/provision, /provision/<slug>). */
 export function isProvisionRoute(path: string): boolean {
   return path === '/provision' || path.startsWith('/provision/') || path.startsWith('/provision?');

--- a/charts/workspace-controller/web/src/styles.css
+++ b/charts/workspace-controller/web/src/styles.css
@@ -91,6 +91,87 @@ body {
   border-color: #3a3a42;
 }
 
+/* Landing-page cluster-health card — one cheap call, links to the full
+   cluster-resources drill-down. */
+.health {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  padding: 0.7rem 1rem;
+  margin-bottom: 1.25rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--text);
+  cursor: pointer;
+}
+.health:hover {
+  border-color: #3a3a42;
+}
+.health-main {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+.health-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  flex: none;
+}
+.dot-ok {
+  background: #56d364;
+  box-shadow: 0 0 0 3px rgba(63, 185, 80, 0.16);
+}
+.dot-warn {
+  background: #e3b341;
+  box-shadow: 0 0 0 3px rgba(210, 153, 34, 0.16);
+}
+.dot-crit {
+  background: #ff7b72;
+  box-shadow: 0 0 0 3px rgba(248, 81, 73, 0.16);
+}
+.dot-unknown {
+  background: var(--muted);
+}
+.health-label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+.health-stats {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  font-size: 0.82rem;
+}
+.health-stat.muted {
+  color: var(--muted);
+}
+.health-cta {
+  color: #58a6ff;
+  font-weight: 600;
+}
+
+/* Back breadcrumb on drill-down pages. */
+.crumb {
+  font: inherit;
+  font-size: 0.8rem;
+  color: var(--muted);
+  background: none;
+  border: none;
+  padding: 0;
+  margin-bottom: 0.4rem;
+  cursor: pointer;
+}
+.crumb:hover {
+  color: var(--text);
+}
+
 .insight-icon {
   flex: none;
 }


### PR DESCRIPTION
## Problem
Intermittent **502s** in the controller dashboard (esp. when reading workspace usage). Root cause: both controller replicas were **OOMKilled** (exit 137) at the 256Mi limit. The landing page eagerly fires two heavy Prometheus workloads on every load — `/api/insights` (2 range-multi + 1 instant-multi over 6h for *all* workspaces) and `/api/capacity` (9 instant + **6 range** queries) — both re-polling, on a threaded server. Memory spikes past 256Mi → OOMKill → in-flight requests 502 → restart → works again.

## Fix
Lazy-load the heavy analytics behind a lightweight summary, per the requested redesign:

- **New `/api/capacity/summary`** (`cluster_health`): cluster CPU/memory rollups + a traffic-light status from ~7 **instant** scalars — no range history, no per-node breakdown.
- **Landing page**: a compact `HealthSummary` card (green/amber/red + CPU%/mem%/nodes) + the workspace list. No eager insights/capacity.
- **`/capacity` drill-down**: the full `CapacityPanel` (history + per-node) and `InsightsBar`, reached from the health card.
- **Per-workspace analysis** stays lazy (row expand / `#/w/<user>`).
- **Memory limit 256Mi → 512Mi** for headroom.

## Result
Summary view makes **one cheap call** instead of a burst of heavy queries. Verified in-cluster: `/api/capacity/summary` → `status: ok` (4 nodes, CPU 21%, mem 43%), pods at **0 restarts** on 512Mi.

## Tests
`controller-python-tests` 64 pass (added `HealthStatusTest` + `ClusterHealthTest`), SPA `tsc` + build clean, vitest 21 pass, `helm unittest charts/workspace-controller` 38 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)