### PR TITLE
feat(quota): derive per-namespace ResourceQuota from the workspace's resources

### DIFF
--- a/charts/workspace/templates/_helpers.tpl
+++ b/charts/workspace/templates/_helpers.tpl
@@ -18,3 +18,75 @@ ConfigMap in `ingress-nginx` and pointing each workspace ingress at it
 via the `proxy-set-headers` annotation (which is *not* a snippet and
 is allowed).
 */}}
+
+{{/* ---- ResourceQuota derivation (#103) --------------------------------------
+Size the per-namespace ResourceQuota from the workspace pod's ACTUAL resource
+requests/limits, so a heavier workspace (a bigger ide, or the privileged dind
+build sidecar) can't silently exhaust the quota and starve its own oauth2-proxy
+pair or cert-manager ACME solver — the failure that took a workspace's ingress
++ TLS down mid-migration. Any quota.{requests,limits}{Cpu,Memory} set explicitly
+in values.yaml still wins; otherwise the value is derived as the pod sum across
+(ide + dind) plus a fixed overhead covering the oauth2-proxy pair, one in-flight
+build Job, the solver, and margin. */}}
+
+{{/* Memory quantity (Gi/Mi/Ki/G/M/plain bytes) -> integer Mi. */}}
+{{- define "workspace.memToMi" -}}
+{{- $q := . | toString -}}
+{{- if hasSuffix "Gi" $q -}}{{- mulf (float64 (trimSuffix "Gi" $q)) 1024 | int -}}
+{{- else if hasSuffix "Mi" $q -}}{{- float64 (trimSuffix "Mi" $q) | int -}}
+{{- else if hasSuffix "Ki" $q -}}{{- divf (float64 (trimSuffix "Ki" $q)) 1024 | int -}}
+{{- else if hasSuffix "G" $q -}}{{- divf (mulf (float64 (trimSuffix "G" $q)) 1000000000) 1048576 | int -}}
+{{- else if hasSuffix "M" $q -}}{{- divf (mulf (float64 (trimSuffix "M" $q)) 1000000) 1048576 | int -}}
+{{- else -}}{{- divf (float64 $q) 1048576 | int -}}
+{{- end -}}
+{{- end -}}
+
+{{/* CPU quantity (cores or millicores) -> integer millicores. */}}
+{{- define "workspace.cpuToMilli" -}}
+{{- $q := . | toString -}}
+{{- if hasSuffix "m" $q -}}{{- float64 (trimSuffix "m" $q) | int -}}
+{{- else -}}{{- mulf (float64 $q) 1000 | int -}}
+{{- end -}}
+{{- end -}}
+
+{{/* dind sidecar defaults, mirrored from deployment.yaml's dindResources default. */}}
+{{- define "workspace.dindDefault" -}}
+{{- $d := dict "limits" (dict "cpu" "2" "memory" "4Gi") "requests" (dict "cpu" "100m" "memory" "256Mi") -}}
+{{- index $d .kind .dim -}}
+{{- end -}}
+
+{{/* Sum one (kind, dim) across the pod's containers (ide + dind when
+build.mode=buildkit). Returns Mi for memory, millicores for cpu.
+Call: (dict "ctx" $ "kind" "limits" "dim" "memory"). */}}
+{{- define "workspace.podSum" -}}
+{{- $ctx := .ctx -}}{{- $kind := .kind -}}{{- $dim := .dim -}}
+{{- $conv := ternary "workspace.memToMi" "workspace.cpuToMilli" (eq $dim "memory") -}}
+{{- $ide := include $conv (index $ctx.Values.resources $kind $dim) | int -}}
+{{- $dind := 0 -}}
+{{- if eq $ctx.Values.build.mode "buildkit" -}}
+{{- $drk := index ($ctx.Values.build.dindResources | default dict) $kind | default dict -}}
+{{- $dindVal := (index $drk $dim) | default (include "workspace.dindDefault" (dict "kind" $kind "dim" $dim)) -}}
+{{- $dind = include $conv $dindVal | int -}}
+{{- end -}}
+{{- add $ide $dind -}}
+{{- end -}}
+
+{{- define "workspace.quotaLimitsMemory" -}}
+{{- if .Values.quota.limitsMemory }}{{ .Values.quota.limitsMemory }}
+{{- else }}{{ printf "%dMi" (add (include "workspace.podSum" (dict "ctx" . "kind" "limits" "dim" "memory") | int) (.Values.quota.overheadMemoryMi | default 4096 | int)) }}{{- end -}}
+{{- end -}}
+
+{{- define "workspace.quotaLimitsCpu" -}}
+{{- if .Values.quota.limitsCpu }}{{ .Values.quota.limitsCpu }}
+{{- else }}{{ printf "%dm" (add (include "workspace.podSum" (dict "ctx" . "kind" "limits" "dim" "cpu") | int) (.Values.quota.overheadCpuMilli | default 2000 | int)) }}{{- end -}}
+{{- end -}}
+
+{{- define "workspace.quotaRequestsMemory" -}}
+{{- if .Values.quota.requestsMemory }}{{ .Values.quota.requestsMemory }}
+{{- else }}{{ printf "%dMi" (add (include "workspace.podSum" (dict "ctx" . "kind" "requests" "dim" "memory") | int) (.Values.quota.overheadReqMemoryMi | default 1024 | int)) }}{{- end -}}
+{{- end -}}
+
+{{- define "workspace.quotaRequestsCpu" -}}
+{{- if .Values.quota.requestsCpu }}{{ .Values.quota.requestsCpu }}
+{{- else }}{{ printf "%dm" (add (include "workspace.podSum" (dict "ctx" . "kind" "requests" "dim" "cpu") | int) (.Values.quota.overheadReqCpuMilli | default 500 | int)) }}{{- end -}}
+{{- end -}}

