### PR TITLE
fix(mobile): open-in-browser uses the oauth2-authenticated proxy URL

### DIFF
--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -271,9 +271,19 @@ export function appEmbedSource(port: number): { uri: string; headers: Record<str
   };
 }
 
-/** Plain proxy URL for an app — for "open in browser". */
+/** Bare proxy URL (Bearer/cookie auth only) — the WebView's post-bootstrap
+ *  destination. A plain browser can't authenticate against this. */
 export function appProxyUrl(port: number): string {
   return `${getConfig().host.replace(/\/+$/, '')}/api/app-proxy/${port}/`;
+}
+
+/** Browser-facing proxy URL for "open in browser": the /oauth-prefixed route
+ *  (same one the web dashboard uses), where the user's oauth2 session cookie —
+ *  or a GitHub login redirect — authenticates. The bare Bearer-only URL renders
+ *  a blank 401 in a browser. Works for the public demo too (its ingress serves
+ *  /oauth/* unauthenticated). */
+export function appBrowserUrl(port: number): string {
+  return `${getConfig().host.replace(/\/+$/, '')}/oauth/api/app-proxy/${port}/`;
 }
 
 // ---- Metrics / health ------------------------------------------------------

--- a/mobile/src/screens/AppViewScreen.tsx
+++ b/mobile/src/screens/AppViewScreen.tsx
@@ -4,7 +4,7 @@ import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
 import { WebView } from 'react-native-webview';
-import { appEmbedSource, appProxyUrl } from '../api/client';
+import { appBrowserUrl, appEmbedSource, appProxyUrl } from '../api/client';
 import { Button } from '../components/ui';
 import { getConfig } from '../store/config';
 import type { AppsStackParams } from '../navigation';
@@ -44,7 +44,7 @@ export default function AppViewScreen() {
             <Ionicons name="refresh" size={20} color={colors.text} />
           </Pressable>
           <Pressable
-            onPress={() => void Linking.openURL(appProxyUrl(port))}
+            onPress={() => void Linking.openURL(appBrowserUrl(port))}
             hitSlop={8}
             accessibilityRole="button"
             accessibilityLabel="Open in browser"


### PR DESCRIPTION
"Open in browser" pointed the system browser at the bare `/api/app-proxy/<port>/` — a Bearer/cookie-only route — so a plain browser got a blank 401 (the white screen). Now it opens `/oauth/api/app-proxy/<port>/`, the same oauth2-authenticated route the web dashboard uses: an existing session cookie authenticates, otherwise it redirects to GitHub login and returns to the app.

Verified live against ws-imran: unauthenticated `GET /oauth/api/app-proxy/4545/` → `302 → /oauth2/start?rd=…`. Mobile `tsc` clean.

Note: the in-app WebView flow itself needed no code change — it was failing because the workspace had an image-only update; a full `make deploy` (helm ingress + server ConfigMap) fixed it, verified end-to-end (Bearer mint → 302 + scoped cookie → app proxy 200 with cookie only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)