### PR TITLE
feat(mobile): Apps tab with in-app WebView preview + design pass

### DIFF
--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -480,6 +480,57 @@ class ClaudeTaskManager:
             stored = f.read().strip()
         return secrets.compare_digest(token, stored)
 
+    # ── App-proxy sessions (mobile WebView) ──────────────────────────────
+    # A native WebView can attach an Authorization header to its FIRST request
+    # only — every sub-resource (script/css/XHR/websocket) an embedded app
+    # loads goes out headerless and would 401 against the app proxy. The web
+    # dashboard doesn't have this problem because oauth2-proxy's session
+    # cookie rides on every request. These sessions give the Bearer-token
+    # client the same property: one Bearer-authenticated mint request sets a
+    # short-lived, HMAC-signed cookie that check_app_proxy_auth() accepts —
+    # for /api/apps + /api/app-proxy/* ONLY, never the general API. The HMAC
+    # is keyed off the stored Bearer token, so regenerating the token also
+    # invalidates every outstanding app session. Stateless: nothing to store
+    # or clean up.
+    APP_SESSION_TTL_SECONDS = 12 * 3600
+
+    @staticmethod
+    def _app_session_sig(expiry_ts):
+        """HMAC for an app session, or None when no Bearer token exists yet
+        (nothing to key off — mint is Bearer-gated, so this only happens for
+        verify, which must then reject)."""
+        if not os.path.exists(ClaudeTaskManager.TOKEN_FILE):
+            return None
+        with open(ClaudeTaskManager.TOKEN_FILE, 'r') as f:
+            key = f.read().strip().encode('utf-8')
+        if not key:
+            return None
+        msg = f'app-session:{expiry_ts}'.encode('utf-8')
+        return hmac.new(key, msg, hashlib.sha256).hexdigest()
+
+    @staticmethod
+    def mint_app_session():
+        """-> 'expiry.sig' cookie value, valid for APP_SESSION_TTL_SECONDS."""
+        expiry = int(time.time()) + ClaudeTaskManager.APP_SESSION_TTL_SECONDS
+        sig = ClaudeTaskManager._app_session_sig(expiry)
+        if sig is None:
+            # Bearer auth passed, so a token exists unless AUTH_MODE=none —
+            # where the proxy is open anyway and the cookie value is inert.
+            return f'{expiry}.none'
+        return f'{expiry}.{sig}'
+
+    @staticmethod
+    def verify_app_session(value):
+        try:
+            expiry_s, sig = value.split('.', 1)
+            expiry = int(expiry_s)
+        except (ValueError, AttributeError):
+            return False
+        if expiry < time.time():
+            return False
+        expect = ClaudeTaskManager._app_session_sig(expiry)
+        return expect is not None and hmac.compare_digest(sig, expect)
+
     @staticmethod
     def regenerate_token():
         ClaudeTaskManager.ensure_tasks_dir()
@@ -3437,6 +3488,9 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         elif claude_path == '/api/claude/auth/token':
             self.handle_claude_get_token()
             return
+        elif claude_path == '/api/claude/apps/session':
+            self.handle_app_session_mint()
+            return
         elif claude_path == '/api/claude/assistants':
             self.handle_claude_list_assistants()
             return
@@ -3752,6 +3806,28 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         if self.headers.get('Remote-User', ''):
             return True
         return False
+
+    APP_SESSION_COOKIE = 'kc_app_session'
+
+    def _app_session_cookie_value(self):
+        """The kc_app_session cookie's value from the request, or ''."""
+        for part in self.headers.get('Cookie', '').split(';'):
+            name, _, value = part.strip().partition('=')
+            if name == self.APP_SESSION_COOKIE:
+                return value
+        return ''
+
+    def check_app_proxy_auth(self):
+        """Auth for the apps list + app proxy ONLY: everything
+        check_claude_auth accepts, plus a valid short-lived app-session
+        cookie (minted by /api/claude/apps/session for the mobile WebView,
+        whose sub-resource requests can't carry an Authorization header).
+        The cookie is deliberately NOT accepted anywhere else — an exfiltrated
+        session grants the embedded-app surface, not the workspace API."""
+        if self.check_claude_auth():
+            return True
+        value = self._app_session_cookie_value()
+        return bool(value) and ClaudeTaskManager.verify_app_session(value)
 
     def send_json(self, data, status=200):
         body = json.dumps(data).encode('utf-8')
@@ -4225,6 +4301,39 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             return
         token = ClaudeTaskManager.get_or_create_token()
         self.send_json({'token': token})
+
+    # Only ever bounce the WebView into the app proxy — anything else would be
+    # an open redirect on an authenticated endpoint.
+    _APP_SESSION_NEXT_RE = re.compile(r'^/api/app-proxy/\d+(/.*)?$')
+
+    def handle_app_session_mint(self):
+        """GET /api/claude/apps/session?next=/api/app-proxy/<port>/
+
+        Bearer-authenticated bootstrap for embedding an app in a native
+        WebView: validates the caller, mints a short-lived app-session cookie
+        (see ClaudeTaskManager.mint_app_session) and 302s to `next`. The
+        WebView attaches its Authorization header to this one request, stores
+        the Set-Cookie, follows the redirect, and every sub-resource the
+        embedded app loads from then on authenticates via the cookie."""
+        if not self.check_claude_auth():
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        qs = urllib.parse.urlsplit(self.path).query
+        next_path = (urllib.parse.parse_qs(qs).get('next') or [''])[0]
+        if not self._APP_SESSION_NEXT_RE.match(next_path):
+            self.send_json({'error': 'next must be an /api/app-proxy/<port>/ path'}, 400)
+            return
+        value = ClaudeTaskManager.mint_app_session()
+        # Secure only when the edge says HTTPS — a hard Secure flag would break
+        # local http (kubectl port-forward) development.
+        secure = '; Secure' if self.headers.get('X-Forwarded-Proto', '') == 'https' else ''
+        cookie = (f'{self.APP_SESSION_COOKIE}={value}; Path=/; HttpOnly; SameSite=Lax; '
+                  f'Max-Age={ClaudeTaskManager.APP_SESSION_TTL_SECONDS}{secure}')
+        self.send_response(302)
+        self.send_header('Set-Cookie', cookie)
+        self.send_header('Location', next_path)
+        self.send_header('Cache-Control', 'no-store')
+        self.end_headers()
 
     def handle_claude_list_assistants(self):
         if not self.check_claude_auth():
