### PR TITLE
feat(controller): search + filters + pagination for the workspace list

### DIFF
--- a/charts/workspace-controller/web/src/app.tsx
+++ b/charts/workspace-controller/web/src/app.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 import { signal } from '@preact/signals';
 import { type Workspace, type WorkspaceState } from './api/workspaces';
 import {
@@ -61,8 +61,48 @@ function CapacityView() {
   );
 }
 
+const PAGE_SIZE = 10;
+type StateFilter = 'all' | 'running' | 'stopped';
+type NsFilter = 'all' | 'isolated' | 'shared';
+
 function WorkspaceList() {
   const rows = workspaces.value;
+  const [query, setQuery] = useState('');
+  const [stateF, setStateF] = useState<StateFilter>('all');
+  const [nsF, setNsF] = useState<NsFilter>('all');
+  const [page, setPage] = useState(0);
+
+  const q = query.trim().toLowerCase();
+  const filtered = rows.filter((w) => {
+    // "running" groups every active state (running/transitioning/degraded) —
+    // the useful split for an operator is active-vs-stopped, not the exact pill.
+    if (stateF === 'running' && w.state === 'stopped') return false;
+    if (stateF === 'stopped' && w.state !== 'stopped') return false;
+    if (nsF === 'isolated' && !w.isolated) return false;
+    if (nsF === 'shared' && w.isolated) return false;
+    if (!q) return true;
+    return (
+      w.user.toLowerCase().includes(q) ||
+      w.namespace.toLowerCase().includes(q) ||
+      (w.version ?? '').toLowerCase().includes(q)
+    );
+  });
+
+  // Clamp the page against the current filtered length so shrinking the result
+  // set (typing, or a workspace disappearing on poll) can't strand an empty page.
+  const pageCount = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const cur = Math.min(page, pageCount - 1);
+  const start = cur * PAGE_SIZE;
+  const pageRows = filtered.slice(start, start + PAGE_SIZE);
+  // Any filter change resets to the first page so results are visible.
+  const withReset = <T,>(setter: (v: T) => void, v: T) => {
+    setter(v);
+    setPage(0);
+  };
+
+  const stateChips: StateFilter[] = ['all', 'running', 'stopped'];
+  const nsChips: NsFilter[] = ['all', 'isolated', 'shared'];
+
   return (
     <div class="app">
       <header class="hdr">
@@ -93,14 +133,62 @@ function WorkspaceList() {
         </div>
       )}
 
+      <div class="filters">
+        <input
+          class="search"
+          type="search"
+          placeholder="Search user, namespace, or version…"
+          aria-label="Search workspaces"
+          value={query}
+          onInput={(e) => withReset(setQuery, (e.target as HTMLInputElement).value)}
+        />
+        <div class="filter-group" role="group" aria-label="Filter by state">
+          {stateChips.map((s) => (
+            <button key={s} class={`chip ${stateF === s ? 'on' : ''}`} onClick={() => withReset(setStateF, s)}>
+              {s === 'all' ? 'All' : s[0].toUpperCase() + s.slice(1)}
+            </button>
+          ))}
+        </div>
+        <div class="filter-group" role="group" aria-label="Filter by namespace isolation">
+          {nsChips.map((s) => (
+            <button key={s} class={`chip ${nsF === s ? 'on' : ''}`} onClick={() => withReset(setNsF, s)}>
+              {s === 'all' ? 'Any ns' : s[0].toUpperCase() + s.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
       {loaded.value && rows.length === 0 && !error.value ? (
         <div class="empty">No workspaces found.</div>
+      ) : filtered.length === 0 ? (
+        <div class="empty">No workspaces match your search or filters.</div>
       ) : (
-        <ul class="list" aria-label="Workspaces">
-          {rows.map((w) => (
-            <Row key={w.deployment} ws={w} />
-          ))}
-        </ul>
+        <>
+          <ul class="list" aria-label="Workspaces">
+            {pageRows.map((w) => (
+              <Row key={w.deployment} ws={w} />
+            ))}
+          </ul>
+          <div class="pager">
+            <span class="pager-info">
+              {start + 1}–{Math.min(start + PAGE_SIZE, filtered.length)} of {filtered.length}
+              {filtered.length !== rows.length ? ` (filtered from ${rows.length})` : ''}
+            </span>
+            {filtered.length > PAGE_SIZE && (
+              <div class="pager-btns">
+                <button class="btn ghost" disabled={cur === 0} onClick={() => setPage(cur - 1)}>
+                  ← Prev
+                </button>
+                <span class="pager-pos">
+                  Page {cur + 1} / {pageCount}
+                </span>
+                <button class="btn ghost" disabled={cur >= pageCount - 1} onClick={() => setPage(cur + 1)}>
+                  Next →
+                </button>
+              </div>
+            )}
+          </div>
+        </>
       )}
     </div>
   );

--- a/charts/workspace-controller/web/src/styles.css
+++ b/charts/workspace-controller/web/src/styles.css
@@ -172,6 +172,57 @@ body {
   color: var(--text);
 }
 
+/* Workspace list search + filter bar. */
+.filters {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+.search {
+  flex: 1 1 240px;
+  min-width: 180px;
+  font: inherit;
+  font-size: 0.88rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  color: var(--text);
+}
+.search::placeholder {
+  color: var(--muted);
+}
+.search:focus {
+  outline: none;
+  border-color: #3a3a42;
+}
+.filter-group {
+  display: flex;
+  gap: 0.3rem;
+}
+
+/* Pagination footer under the list. */
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+.pager-info,
+.pager-pos {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+.pager-btns {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .insight-icon {
   flex: none;
 }


### PR DESCRIPTION
The workspace list grew past a screenful as workspaces migrate into their own namespaces. This adds:

- **Search box** — matches user, namespace, or version (case-insensitive substring).
- **State filter chips** — All / Running / Stopped (Running = any active state).
- **Namespace-isolation chips** — Any / Isolated / Shared (topical during the #103 migration; distinguishes migrated workspaces from shared-namespace ones).
- **Pagination** — 10 per page, with "N–M of T (filtered from X)" and Prev/Next.

Filtering resets to page 1, and the page index is clamped against the filtered length so a shrinking result set (typing, or a workspace dropping out on the 5s poll) can't strand an empty page.

Frontend-only (`app.tsx` + `styles.css`). `tsc` + build clean, vitest 21 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)