--- a/charts/workspace/templates/resourcequota.yaml
+++ b/charts/workspace/templates/resourcequota.yaml
@@ -22,10 +22,10 @@ metadata:
     app: ws-{{ .Values.user.name }}
 spec:
   hard:
-    requests.cpu: {{ .Values.quota.requestsCpu | quote }}
-    requests.memory: {{ .Values.quota.requestsMemory | quote }}
-    limits.cpu: {{ .Values.quota.limitsCpu | quote }}
-    limits.memory: {{ .Values.quota.limitsMemory | quote }}
+    requests.cpu: {{ include "workspace.quotaRequestsCpu" . | trim | quote }}
+    requests.memory: {{ include "workspace.quotaRequestsMemory" . | trim | quote }}
+    limits.cpu: {{ include "workspace.quotaLimitsCpu" . | trim | quote }}
+    limits.memory: {{ include "workspace.quotaLimitsMemory" . | trim | quote }}
     pods: {{ .Values.quota.pods | quote }}
 {{- if .Values.quota.limitRange.enabled }}
 ---

--- a/charts/workspace/tests/resourcequota_test.yaml
+++ b/charts/workspace/tests/resourcequota_test.yaml
@@ -2,7 +2,9 @@ suite: per-namespace ResourceQuota + LimitRange (#103)
 templates:
   - templates/resourcequota.yaml
 tests:
-  - it: renders a ResourceQuota in the workspace's own namespace
+  - it: derives the quota from the pod's resources (default kaniko workspace)
+    # ide 4Gi/2 (chart default), no dind. limits = ide + overhead (2000m/4096Mi);
+    # requests = ide requests 250m/1Gi + overheadReq (500m/1024Mi).
     set:
       user.name: alice
       namespace: ws-alice
@@ -18,16 +20,48 @@ tests:
           value: ws-alice
       - equal:
           path: spec.hard["requests.cpu"]
-          value: "2"
+          value: "750m"
+      - equal:
+          path: spec.hard["requests.memory"]
+          value: 2048Mi
       - equal:
           path: spec.hard["limits.cpu"]
-          value: "8"
+          value: "4000m"
       - equal:
           path: spec.hard["limits.memory"]
-          value: 12Gi
+          value: 8192Mi
       - equal:
           path: spec.hard.pods
           value: "20"
+
+  - it: adds the dind sidecar to the derived quota (buildkit)
+    # ide 4Gi/2 + dind 4Gi/2 + overhead 4Gi/2 = 12288Mi / 6000m.
+    set:
+      user.name: alice
+      namespace: ws-alice
+      build.mode: buildkit
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.hard["limits.cpu"]
+          value: "6000m"
+      - equal:
+          path: spec.hard["limits.memory"]
+          value: 12288Mi
+
+  - it: scales the quota with a heavier ide (no manual override needed)
+    # ide 8Gi + dind 4Gi + overhead 4Gi = 16384Mi (16Gi) — the value that used
+    # to require a hand-set quota override.
+    set:
+      user.name: alice
+      namespace: ws-alice
+      build.mode: buildkit
+      resources.limits.memory: 8Gi
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.hard["limits.memory"]
+          value: 16384Mi
 
   - it: renders a LimitRange with container defaults
     set:
@@ -51,8 +85,8 @@ tests:
     set:
       user.name: alice
       namespace: ws-alice
-      # Distinct from the chart defaults (8 / 3Gi) so this actually proves the
-      # override path, not just a coincidental match.
+      # An explicit value pins the quota, bypassing derivation. Distinct from any
+      # derived value so this proves the override path, not a coincidental match.
       quota.limitsCpu: "16"
       quota.requestsMemory: 6Gi
     documentIndex: 0

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -133,21 +133,31 @@ resources:
 
 # Per-namespace ResourceQuota + LimitRange (see templates/resourcequota.yaml).
 # Now that each workspace owns its namespace, the quota bounds a single tenant
-# instead of a shared pool. Sized to hold the workspace pod AT ITS LIMITS —
-# ide (3 CPU / 4Gi) + the privileged `dind` build sidecar (2 CPU / 4Gi, present
-# whenever build.mode adds docker-in-docker) + the oauth2-proxy pair + one
-# in-flight build Job — with headroom. The earlier 4 CPU / 8Gi ceiling could
-# not admit a dind workspace at all (5 CPU pod alone), which stalled the #103
-# migration for demo. These are ceilings, not reservations: a lighter (kaniko /
-# no-dind) workspace only ever requests what it uses, so the higher cap costs no
-# scheduled capacity. Ties into #95 — override per user for heavier workloads.
+# instead of a shared pool.
+#
+# The four requests/limits caps below default to "" => AUTO-DERIVED from the
+# workspace pod's own resources: the sum across ide + the privileged `dind`
+# build sidecar (present when build.mode=buildkit), plus a fixed overhead for
+# the oauth2-proxy pair, one in-flight build Job, and the cert-manager ACME
+# solver. This keeps the quota correct as a workspace's ide/dind limits change,
+# instead of a static ceiling a heavier workspace could exhaust by itself —
+# which starved oauth2-proxy + cert-manager and took a workspace's ingress/TLS
+# down on migration (#103). Pin any field to override the derived value. These
+# are ceilings, not reservations, so a lighter (kaniko / no-dind) workspace only
+# requests what it uses. Ties into #95.
 quota:
   enabled: true
-  requestsCpu: "2"
-  requestsMemory: 3Gi
-  limitsCpu: "8"
-  limitsMemory: 12Gi
+  requestsCpu: ""      # "" => derive (ide+dind requests + overheadReq*)
+  requestsMemory: ""
+  limitsCpu: ""        # "" => derive (ide+dind limits + overhead*)
+  limitsMemory: ""
   pods: "20"
+  # Headroom added on top of the derived pod sum (oauth2-proxy pair + one build
+  # Job + ACME solver + margin). Tune if your auxiliary pods differ.
+  overheadCpuMilli: 2000
+  overheadMemoryMi: 4096
+  overheadReqCpuMilli: 500
+  overheadReqMemoryMi: 1024
   # LimitRange defaults applied to any container that omits its own
   # requests/limits (e.g. ad-hoc build Jobs), so nothing runs unbounded.
   limitRange:


### PR DESCRIPTION
## Problem
The per-namespace `ResourceQuota` was a **static** value, so a heavier workspace could exhaust it by itself. mjumiapp overrides ide to 8Gi (+ dind 4Gi = **12Gi**) — exactly the chart-default 12Gi memory quota — so its `oauth2-proxy` pair and the cert-manager ACME solver had no room to schedule, and its ingress/TLS never came up during migration (#103). We'd been working around it with hand-set per-user quota overrides (mjumiapp, imran, joediv).

## Fix
The four `quota.{requests,limits}{Cpu,Memory}` fields now default to `""` ⇒ **derived** from the pod's actual resources: the sum across **ide + the dind sidecar** (when `build.mode=buildkit`) plus a fixed, tunable overhead (`overhead*`) for the oauth2-proxy pair, one in-flight build Job, and the solver. Any field set explicitly still wins, so existing overrides keep working.

Parsing/derivation lives in `_helpers.tpl` (`memToMi`, `cpuToMilli`, `podSum`, and the four `quota*` helpers).

## Derived values (verified via `helm template`)
| workspace | limits.cpu | limits.memory |
|---|---|---|
| default (kaniko, ide 4Gi) | 4000m | 8192Mi |
| buildkit (ide 4Gi + dind 4Gi) | 6000m | 12288Mi |
| heavy (ide 8Gi + dind) | 6000m | **16384Mi** |

That heavy case is exactly the 16Gi we'd been setting by hand — now automatic, so the per-user overrides become redundant (they still work; can be removed from GitOps later).

## Tests
`helm unittest charts/workspace` → **71 pass**, including new buildkit + heavy-ide derivation cases and the explicit-override case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)