@@ -5710,7 +5819,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         upstream's 101 response is relayed verbatim so the client sees the
         real Sec-WebSocket-Accept handshake.
         """
-        if not self.check_claude_auth():
+        if not self.check_app_proxy_auth():
             self.send_response(401)
             self.end_headers()
             return
@@ -5874,7 +5983,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
           (the Vite-style case where the dev server only matches its own
           --base prefix).
         """
-        if not self.check_claude_auth():
+        if not self.check_app_proxy_auth():
             self.send_response(401)
             self.end_headers()
             return
@@ -6045,7 +6154,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
     # --- Apps API (list + pin CRUD) ---
 
     def _handle_apps_list(self):
-        if not self.check_claude_auth():
+        if not self.check_app_proxy_auth():
             self.send_response(401)
             self.end_headers()
             return

--- a/charts/workspace/templates/ingress-claude-api.yaml
+++ b/charts/workspace/templates/ingress-claude-api.yaml
@@ -54,9 +54,12 @@ spec:
     http:
       paths:
       # The capture group is re-applied by rewrite-target (/$1), so the path
-      # reaches BrowserHandler unchanged. Covers the task API, memory store, and
-      # the metrics/health probes the mobile client polls.
-      - path: /(api/claude/.*|api/memory.*|metrics|health)
+      # reaches BrowserHandler unchanged. Covers the task API, memory store,
+      # the metrics/health probes the mobile client polls, and the Applications
+      # surface (list + reverse proxy + the WebView session bootstrap under
+      # api/claude/) — the app proxy accepts a Bearer token or the scoped
+      # kc_app_session cookie it mints (see server.py check_app_proxy_auth).
+      - path: /(api/claude/.*|api/memory.*|api/apps|api/app-proxy/.*|metrics|health)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/charts/workspace/tests/app_session_test.py
+++ b/charts/workspace/tests/app_session_test.py
@@ -1,0 +1,116 @@
+"""Tests for the app-proxy session bootstrap (mobile WebView embedding).
+
+A native WebView can only attach an Authorization header to its first
+request, so /api/claude/apps/session mints a short-lived HMAC cookie that
+check_app_proxy_auth() accepts on the apps surface only. These tests cover
+the mint/verify round-trip, expiry, tampering, invalidation on token
+rotation, the cookie parse, and the open-redirect guard on `next`.
+
+Run with:
+    cd charts/workspace && python3 -m unittest tests.app_session_test
+"""
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+import server  # noqa: E402
+
+M = server.ClaudeTaskManager
+
+
+class AppSessionUnit(unittest.TestCase):
+    def setUp(self):
+        # Point the token file at a temp path so mint/verify key off a
+        # known, isolated Bearer token.
+        self._token_file_save = M.TOKEN_FILE
+        fd, self._token_path = tempfile.mkstemp(prefix='kc-token-')
+        os.close(fd)
+        with open(self._token_path, 'w') as f:
+            f.write('test-bearer-token')
+        M.TOKEN_FILE = self._token_path
+
+    def tearDown(self):
+        M.TOKEN_FILE = self._token_file_save
+        os.unlink(self._token_path)
+
+    def test_mint_verify_round_trip(self):
+        self.assertTrue(M.verify_app_session(M.mint_app_session()))
+
+    def test_expired_session_rejected(self):
+        expired = int(time.time()) - 10
+        value = f'{expired}.{M._app_session_sig(expired)}'
+        self.assertFalse(M.verify_app_session(value))
+
+    def test_tampered_signature_rejected(self):
+        value = M.mint_app_session()
+        expiry, sig = value.split('.', 1)
+        bad = sig[:-1] + ('0' if sig[-1] != '0' else '1')
+        self.assertFalse(M.verify_app_session(f'{expiry}.{bad}'))
+
+    def test_tampered_expiry_rejected(self):
+        # Extending the expiry without re-signing must fail.
+        value = M.mint_app_session()
+        expiry, sig = value.split('.', 1)
+        self.assertFalse(M.verify_app_session(f'{int(expiry) + 9999}.{sig}'))
+
+    def test_garbage_values_rejected(self):
+        for v in ('', 'nodot', '123.', '.sig', 'notanint.deadbeef', None):
+            self.assertFalse(M.verify_app_session(v), repr(v))
+
+    def test_token_rotation_invalidates_sessions(self):
+        # Sessions are keyed off the stored Bearer token, so rotating it
+        # (what regenerate_token does) must invalidate outstanding cookies.
+        value = M.mint_app_session()
+        self.assertTrue(M.verify_app_session(value))
+        with open(self._token_path, 'w') as f:
+            f.write('rotated-token')
+        self.assertFalse(M.verify_app_session(value))
+
+
+class _FakeHeaders(dict):
+    def get(self, k, default=''):
+        return super().get(k, default)
+
+
+class CookieParseUnit(unittest.TestCase):
+    def _value(self, cookie_header):
+        fake = type('H', (), {
+            'APP_SESSION_COOKIE': server.BrowserHandler.APP_SESSION_COOKIE,
+            'headers': _FakeHeaders(Cookie=cookie_header),
+        })()
+        return server.BrowserHandler._app_session_cookie_value(fake)
+
+    def test_finds_cookie_among_others(self):
+        self.assertEqual(self._value('a=1; kc_app_session=exp.sig; b=2'), 'exp.sig')
+
+    def test_missing_cookie_is_empty(self):
+        self.assertEqual(self._value('a=1; b=2'), '')
+        self.assertEqual(self._value(''), '')
+
+    def test_name_must_match_exactly(self):
+        self.assertEqual(self._value('xkc_app_session=nope'), '')
+
+
+class NextPathGuardUnit(unittest.TestCase):
+    """The mint endpoint must only ever redirect into the app proxy."""
+
+    RE = server.BrowserHandler._APP_SESSION_NEXT_RE
+
+    def test_accepts_app_proxy_paths(self):
+        for p in ('/api/app-proxy/3000/', '/api/app-proxy/8080',
+                  '/api/app-proxy/3000/deep/path'):
+            self.assertIsNotNone(self.RE.match(p), p)
+
+    def test_rejects_everything_else(self):
+        for p in ('/', '/api/claude/tasks', '//evil.com/', 'https://evil.com',
+                  '/api/app-proxy/notaport/', '', '/api/app-proxyx/1/'):
+            self.assertIsNone(self.RE.match(p), p)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -19,10 +19,12 @@ import OnboardingScreen from './src/screens/OnboardingScreen';
 import TasksScreen from './src/screens/TasksScreen';
 import TaskDetailScreen from './src/screens/TaskDetailScreen';
 import NewTaskScreen from './src/screens/NewTaskScreen';
+import AppsScreen from './src/screens/AppsScreen';
+import AppViewScreen from './src/screens/AppViewScreen';
 import MemoryScreen from './src/screens/MemoryScreen';
 import MetricsScreen from './src/screens/MetricsScreen';
 import SettingsScreen from './src/screens/SettingsScreen';
-import type { TasksStackParams } from './src/navigation';
+import type { AppsStackParams, TasksStackParams } from './src/navigation';
 import { hydrate, isConfigured } from './src/store/config';
 import { useConfig } from './src/store/useConfig';
 import { colors, font } from './src/theme';
@@ -62,10 +64,21 @@ function TasksStack() {
   );
 }
 
+const AppsStackNav = createNativeStackNavigator<AppsStackParams>();
+function AppsStack() {
+  return (
+    <AppsStackNav.Navigator screenOptions={headerOptions}>
+      <AppsStackNav.Screen name="AppList" component={AppsScreen} options={{ headerShown: false }} />
+      <AppsStackNav.Screen name="AppView" component={AppViewScreen} options={{ title: 'App' }} />
+    </AppsStackNav.Navigator>
+  );
+}
+
 const Tab = createBottomTabNavigator();
 
 const TAB_ICONS: Record<string, [keyof typeof Ionicons.glyphMap, keyof typeof Ionicons.glyphMap]> = {
   Tasks: ['layers-outline', 'layers'],
+  Apps: ['globe-outline', 'globe'],
   Memory: ['bookmark-outline', 'bookmark'],
   Metrics: ['stats-chart-outline', 'stats-chart'],
   Settings: ['settings-outline', 'settings'],
@@ -87,6 +100,7 @@ function MainTabs() {
       })}
     >
       <Tab.Screen name="Tasks" component={TasksStack} />
+      <Tab.Screen name="Apps" component={AppsStack} />
       <Tab.Screen name="Memory" component={MemoryScreen} />
       <Tab.Screen name="Metrics" component={MetricsScreen} />
       <Tab.Screen name="Settings" component={SettingsScreen} />
@@ -121,12 +135,13 @@ export default function App() {
 }
 
 const styles = StyleSheet.create({
+  // No fixed height/paddingBottom: bottom-tabs sizes itself around the
+  // home-indicator inset, and a hardcoded 66px bar crowds the indicator on
+  // devices that have one (and wastes space on ones that don't).
   tabBar: {
     backgroundColor: colors.bgElevated,
     borderTopColor: colors.border,
-    height: 66,
-    paddingBottom: 9,
-    paddingTop: 8,
+    paddingTop: 6,
   },
   boot: { flex: 1, backgroundColor: colors.bg, alignItems: 'center', justifyContent: 'center' },
   bootText: { color: colors.text, fontSize: font.size.xl, fontWeight: '800' },

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -26,7 +26,8 @@
         "react-native": "0.85.3",
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
-        "react-native-web": "^0.21.2"
+        "react-native-web": "^0.21.2",
+        "react-native-webview": "13.16.1"
       },
       "devDependencies": {
         "@types/react": "~19.2.2",
@@ -5591,6 +5592,20 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.16.1",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.1.tgz",
+      "integrity": "sha512-If0eHhoEdOYDcHsX+xBFwHMbWBGK1BvGDQDQdVkwtSIXiq1uiqjkpWVP2uQ1as94J0CzvFE9PUNDuhiX0Z6ubw==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/react-native/node_modules/anser": {
       "version": "1.4.10",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -21,7 +21,8 @@
     "react-native": "0.85.3",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",
-    "react-native-web": "^0.21.2"
+    "react-native-web": "^0.21.2",
+    "react-native-webview": "13.16.1"
   },
   "devDependencies": {
     "@types/react": "~19.2.2",

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -15,13 +15,14 @@
  */
 import { getConfig } from '../store/config';
 import {
+  mockApps,
   mockHealth,
   mockMemory,
   mockMetrics,
   mockTaskDetail,
   mockTasks,
 } from '../mock/mockData';
-import type { Health, MemoryRecord, Metrics, TaskDetail, TaskSummary } from './types';
+import type { AppEntry, Health, MemoryRecord, Metrics, TaskDetail, TaskSummary } from './types';
 
 export class ApiError extends Error {
   status: number;
@@ -50,10 +51,16 @@ function buildUrl(host: string, path: string, query?: ReqOpts['query']): string 
   return url;
 }
 
+// A stalled connection should fail visibly, not spin forever — polling screens
+// recover on the next tick, and one-shot actions surface a real error.
+const REQUEST_TIMEOUT_MS = 15000;
+
 async function request<T>(path: string, opts: ReqOpts = {}): Promise<T> {
   const { host, token } = getConfig();
   if (!host || !token) throw new ApiError('Not configured', 0);
   const url = buildUrl(host, path, opts.query);
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), REQUEST_TIMEOUT_MS);
   let res: Response;
   try {
     res = await fetch(url, {
@@ -64,9 +71,13 @@ async function request<T>(path: string, opts: ReqOpts = {}): Promise<T> {
         ...(opts.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
       },
       body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+      signal: abort.signal,
     });
   } catch (e) {
-    throw new ApiError(`Network error: ${(e as Error).message}`, 0);
+    const aborted = (e as Error).name === 'AbortError';
+    throw new ApiError(aborted ? 'Request timed out' : `Network error: ${(e as Error).message}`, 0);
+  } finally {
+    clearTimeout(timer);
   }
   const ctype = res.headers.get('Content-Type') || '';
   const parsed: unknown = ctype.includes('application/json')
@@ -228,6 +239,41 @@ function normalizeMemory(m: RawMemory): MemoryRecord {
         ? m.tags.split(',').map((s) => s.trim()).filter(Boolean)
         : [];
   return { ...m, tags };
+}
+
+// ---- Applications ------------------------------------------------------------
+
+/** Apps running in the workspace (auto-discovered listeners + pins). */
+export async function listApps(): Promise<AppEntry[]> {
+  if (getConfig().mock) {
+    await delay(120);
+    return [...mockApps];
+  }
+  const data = await request<{ apps?: AppEntry[] }>('/api/apps');
+  return data.apps ?? [];
+}
+
+/**
+ * URL + headers for embedding an app in the WebView.
+ *
+ * A WebView only attaches headers to its FIRST request, so we point it at the
+ * Bearer-authenticated session bootstrap (/api/claude/apps/session): the server
+ * validates the token, sets a short-lived app-session cookie scoped to the app
+ * proxy, and 302s into /api/app-proxy/<port>/. Every sub-resource the embedded
+ * app loads after that authenticates via the cookie the WebView just stored.
+ */
+export function appEmbedSource(port: number): { uri: string; headers: Record<string, string> } {
+  const { host, token } = getConfig();
+  const next = encodeURIComponent(`/api/app-proxy/${port}/`);
+  return {
+    uri: `${host.replace(/\/+$/, '')}/api/claude/apps/session?next=${next}`,
+    headers: { Authorization: `Bearer ${token}` },
+  };
+}
+
+/** Plain proxy URL for an app — for "open in browser". */
+export function appProxyUrl(port: number): string {
+  return `${getConfig().host.replace(/\/+$/, '')}/api/app-proxy/${port}/`;
 }
 
 // ---- Metrics / health ------------------------------------------------------

--- a/mobile/src/api/types.ts
+++ b/mobile/src/api/types.ts
@@ -39,3 +39,16 @@ export interface Health {
   browser?: boolean;
   ok?: boolean;
 }
+
+/** One entry on the Applications tab (mirrors /api/apps). */
+export interface AppEntry {
+  port: number;
+  /** Pinned name, or '' for an auto-discovered listener. */
+  name: string;
+  pinned: boolean;
+  /** running (listening now) | stopped (pinned, not listening) | blocked (reserved port). */
+  status: 'running' | 'stopped' | 'blocked';
+  strip_prefix: boolean;
+  /** Bind address from /proc/net/tcp, e.g. "127.0.0.1". */
+  addr: string;
+}

--- a/mobile/src/components/ui.tsx
+++ b/mobile/src/components/ui.tsx
@@ -182,6 +182,19 @@ export function Label({ children, style }: { children: React.ReactNode; style?: 
   return <Text style={[styles.label, style]}>{children}</Text>;
 }
 
+/** Inline, non-blocking error strip. Shown when a screen still has (stale)
+ *  data to display — a full-screen error state would throw that away. */
+export function ErrorBanner({ message }: { message: string }) {
+  return (
+    <View style={styles.errBanner} accessibilityRole="alert">
+      <Ionicons name="cloud-offline-outline" size={15} color={colors.danger} />
+      <Text style={styles.errBannerText} numberOfLines={2}>
+        {message}
+      </Text>
+    </View>
+  );
+}
+
 export { Ionicons };
 
 const styles = StyleSheet.create({
@@ -249,4 +262,18 @@ const styles = StyleSheet.create({
     letterSpacing: 0.7,
     marginBottom: space.sm,
   },
+  errBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: space.sm,
+    marginHorizontal: space.lg,
+    marginBottom: space.md,
+    paddingHorizontal: space.md,
+    paddingVertical: space.sm,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.danger + '55',
+    backgroundColor: colors.danger + '14',
+  },
+  errBannerText: { flex: 1, color: colors.danger, fontSize: font.size.sm },
 });

--- a/mobile/src/mock/mockData.ts
+++ b/mobile/src/mock/mockData.ts
@@ -6,7 +6,7 @@
  * Timestamps are offsets from load time so the relative labels ("90s ago",
  * "1h ago") read realistically whenever screenshots are regenerated.
  */
-import type { Health, MemoryRecord, Metrics, TaskDetail, TaskSummary } from '../api/types';
+import type { AppEntry, Health, MemoryRecord, Metrics, TaskDetail, TaskSummary } from '../api/types';
 
 const NOW = Math.floor(Date.now() / 1000);
 
@@ -164,3 +164,30 @@ export const mockHealth: Health = {
   browser: false,
   ok: true,
 };
+
+export const mockApps: AppEntry[] = [
+  {
+    port: 3000,
+    name: 'storefront',
+    pinned: true,
+    status: 'running',
+    strip_prefix: false,
+    addr: '127.0.0.1',
+  },
+  {
+    port: 8080,
+    name: '',
+    pinned: false,
+    status: 'running',
+    strip_prefix: false,
+    addr: '127.0.0.1',
+  },
+  {
+    port: 5173,
+    name: 'admin-ui',
+    pinned: true,
+    status: 'stopped',
+    strip_prefix: true,
+    addr: '127.0.0.1',
+  },
+];

--- a/mobile/src/navigation.ts
+++ b/mobile/src/navigation.ts
@@ -8,3 +8,11 @@ export type TasksStackParams = {
 };
 
 export type TasksNav = NativeStackNavigationProp<TasksStackParams>;
+
+/** Stack routes for the Apps tab. */
+export type AppsStackParams = {
+  AppList: undefined;
+  AppView: { port: number; name: string };
+};
+
+export type AppsNav = NativeStackNavigationProp<AppsStackParams>;

--- a/mobile/src/screens/AppViewScreen.tsx
+++ b/mobile/src/screens/AppViewScreen.tsx
@@ -1,0 +1,163 @@
+/** In-app preview of a workspace web app, rendered in a WebView. */
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
+import { WebView } from 'react-native-webview';
+import { appEmbedSource, appProxyUrl } from '../api/client';
+import { Button } from '../components/ui';
+import { getConfig } from '../store/config';
+import type { AppsStackParams } from '../navigation';
+import { colors, font, radius, space } from '../theme';
+
+export default function AppViewScreen() {
+  const route = useRoute<RouteProp<AppsStackParams, 'AppView'>>();
+  const nav = useNavigation();
+  const { port, name } = route.params;
+  const webRef = useRef<WebView>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // Bump to remount the WebView — a clean retry that re-runs the whole
+  // session bootstrap, not just a reload of a possibly-401'd page.
+  const [attempt, setAttempt] = useState(0);
+
+  // The session bootstrap: Bearer on the first request only (all a WebView
+  // can do); the server 302s into the app proxy and sets a scoped cookie the
+  // embedded app's sub-resources authenticate with. In demo mode the proxy
+  // is open, so point straight at it.
+  const source = getConfig().mock
+    ? { uri: appProxyUrl(port) }
+    : appEmbedSource(port);
+
+  useLayoutEffect(() => {
+    nav.setOptions({
+      title: name,
+      headerRight: () => (
+        <View style={styles.headerBtns}>
+          <Pressable
+            onPress={() => webRef.current?.reload()}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel="Reload app"
+            style={styles.headerBtn}
+          >
+            <Ionicons name="refresh" size={20} color={colors.text} />
+          </Pressable>
+          <Pressable
+            onPress={() => void Linking.openURL(appProxyUrl(port))}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel="Open in browser"
+            style={styles.headerBtn}
+          >
+            <Ionicons name="open-outline" size={20} color={colors.text} />
+          </Pressable>
+        </View>
+      ),
+    });
+  }, [nav, name, port]);
+
+  if (error) {
+    return (
+      <View style={styles.errWrap}>
+        <View style={styles.errIcon}>
+          <Ionicons name="cloud-offline-outline" size={28} color={colors.danger} />
+        </View>
+        <Text style={styles.errTitle}>Couldn't load {name}</Text>
+        <Text style={styles.errMsg}>{error}</Text>
+        <Button
+          title="Try again"
+          icon="refresh"
+          onPress={() => {
+            setError(null);
+            setLoading(true);
+            setAttempt((a) => a + 1);
+          }}
+          style={{ marginTop: space.lg, alignSelf: 'stretch' }}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.wrap}>
+      <WebView
+        key={attempt}
+        ref={webRef}
+        source={source}
+        style={styles.web}
+        // Share the native cookie jar so the app-session cookie set by the
+        // bootstrap redirect rides on every sub-resource request.
+        sharedCookiesEnabled
+        thirdPartyCookiesEnabled
+        // Dev servers talk websockets (HMR) and fetch from the same origin.
+        originWhitelist={['*']}
+        allowsBackForwardNavigationGestures
+        pullToRefreshEnabled
+        setSupportMultipleWindows={false}
+        onLoadEnd={() => setLoading(false)}
+        onError={(e) => {
+          setLoading(false);
+          setError(e.nativeEvent.description || 'The app did not respond.');
+        }}
+        onHttpError={(e) => {
+          // Only the top-level document failing is fatal; a 404 favicon isn't.
+          if (e.nativeEvent.url.includes(`/api/app-proxy/${port}`) && e.nativeEvent.statusCode >= 500) {
+            setLoading(false);
+            setError(`The app returned HTTP ${e.nativeEvent.statusCode}.`);
+          }
+        }}
+        startInLoadingState={false}
+      />
+      {loading ? (
+        <View style={styles.loadingBar} pointerEvents="none">
+          <Text style={styles.loadingText}>Connecting to {name}…</Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { flex: 1, backgroundColor: colors.bg },
+  web: { flex: 1, backgroundColor: colors.bg },
+  headerBtns: { flexDirection: 'row', gap: space.md },
+  headerBtn: { padding: 2 },
+  loadingBar: {
+    position: 'absolute',
+    top: space.md,
+    alignSelf: 'center',
+    backgroundColor: colors.bgElevated,
+    borderColor: colors.border,
+    borderWidth: 1,
+    borderRadius: radius.pill,
+    paddingHorizontal: space.lg,
+    paddingVertical: space.sm,
+  },
+  loadingText: { color: colors.textMuted, fontSize: font.size.sm, fontWeight: '600' },
+  errWrap: {
+    flex: 1,
+    backgroundColor: colors.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: space.xl,
+  },
+  errIcon: {
+    width: 60,
+    height: 60,
+    borderRadius: radius.xl,
+    backgroundColor: colors.danger + '1a',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: space.md,
+  },
+  errTitle: { color: colors.text, fontSize: font.size.lg, fontWeight: '700' },
+  errMsg: {
+    color: colors.textMuted,
+    fontSize: font.size.sm,
+    textAlign: 'center',
+    marginTop: space.sm,
+    maxWidth: 300,
+    lineHeight: 20,
+  },
+});

--- a/mobile/src/screens/AppsScreen.tsx
+++ b/mobile/src/screens/AppsScreen.tsx
@@ -1,0 +1,151 @@
+/** Applications: web apps running in the workspace, embeddable in-app. */
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import React, { useCallback, useState } from 'react';
+import { FlatList, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { listApps } from '../api/client';
+import { Card, EmptyState, ErrorBanner, Loading, ScreenHeader } from '../components/ui';
+import type { AppsNav } from '../navigation';
+import type { AppEntry } from '../api/types';
+import { colors, font, radius, space } from '../theme';
+import { usePolling } from '../util/usePolling';
+
+const STATUS_META: Record<AppEntry['status'], { color: string; label: string }> = {
+  running: { color: colors.success, label: 'running' },
+  stopped: { color: colors.killed, label: 'stopped' },
+  blocked: { color: colors.warning, label: 'reserved' },
+};
+
+function appTitle(app: AppEntry): string {
+  return app.name || `Port ${app.port}`;
+}
+
+export default function AppsScreen() {
+  const nav = useNavigation<AppsNav>();
+  const [apps, setApps] = useState<AppEntry[] | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const list = await listApps();
+      // Running first, then pinned-but-stopped; stable by port within a group.
+      list.sort(
+        (a, b) =>
+          Number(b.status === 'running') - Number(a.status === 'running') || a.port - b.port,
+      );
+      setApps(list);
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+      setApps((prev) => prev ?? []);
+    }
+  }, []);
+
+  // Listeners come and go as the user's dev servers start/stop; poll gently
+  // while this tab is focused (usePolling also fires immediately on focus).
+  usePolling(load, 6000);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await load();
+    setRefreshing(false);
+  };
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      <ScreenHeader title="Apps" subtitle="Web apps running in your workspace" />
+
+      {error && apps !== null && apps.length > 0 ? <ErrorBanner message={error} /> : null}
+
+      {apps === null ? (
+        <Loading label="Finding running apps…" />
+      ) : apps.length === 0 ? (
+        error ? (
+          <EmptyState
+            icon="cloud-offline-outline"
+            title="Couldn't load apps"
+            subtitle={error}
+          />
+        ) : (
+          <EmptyState
+            icon="globe-outline"
+            title="No apps running"
+            subtitle="Start a dev server in your workspace (e.g. on port 3000) and it shows up here, ready to preview."
+          />
+        )
+      ) : (
+        <FlatList
+          data={apps}
+          keyExtractor={(a) => String(a.port)}
+          contentContainerStyle={styles.list}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.accent} />
+          }
+          renderItem={({ item }) => {
+            const meta = STATUS_META[item.status] ?? STATUS_META.stopped;
+            const openable = item.status === 'running';
+            return (
+              <Card
+                style={styles.row}
+                onPress={
+                  openable
+                    ? () => nav.navigate('AppView', { port: item.port, name: appTitle(item) })
+                    : undefined
+                }
+              >
+                <View style={[styles.appIcon, !openable && { opacity: 0.5 }]}>
+                  <Ionicons name="globe-outline" size={20} color={colors.accent} />
+                </View>
+                <View style={styles.rowMain}>
+                  <View style={styles.rowTitle}>
+                    <Text style={[styles.name, !openable && { color: colors.textMuted }]} numberOfLines={1}>
+                      {appTitle(item)}
+                    </Text>
+                    {item.pinned ? (
+                      <Ionicons name="pin" size={12} color={colors.textFaint} />
+                    ) : null}
+                  </View>
+                  <View style={styles.rowMeta}>
+                    <View style={[styles.dot, { backgroundColor: meta.color }]} />
+                    <Text style={[styles.metaText, { color: meta.color }]}>{meta.label}</Text>
+                    <Text style={styles.metaDim}>·</Text>
+                    <Text style={styles.metaDim}>
+                      {item.addr}:{item.port}
+                    </Text>
+                  </View>
+                </View>
+                {openable ? (
+                  <Ionicons name="chevron-forward" size={18} color={colors.textFaint} />
+                ) : null}
+              </Card>
+            );
+          }}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  list: { paddingHorizontal: space.lg, paddingBottom: space.xl, gap: space.md },
+  row: { flexDirection: 'row', alignItems: 'center', gap: space.md },
+  appIcon: {
+    width: 42,
+    height: 42,
+    borderRadius: radius.md,
+    backgroundColor: colors.accent + '1a',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  rowMain: { flex: 1, gap: 3 },
+  rowTitle: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  name: { color: colors.text, fontSize: font.size.md, fontWeight: '700', flexShrink: 1 },
+  rowMeta: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  dot: { width: 7, height: 7, borderRadius: 4 },
+  metaText: { fontSize: font.size.xs, fontWeight: '700', textTransform: 'uppercase', letterSpacing: 0.5 },
+  metaDim: { color: colors.textFaint, fontSize: font.size.xs, fontFamily: font.mono },
+});

--- a/mobile/src/screens/MemoryScreen.tsx
+++ b/mobile/src/screens/MemoryScreen.tsx
@@ -1,10 +1,11 @@
 /** Persistent memory browser (read-only) — searchable, compact rows. */
 import { Ionicons } from '@expo/vector-icons';
-import React, { useEffect, useMemo, useState } from 'react';
-import { FlatList, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import React, { useCallback, useMemo, useState } from 'react';
+import { FlatList, Pressable, RefreshControl, StyleSheet, Text, TextInput, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useFocusEffect } from '@react-navigation/native';
 import { listMemory } from '../api/client';
-import { EmptyState, Loading, ScreenHeader } from '../components/ui';
+import { EmptyState, ErrorBanner, Loading, ScreenHeader } from '../components/ui';
 import type { MemoryRecord } from '../api/types';
 import { colors, font, radius, space } from '../theme';
 
@@ -14,12 +15,32 @@ export default function MemoryScreen() {
   const [items, setItems] = useState<MemoryRecord[] | null>(null);
   const [query, setQuery] = useState('');
   const [openKey, setOpenKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
 
-  useEffect(() => {
-    listMemory()
-      .then(setItems)
-      .catch(() => setItems([]));
+  const load = useCallback(async () => {
+    try {
+      setItems(await listMemory());
+      setError(null);
+    } catch (e) {
+      // A failed load must not masquerade as "no memory entries".
+      setError((e as Error).message);
+      setItems((prev) => prev ?? []);
+    }
   }, []);
+
+  // Memories change as tasks run; refetch whenever the tab regains focus.
+  useFocusEffect(
+    useCallback(() => {
+      void load();
+    }, [load]),
+  );
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await load();
+    setRefreshing(false);
+  };
 
   const filtered = useMemo(() => {
     if (!items) return null;
@@ -54,14 +75,20 @@ export default function MemoryScreen() {
         </View>
       ) : null}
 
+      {error && items !== null && items.length > 0 ? <ErrorBanner message={error} /> : null}
+
       {filtered === null ? (
         <Loading label="Loading memory…" />
       ) : items && items.length === 0 ? (
-        <EmptyState
-          icon="bookmark-outline"
-          title="No memory entries"
-          subtitle="Facts you ask the workspace to remember show up here."
-        />
+        error ? (
+          <EmptyState icon="cloud-offline-outline" title="Couldn't load memory" subtitle={error} />
+        ) : (
+          <EmptyState
+            icon="bookmark-outline"
+            title="No memory entries"
+            subtitle="Facts you ask the workspace to remember show up here."
+          />
+        )
       ) : filtered.length === 0 ? (
         <EmptyState icon="search-outline" title="No matches" subtitle={`Nothing matches “${query.trim()}”.`} />
       ) : (
@@ -72,6 +99,9 @@ export default function MemoryScreen() {
           keyboardShouldPersistTaps="handled"
           keyboardDismissMode="on-drag"
           showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.accent} />
+          }
           ListHeaderComponent={
             <Text style={styles.count}>
               {filtered.length} {filtered.length === 1 ? 'entry' : 'entries'}

--- a/mobile/src/screens/MetricsScreen.tsx
+++ b/mobile/src/screens/MetricsScreen.tsx
@@ -1,11 +1,15 @@
 /** Workspace metrics + service health. */
-import React, { useCallback, useEffect, useState } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import React, { useCallback, useState } from 'react';
+import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { getHealth, getMetrics } from '../api/client';
-import { Card, Loading, ScreenHeader } from '../components/ui';
+import { Card, EmptyState, Loading, ScreenHeader } from '../components/ui';
 import type { Health, Metrics } from '../api/types';
 import { colors, font, radius, space } from '../theme';
+import { usePolling } from '../util/usePolling';
+
+/** Percentage that stays sane when the denominator is missing or zero. */
+const pctOf = (used: number, total: number) => (total > 0 ? (used / total) * 100 : 0);
 
 function Bar({ pct, color }: { pct: number; color: string }) {
   return (
@@ -44,26 +48,45 @@ function Gauge({ label, used, total, unit, pct, color }: {
 export default function MetricsScreen() {
   const [m, setM] = useState<Metrics | null>(null);
   const [h, setH] = useState<Health | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
 
   const load = useCallback(async () => {
-    const [metrics, health] = await Promise.all([
-      getMetrics().catch(() => null),
-      getHealth().catch(() => null),
-    ]);
-    if (metrics) setM(metrics);
-    if (health) setH(health);
+    try {
+      const [metrics, health] = await Promise.all([getMetrics(), getHealth().catch(() => null)]);
+      setM(metrics);
+      if (health) setH(health);
+      setError(null);
+    } catch (e) {
+      // Keep the last good gauges through a blip; only a never-loaded screen
+      // falls through to the full-screen error below.
+      setError((e as Error).message);
+    }
   }, []);
 
-  useEffect(() => {
-    load();
-    const id = setInterval(load, 5000);
-    return () => clearInterval(id);
-  }, [load]);
+  usePolling(load, 5000);
 
-  if (!m) return <Loading label="Loading metrics…" />;
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await load();
+    setRefreshing(false);
+  };
 
-  const memPct = (m.memory_used_mb / m.memory_total_mb) * 100;
-  const diskPct = (m.disk_used_gb / m.disk_total_gb) * 100;
+  if (!m) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top']}>
+        <ScreenHeader title="Metrics" subtitle="Live workspace resources" />
+        {error ? (
+          <EmptyState icon="cloud-offline-outline" title="Couldn't load metrics" subtitle={error} />
+        ) : (
+          <Loading label="Loading metrics…" />
+        )}
+      </SafeAreaView>
+    );
+  }
+
+  const memPct = pctOf(m.memory_used_mb, m.memory_total_mb);
+  const diskPct = pctOf(m.disk_used_gb, m.disk_total_gb);
 
   const services: [string, boolean | undefined][] = [
     ['VS Code', h?.vscode],
@@ -74,7 +97,13 @@ export default function MetricsScreen() {
   return (
     <SafeAreaView style={styles.safe} edges={['top']}>
       <ScreenHeader title="Metrics" subtitle="Live workspace resources" />
-      <ScrollView contentContainerStyle={styles.list} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        contentContainerStyle={styles.list}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.accent} />
+        }
+      >
         <Gauge label="CPU" used={Math.round(m.cpu_percent)} total={100} unit="%" pct={m.cpu_percent} color={colors.accent} />
         <Gauge label="Memory" used={Math.round(m.memory_used_mb)} total={Math.round(m.memory_total_mb)} unit="MB" pct={memPct} color={colors.warning} />
         <Gauge label="Disk" used={Math.round(m.disk_used_gb)} total={Math.round(m.disk_total_gb)} unit="GB" pct={diskPct} color={colors.success} />

--- a/mobile/src/screens/NewTaskScreen.tsx
+++ b/mobile/src/screens/NewTaskScreen.tsx
@@ -25,13 +25,19 @@ export default function NewTaskScreen() {
   const [workdir, setWorkdir] = useState('/home/dev');
   const [assistant, setAssistant] = useState('claude');
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function submit() {
     if (!prompt.trim()) return;
     setBusy(true);
+    setError(null);
     try {
       const t = await createTask({ prompt: prompt.trim(), workdir, assistant });
       nav.replace('TaskDetail', { id: t.id });
+    } catch (e) {
+      // The prompt stays in the form — surface why it didn't start instead of
+      // silently doing nothing.
+      setError(e instanceof Error ? e.message : 'Failed to start the task');
     } finally {
       setBusy(false);
     }
@@ -74,13 +80,19 @@ export default function NewTaskScreen() {
             ))}
           </View>
 
+          {error ? (
+            <Text style={styles.error} accessibilityRole="alert">
+              {error}
+            </Text>
+          ) : null}
+
           <Button
             title="Start task"
             icon="rocket-outline"
             onPress={submit}
             loading={busy}
             disabled={!prompt.trim()}
-            style={{ marginTop: space.xxl }}
+            style={{ marginTop: error ? space.md : space.xxl }}
           />
         </ScrollView>
       </KeyboardAvoidingView>
@@ -125,4 +137,5 @@ const styles = StyleSheet.create({
   chipActive: { backgroundColor: colors.accent + '22', borderColor: colors.accent },
   chipText: { color: colors.textMuted, fontSize: font.size.sm, fontWeight: '500' },
   chipTextActive: { color: colors.accent, fontWeight: '700' },
+  error: { color: colors.danger, fontSize: font.size.sm, marginTop: space.xl, lineHeight: 19 },
 });

--- a/mobile/src/screens/TaskDetailScreen.tsx
+++ b/mobile/src/screens/TaskDetailScreen.tsx
@@ -1,7 +1,7 @@
 /** Task detail: live-tailed output + follow-up composer. */
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -20,6 +20,7 @@ import type { TaskDetail } from '../api/types';
 import type { TasksStackParams } from '../navigation';
 import { parseAnsiLines } from '../util/ansi';
 import { colors, font, radius, space, statusColor } from '../theme';
+import { usePolling } from '../util/usePolling';
 
 // Mobile key bar: control keys you can't type into the composer. Paste pulls the
 // clipboard into the input; the rest go straight to the live tmux session.
@@ -54,7 +55,11 @@ export default function TaskDetailScreen() {
   const [msg, setMsg] = useState('');
   const [sending, setSending] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [sendErr, setSendErr] = useState<string | null>(null);
   const scrollRef = useRef<ScrollView>(null);
+  // Only auto-follow new output while the user is pinned near the bottom —
+  // force-scrolling while they read scrollback makes the log unreadable.
+  const pinnedToBottom = useRef(true);
 
   const load = useCallback(async () => {
     try {
@@ -69,11 +74,7 @@ export default function TaskDetailScreen() {
     }
   }, [id]);
 
-  useEffect(() => {
-    load();
-    const t = setInterval(load, 3000);
-    return () => clearInterval(t);
-  }, [load]);
+  usePolling(load, 3000);
 
   const active = task?.status === 'running' || task?.status === 'waiting';
   const lines = useMemo(() => parseAnsiLines(output), [output]);
@@ -130,10 +131,15 @@ export default function TaskDetailScreen() {
   async function send() {
     if (!msg.trim()) return;
     setSending(true);
+    setSendErr(null);
     try {
       await sendMessage(id, msg.trim());
       setMsg('');
       await load();
+    } catch (e) {
+      // Keep the draft so the user can retry; a silent failure here looks
+      // exactly like a hung assistant.
+      setSendErr(e instanceof Error ? e.message : 'Failed to send');
     } finally {
       setSending(false);
     }
@@ -165,7 +171,15 @@ export default function TaskDetailScreen() {
           ref={scrollRef}
           style={styles.term}
           contentContainerStyle={styles.termContent}
-          onContentSizeChange={() => scrollRef.current?.scrollToEnd({ animated: false })}
+          scrollEventThrottle={64}
+          onScroll={(e) => {
+            const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
+            pinnedToBottom.current =
+              contentOffset.y + layoutMeasurement.height >= contentSize.height - 40;
+          }}
+          onContentSizeChange={() => {
+            if (pinnedToBottom.current) scrollRef.current?.scrollToEnd({ animated: false });
+          }}
         >
           {lines.length === 0 ? (
             <Text style={styles.termText}>(no output yet)</Text>
@@ -205,15 +219,20 @@ export default function TaskDetailScreen() {
                 </Pressable>
               ))}
             </ScrollView>
+            {sendErr ? (
+              <Text style={styles.sendErr} accessibilityRole="alert">
+                Couldn't send: {sendErr}
+              </Text>
+            ) : null}
             <View style={styles.composer}>
-            <TextInput
-              value={msg}
-              onChangeText={setMsg}
-              placeholder="Send a follow-up…"
-              placeholderTextColor={colors.textFaint}
-              style={styles.composerInput}
-              multiline
-            />
+              <TextInput
+                value={msg}
+                onChangeText={setMsg}
+                placeholder="Send a follow-up…"
+                placeholderTextColor={colors.textFaint}
+                style={styles.composerInput}
+                multiline
+              />
               <Button
                 title="Send"
                 icon="arrow-up"
@@ -283,6 +302,12 @@ const styles = StyleSheet.create({
     fontSize: font.size.md,
   },
   sendBtn: { paddingHorizontal: space.lg },
+  sendErr: {
+    color: colors.danger,
+    fontSize: font.size.xs,
+    paddingHorizontal: space.lg,
+    paddingTop: space.sm,
+  },
   finishedBar: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/mobile/src/screens/TasksScreen.tsx
+++ b/mobile/src/screens/TasksScreen.tsx
@@ -2,16 +2,17 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { LinearGradient } from 'expo-linear-gradient';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { listTasks } from '../api/client';
-import { Card, EmptyState, Loading, ScreenHeader, StatusPill } from '../components/ui';
+import { Card, EmptyState, ErrorBanner, Loading, ScreenHeader, StatusPill } from '../components/ui';
 import { getConfig } from '../store/config';
 import type { TasksNav } from '../navigation';
 import type { TaskSummary } from '../api/types';
 import { colors, font, gradients, radius, space, statusColor } from '../theme';
 import { relativeTime } from '../util/format';
+import { usePolling } from '../util/usePolling';
 
 function hostLabel(): string {
   const h = getConfig().host;
@@ -41,11 +42,7 @@ export default function TasksScreen() {
     }
   }, []);
 
-  useEffect(() => {
-    load();
-    const id = setInterval(load, 4000);
-    return () => clearInterval(id);
-  }, [load]);
+  usePolling(load, 4000);
 
   const onRefresh = async () => {
     setRefreshing(true);
@@ -60,7 +57,7 @@ export default function TasksScreen() {
       <ScreenHeader
         brand
         title="kube-coder"
-        subtitle={error ? error : `${hostLabel()}${running ? `  ·  ${running} active` : ''}`}
+        subtitle={`${hostLabel()}${running ? `  ·  ${running} active` : ''}`}
         right={
           <Pressable onPress={() => nav.navigate('NewTask')}>
             <LinearGradient
@@ -76,14 +73,20 @@ export default function TasksScreen() {
         }
       />
 
+      {error && tasks !== null && tasks.length > 0 ? <ErrorBanner message={error} /> : null}
+
       {tasks === null ? (
         <Loading label="Loading tasks…" />
       ) : tasks.length === 0 ? (
-        <EmptyState
-          icon="rocket-outline"
-          title="No tasks yet"
-          subtitle="Tap New to start a Claude task on your workspace — it runs remotely and you can follow along here."
-        />
+        error ? (
+          <EmptyState icon="cloud-offline-outline" title="Couldn't reach your workspace" subtitle={error} />
+        ) : (
+          <EmptyState
+            icon="rocket-outline"
+            title="No tasks yet"
+            subtitle="Tap New to start a Claude task on your workspace — it runs remotely and you can follow along here."
+          />
+        )
       ) : (
         <FlatList
           data={tasks}

--- a/mobile/src/util/usePolling.ts
+++ b/mobile/src/util/usePolling.ts
@@ -1,0 +1,23 @@
+/** Focus-aware polling. */
+import { useFocusEffect } from '@react-navigation/native';
+import { useCallback, useRef } from 'react';
+
+/**
+ * Run `fn` immediately and then every `intervalMs` — but only while the screen
+ * is focused. Tab screens stay mounted when the user switches tabs, so a plain
+ * setInterval keeps hammering the API (and the battery) from every tab at
+ * once; this stops the timer on blur and refreshes immediately on refocus so
+ * the screen never shows stale data.
+ */
+export function usePolling(fn: () => void | Promise<void>, intervalMs: number): void {
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+
+  useFocusEffect(
+    useCallback(() => {
+      void fnRef.current();
+      const id = setInterval(() => void fnRef.current(), intervalMs);
+      return () => clearInterval(id);
+    }, [intervalMs]),
+  );
+}


### PR DESCRIPTION
## Apps tab (web-dashboard Applications parity)
- **AppsScreen** — lists the workspace's running/pinned web apps from `/api/apps` (status pill, pin marker, addr:port), polls while focused, pull-to-refresh, distinct empty/offline states.
- **AppViewScreen** — renders the app in a `react-native-webview` with reload + open-in-browser header actions, a floating connecting pill, and a full retry error state. Websockets (HMR) work through the proxy.

## How WebView auth works
A WebView attaches headers only to its **first** request, so an embedded app's sub-resources (JS/CSS/XHR/WS) could never Bearer-authenticate — the same reason the web page needs oauth2-proxy's cookie. New `GET /api/claude/apps/session` (Bearer-gated) mints a **short-lived HMAC app-session cookie** and 302s into `/api/app-proxy/<port>/`:
- Keyed off the stored Bearer token → token rotation invalidates all sessions; stateless, nothing stored.
- Honored by `check_app_proxy_auth()` on the apps surface **only** (list + proxy + proxy websockets) — never the general API, so an exfiltrated cookie grants the embedded-app surface, not the workspace.
- `next` is regex-pinned to `/api/app-proxy/<port>/` (no open redirect).
- Bearer ingress now also routes `api/apps` + `api/app-proxy/*`. Public demo works unchanged (AUTH_MODE=none).

## Design pass
- Tab bar respects the home-indicator safe area (was hardcoded 66px).
- 15s request timeout — stalled connections fail visibly.
- Focus-aware polling everywhere (`usePolling`): hidden tabs stop hitting the API; refocus refreshes immediately.
- Failed loads no longer masquerade as empty states (Memory showed "No memory entries" on a network failure); shared `ErrorBanner` keeps stale data through blips.
- NewTask / TaskDetail follow-up failures surface inline (previously silently swallowed).
- Task output only auto-scrolls while pinned near the bottom — no more yanking while reading scrollback.
- Pull-to-refresh on Memory + Metrics; Metrics shows a retryable error instead of loading forever, and survives zero-total denominators.

## Tests
- 11 new server tests (mint/verify round-trip, expiry, tamper, rotation invalidation, cookie parse, next-path guard) — python suite **605 pass**.
- `helm unittest charts/workspace` **71 pass** (ingress change covered).
- Mobile `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)