### PR TITLE
feat(mobile): split-pane task+app view, task search, Active/Done segments

### DIFF
--- a/mobile/src/components/AppEmbed.tsx
+++ b/mobile/src/components/AppEmbed.tsx
@@ -1,0 +1,154 @@
+/** Embeddable WebView for a workspace app — used full-screen by AppViewScreen
+ *  and as the lower pane of the task-detail split view. Owns the session
+ *  bootstrap, loading pill, and a retryable error state. */
+import { Ionicons } from '@expo/vector-icons';
+import React, { useRef, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { WebView } from 'react-native-webview';
+import { appEmbedSource, appProxyUrl } from '../api/client';
+import { getConfig } from '../store/config';
+import { colors, font, radius, space } from '../theme';
+import { Button } from './ui';
+
+export interface AppEmbedHandle {
+  reload: () => void;
+}
+
+export function AppEmbed({
+  port,
+  name,
+  compact,
+  embedRef,
+}: {
+  port: number;
+  name: string;
+  /** Tighter error/loading chrome for the split pane. */
+  compact?: boolean;
+  /** Imperative reload hook for a parent-owned toolbar button. */
+  embedRef?: React.MutableRefObject<AppEmbedHandle | null>;
+}) {
+  const webRef = useRef<WebView>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // Bump to remount the WebView — a clean retry that re-runs the whole
+  // session bootstrap, not just a reload of a possibly-401'd page.
+  const [attempt, setAttempt] = useState(0);
+
+  if (embedRef) embedRef.current = { reload: () => webRef.current?.reload() };
+
+  // The session bootstrap: Bearer on the first request only (all a WebView
+  // can do); the server 302s into the app proxy and sets a scoped cookie the
+  // embedded app's sub-resources authenticate with. In demo mode the proxy
+  // is open, so point straight at it.
+  const source = getConfig().mock ? { uri: appProxyUrl(port) } : appEmbedSource(port);
+
+  if (error) {
+    return (
+      <View style={[styles.errWrap, compact && styles.errWrapCompact]}>
+        {!compact ? (
+          <View style={styles.errIcon}>
+            <Ionicons name="cloud-offline-outline" size={28} color={colors.danger} />
+          </View>
+        ) : null}
+        <Text style={compact ? styles.errTitleCompact : styles.errTitle}>
+          Couldn't load {name}
+        </Text>
+        <Text style={styles.errMsg} numberOfLines={compact ? 2 : undefined}>
+          {error}
+        </Text>
+        <Button
+          title="Try again"
+          icon="refresh"
+          onPress={() => {
+            setError(null);
+            setLoading(true);
+            setAttempt((a) => a + 1);
+          }}
+          style={compact ? { marginTop: space.sm } : { marginTop: space.lg, alignSelf: 'stretch' }}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.wrap}>
+      <WebView
+        key={attempt}
+        ref={webRef}
+        source={source}
+        style={styles.web}
+        // Share the native cookie jar so the app-session cookie set by the
+        // bootstrap redirect rides on every sub-resource request.
+        sharedCookiesEnabled
+        thirdPartyCookiesEnabled
+        // Dev servers talk websockets (HMR) and fetch from the same origin.
+        originWhitelist={['*']}
+        allowsBackForwardNavigationGestures
+        pullToRefreshEnabled={!compact}
+        setSupportMultipleWindows={false}
+        onLoadEnd={() => setLoading(false)}
+        onError={(e) => {
+          setLoading(false);
+          setError(e.nativeEvent.description || 'The app did not respond.');
+        }}
+        onHttpError={(e) => {
+          // Only the top-level document failing is fatal; a 404 favicon isn't.
+          if (e.nativeEvent.url.includes(`/api/app-proxy/${port}`) && e.nativeEvent.statusCode >= 500) {
+            setLoading(false);
+            setError(`The app returned HTTP ${e.nativeEvent.statusCode}.`);
+          }
+        }}
+        startInLoadingState={false}
+      />
+      {loading ? (
+        <View style={styles.loadingBar} pointerEvents="none">
+          <Text style={styles.loadingText}>Connecting to {name}…</Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { flex: 1, backgroundColor: colors.bg },
+  web: { flex: 1, backgroundColor: colors.bg },
+  loadingBar: {
+    position: 'absolute',
+    top: space.md,
+    alignSelf: 'center',
+    backgroundColor: colors.bgElevated,
+    borderColor: colors.border,
+    borderWidth: 1,
+    borderRadius: radius.pill,
+    paddingHorizontal: space.lg,
+    paddingVertical: space.sm,
+  },
+  loadingText: { color: colors.textMuted, fontSize: font.size.sm, fontWeight: '600' },
+  errWrap: {
+    flex: 1,
+    backgroundColor: colors.bg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: space.xl,
+  },
+  errWrapCompact: { padding: space.md },
+  errIcon: {
+    width: 60,
+    height: 60,
+    borderRadius: radius.xl,
+    backgroundColor: colors.danger + '1a',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: space.md,
+  },
+  errTitle: { color: colors.text, fontSize: font.size.lg, fontWeight: '700' },
+  errTitleCompact: { color: colors.text, fontSize: font.size.md, fontWeight: '700' },
+  errMsg: {
+    color: colors.textMuted,
+    fontSize: font.size.sm,
+    textAlign: 'center',
+    marginTop: space.sm,
+    maxWidth: 300,
+    lineHeight: 20,
+  },
+});

--- a/mobile/src/components/AppPickerSheet.tsx
+++ b/mobile/src/components/AppPickerSheet.tsx
@@ -1,0 +1,158 @@
+/** Bottom-sheet picker for which workspace app to show in the split pane:
+ *  running apps from /api/apps, or any port typed by hand. */
+import { Ionicons } from '@expo/vector-icons';
+import React, { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { listApps } from '../api/client';
+import type { AppEntry } from '../api/types';
+import { colors, font, radius, space } from '../theme';
+
+export function AppPickerSheet({
+  visible,
+  onPick,
+  onClose,
+}: {
+  visible: boolean;
+  onPick: (port: number, name: string) => void;
+  onClose: () => void;
+}) {
+  const [apps, setApps] = useState<AppEntry[] | null>(null);
+  const [customPort, setCustomPort] = useState('');
+
+  useEffect(() => {
+    if (!visible) return;
+    setApps(null);
+    listApps()
+      .then((list) => setApps(list.filter((a) => a.status === 'running')))
+      .catch(() => setApps([]));
+  }, [visible]);
+
+  const custom = parseInt(customPort, 10);
+  const customValid = Number.isInteger(custom) && custom > 0 && custom < 65536;
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        {/* Stop backdrop-press from closing when tapping the sheet itself. */}
+        <Pressable style={styles.sheet} onPress={() => undefined}>
+          <View style={styles.grabber} />
+          <Text style={styles.title}>Show an app alongside</Text>
+          <Text style={styles.subtitle}>Pick a running app, or enter a port.</Text>
+
+          {apps === null ? (
+            <View style={styles.loading}>
+              <ActivityIndicator color={colors.accent} />
+            </View>
+          ) : apps.length === 0 ? (
+            <Text style={styles.empty}>No running apps found — enter a port below.</Text>
+          ) : (
+            apps.map((a) => (
+              <Pressable
+                key={a.port}
+                style={styles.row}
+                onPress={() => onPick(a.port, a.name || `Port ${a.port}`)}
+              >
+                <View style={styles.rowIcon}>
+                  <Ionicons name="globe-outline" size={16} color={colors.accent} />
+                </View>
+                <Text style={styles.rowName}>{a.name || `Port ${a.port}`}</Text>
+                <Text style={styles.rowPort}>:{a.port}</Text>
+              </Pressable>
+            ))
+          )}
+
+          <View style={styles.customRow}>
+            <TextInput
+              value={customPort}
+              onChangeText={setCustomPort}
+              placeholder="Custom port (e.g. 3000)"
+              placeholderTextColor={colors.textFaint}
+              keyboardType="number-pad"
+              style={styles.customInput}
+            />
+            <Pressable
+              disabled={!customValid}
+              onPress={() => customValid && onPick(custom, `Port ${custom}`)}
+              style={[styles.customBtn, !customValid && { opacity: 0.4 }]}
+            >
+              <Text style={styles.customBtnText}>Show</Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: { flex: 1, backgroundColor: '#000a', justifyContent: 'flex-end' },
+  sheet: {
+    backgroundColor: colors.bgElevated,
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: space.xl,
+    paddingBottom: space.xxl,
+    gap: space.sm,
+  },
+  grabber: {
+    alignSelf: 'center',
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colors.borderStrong,
+    marginBottom: space.md,
+  },
+  title: { color: colors.text, fontSize: font.size.lg, fontWeight: '800' },
+  subtitle: { color: colors.textMuted, fontSize: font.size.sm, marginBottom: space.sm },
+  loading: { paddingVertical: space.xl, alignItems: 'center' },
+  empty: { color: colors.textFaint, fontSize: font.size.sm, paddingVertical: space.md },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: space.md,
+    paddingVertical: space.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  rowIcon: {
+    width: 30,
+    height: 30,
+    borderRadius: radius.sm,
+    backgroundColor: colors.accent + '1a',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  rowName: { flex: 1, color: colors.text, fontSize: font.size.md, fontWeight: '600' },
+  rowPort: { color: colors.textFaint, fontSize: font.size.sm, fontFamily: font.mono },
+  customRow: { flexDirection: 'row', gap: space.sm, marginTop: space.md },
+  customInput: {
+    flex: 1,
+    height: 44,
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    color: colors.text,
+    paddingHorizontal: space.md,
+    fontSize: font.size.md,
+  },
+  customBtn: {
+    height: 44,
+    paddingHorizontal: space.lg,
+    borderRadius: radius.md,
+    backgroundColor: colors.accent,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  customBtnText: { color: colors.accentText, fontWeight: '700', fontSize: font.size.md },
+});

--- a/mobile/src/screens/AppViewScreen.tsx
+++ b/mobile/src/screens/AppViewScreen.tsx
@@ -1,33 +1,18 @@
 /** In-app preview of a workspace web app, rendered in a WebView. */
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
-import React, { useLayoutEffect, useRef, useState } from 'react';
-import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
-import { WebView } from 'react-native-webview';
-import { appBrowserUrl, appEmbedSource, appProxyUrl } from '../api/client';
-import { Button } from '../components/ui';
-import { getConfig } from '../store/config';
+import React, { useLayoutEffect, useRef } from 'react';
+import { Linking, Pressable, StyleSheet, View } from 'react-native';
+import { appBrowserUrl } from '../api/client';
+import { AppEmbed, type AppEmbedHandle } from '../components/AppEmbed';
 import type { AppsStackParams } from '../navigation';
-import { colors, font, radius, space } from '../theme';
+import { colors, space } from '../theme';
 
 export default function AppViewScreen() {
   const route = useRoute<RouteProp<AppsStackParams, 'AppView'>>();
   const nav = useNavigation();
   const { port, name } = route.params;
-  const webRef = useRef<WebView>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  // Bump to remount the WebView — a clean retry that re-runs the whole
-  // session bootstrap, not just a reload of a possibly-401'd page.
-  const [attempt, setAttempt] = useState(0);
-
-  // The session bootstrap: Bearer on the first request only (all a WebView
-  // can do); the server 302s into the app proxy and sets a scoped cookie the
-  // embedded app's sub-resources authenticate with. In demo mode the proxy
-  // is open, so point straight at it.
-  const source = getConfig().mock
-    ? { uri: appProxyUrl(port) }
-    : appEmbedSource(port);
+  const embedRef = useRef<AppEmbedHandle | null>(null);
 
   useLayoutEffect(() => {
     nav.setOptions({
@@ -35,7 +20,7 @@ export default function AppViewScreen() {
       headerRight: () => (
         <View style={styles.headerBtns}>
           <Pressable
-            onPress={() => webRef.current?.reload()}
+            onPress={() => embedRef.current?.reload()}
             hitSlop={8}
             accessibilityRole="button"
             accessibilityLabel="Reload app"
@@ -57,107 +42,10 @@ export default function AppViewScreen() {
     });
   }, [nav, name, port]);
 
-  if (error) {
-    return (
-      <View style={styles.errWrap}>
-        <View style={styles.errIcon}>
-          <Ionicons name="cloud-offline-outline" size={28} color={colors.danger} />
-        </View>
-        <Text style={styles.errTitle}>Couldn't load {name}</Text>
-        <Text style={styles.errMsg}>{error}</Text>
-        <Button
-          title="Try again"
-          icon="refresh"
-          onPress={() => {
-            setError(null);
-            setLoading(true);
-            setAttempt((a) => a + 1);
-          }}
-          style={{ marginTop: space.lg, alignSelf: 'stretch' }}
-        />
-      </View>
-    );
-  }
-
-  return (
-    <View style={styles.wrap}>
-      <WebView
-        key={attempt}
-        ref={webRef}
-        source={source}
-        style={styles.web}
-        // Share the native cookie jar so the app-session cookie set by the
-        // bootstrap redirect rides on every sub-resource request.
-        sharedCookiesEnabled
-        thirdPartyCookiesEnabled
-        // Dev servers talk websockets (HMR) and fetch from the same origin.
-        originWhitelist={['*']}
-        allowsBackForwardNavigationGestures
-        pullToRefreshEnabled
-        setSupportMultipleWindows={false}
-        onLoadEnd={() => setLoading(false)}
-        onError={(e) => {
-          setLoading(false);
-          setError(e.nativeEvent.description || 'The app did not respond.');
-        }}
-        onHttpError={(e) => {
-          // Only the top-level document failing is fatal; a 404 favicon isn't.
-          if (e.nativeEvent.url.includes(`/api/app-proxy/${port}`) && e.nativeEvent.statusCode >= 500) {
-            setLoading(false);
-            setError(`The app returned HTTP ${e.nativeEvent.statusCode}.`);
-          }
-        }}
-        startInLoadingState={false}
-      />
-      {loading ? (
-        <View style={styles.loadingBar} pointerEvents="none">
-          <Text style={styles.loadingText}>Connecting to {name}…</Text>
-        </View>
-      ) : null}
-    </View>
-  );
+  return <AppEmbed port={port} name={name} embedRef={embedRef} />;
 }
 
 const styles = StyleSheet.create({
-  wrap: { flex: 1, backgroundColor: colors.bg },
-  web: { flex: 1, backgroundColor: colors.bg },
   headerBtns: { flexDirection: 'row', gap: space.md },
   headerBtn: { padding: 2 },
-  loadingBar: {
-    position: 'absolute',
-    top: space.md,
-    alignSelf: 'center',
-    backgroundColor: colors.bgElevated,
-    borderColor: colors.border,
-    borderWidth: 1,
-    borderRadius: radius.pill,
-    paddingHorizontal: space.lg,
-    paddingVertical: space.sm,
-  },
-  loadingText: { color: colors.textMuted, fontSize: font.size.sm, fontWeight: '600' },
-  errWrap: {
-    flex: 1,
-    backgroundColor: colors.bg,
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: space.xl,
-  },
-  errIcon: {
-    width: 60,
-    height: 60,
-    borderRadius: radius.xl,
-    backgroundColor: colors.danger + '1a',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: space.md,
-  },
-  errTitle: { color: colors.text, fontSize: font.size.lg, fontWeight: '700' },
-  errMsg: {
-    color: colors.textMuted,
-    fontSize: font.size.sm,
-    textAlign: 'center',
-    marginTop: space.sm,
-    maxWidth: 300,
-    lineHeight: 20,
-  },
 });

--- a/mobile/src/screens/TaskDetailScreen.tsx
+++ b/mobile/src/screens/TaskDetailScreen.tsx
@@ -15,12 +15,23 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as Clipboard from 'expo-clipboard';
 import { getTask, getTaskOutput, killTask, sendKey, sendMessage } from '../api/client';
+import { AppEmbed } from '../components/AppEmbed';
+import { AppPickerSheet } from '../components/AppPickerSheet';
 import { Button, Loading, StatusPill } from '../components/ui';
+import { getItem, setItem } from '../store/storage';
 import type { TaskDetail } from '../api/types';
 import type { TasksStackParams } from '../navigation';
 import { parseAnsiLines } from '../util/ansi';
 import { colors, font, radius, space, statusColor } from '../theme';
 import { usePolling } from '../util/usePolling';
+
+// Last app shown in the split pane, remembered across tasks/restarts so the
+// toggle is one tap once you've picked your dev server.
+const SPLIT_APP_KEY = 'kc.splitApp';
+interface SplitApp {
+  port: number;
+  name: string;
+}
 
 // Mobile key bar: control keys you can't type into the composer. Paste pulls the
 // clipboard into the input; the rest go straight to the live tmux session.
@@ -60,6 +71,38 @@ export default function TaskDetailScreen() {
   // Only auto-follow new output while the user is pinned near the bottom —
   // force-scrolling while they read scrollback makes the log unreadable.
   const pinnedToBottom = useRef(true);
+  // Split view: watch an app run in the lower half while the task streams in
+  // the upper half. null = off. The picker chooses which app/port.
+  const [splitApp, setSplitApp] = useState<SplitApp | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  async function toggleSplit() {
+    if (splitApp) {
+      setSplitApp(null);
+      return;
+    }
+    // One-tap re-open with the remembered app; picker only on first use.
+    const saved = await getItem(SPLIT_APP_KEY);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as SplitApp;
+        if (parsed && typeof parsed.port === 'number') {
+          setSplitApp(parsed);
+          return;
+        }
+      } catch {
+        /* fall through to picker */
+      }
+    }
+    setPickerOpen(true);
+  }
+
+  function pickApp(port: number, name: string) {
+    const app = { port, name };
+    setSplitApp(app);
+    setPickerOpen(false);
+    void setItem(SPLIT_APP_KEY, JSON.stringify(app));
+  }
 
   const load = useCallback(async () => {
     try {
@@ -109,11 +152,25 @@ export default function TaskDetailScreen() {
   }, [id, load]);
 
   // Destructive action lives in the header — far from the compose/Send area at
-  // the bottom so it can't be hit by accident.
+  // the bottom so it can't be hit by accident. The split toggle sits beside it.
   useLayoutEffect(() => {
     nav.setOptions({
-      headerRight: active
-        ? () => (
+      headerRight: () => (
+        <View style={styles.headerBtns}>
+          <Pressable
+            onPress={() => void toggleSplit()}
+            hitSlop={10}
+            accessibilityRole="button"
+            accessibilityLabel={splitApp ? 'Close app pane' : 'Show an app alongside'}
+            style={styles.headerBtn}
+          >
+            <Ionicons
+              name={splitApp ? 'contract-outline' : 'browsers-outline'}
+              size={22}
+              color={splitApp ? colors.accent : colors.text}
+            />
+          </Pressable>
+          {active ? (
             <Pressable
               onPress={promptKill}
               hitSlop={10}
@@ -123,10 +180,12 @@ export default function TaskDetailScreen() {
             >
               <Ionicons name="stop-circle-outline" size={24} color={colors.danger} />
             </Pressable>
-          )
-        : undefined,
+          ) : null}
+        </View>
+      ),
     });
-  }, [nav, active, promptKill]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nav, active, promptKill, splitApp]);
 
   async function send() {
     if (!msg.trim()) return;
@@ -156,6 +215,9 @@ export default function TaskDetailScreen() {
         style={{ flex: 1 }}
         keyboardVerticalOffset={90}
       >
+        {/* Top pane: the task itself. With the split open it takes half the
+            screen; the app pane below takes the other half. */}
+        <View style={{ flex: 1 }}>
         <View style={styles.head}>
           <View style={styles.headTop}>
             <StatusPill status={task.status} />
@@ -249,6 +311,44 @@ export default function TaskDetailScreen() {
             <Text style={styles.finishedText}>{note.text}</Text>
           </View>
         )}
+        </View>
+
+        {splitApp ? (
+          <View style={styles.appPane}>
+            <View style={styles.paneBar}>
+              <Ionicons name="globe-outline" size={14} color={colors.accent} />
+              <Text style={styles.paneTitle} numberOfLines={1}>
+                {splitApp.name}
+                <Text style={styles.panePort}>  :{splitApp.port}</Text>
+              </Text>
+              <Pressable
+                onPress={() => setPickerOpen(true)}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="Change app"
+                style={styles.paneBtn}
+              >
+                <Ionicons name="swap-horizontal" size={16} color={colors.textMuted} />
+              </Pressable>
+              <Pressable
+                onPress={() => setSplitApp(null)}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="Close app pane"
+                style={styles.paneBtn}
+              >
+                <Ionicons name="close" size={16} color={colors.textMuted} />
+              </Pressable>
+            </View>
+            <AppEmbed compact port={splitApp.port} name={splitApp.name} />
+          </View>
+        ) : null}
+
+        <AppPickerSheet
+          visible={pickerOpen}
+          onPick={pickApp}
+          onClose={() => setPickerOpen(false)}
+        />
       </KeyboardAvoidingView>
     </SafeAreaView>
   );
@@ -256,7 +356,24 @@ export default function TaskDetailScreen() {
 
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: colors.bg },
+  headerBtns: { flexDirection: 'row', alignItems: 'center' },
   headerBtn: { paddingHorizontal: space.sm, paddingVertical: 2 },
+  // Split view: the app pane mirrors the top pane's flex so the screen splits
+  // 50/50, with a slim toolbar naming the app + change/close actions.
+  appPane: { flex: 1, borderTopWidth: 2, borderTopColor: colors.borderStrong },
+  paneBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: space.sm,
+    paddingHorizontal: space.md,
+    paddingVertical: 6,
+    backgroundColor: colors.bgElevated,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  paneTitle: { flex: 1, color: colors.text, fontSize: font.size.sm, fontWeight: '700' },
+  panePort: { color: colors.textFaint, fontWeight: '400', fontFamily: font.mono },
+  paneBtn: { padding: 4 },
   head: { padding: space.lg, gap: space.sm, borderBottomWidth: 1, borderBottomColor: colors.border },
   headTop: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
   id: { color: colors.textFaint, fontSize: font.size.sm, fontFamily: font.mono },

--- a/mobile/src/screens/TasksScreen.tsx
+++ b/mobile/src/screens/TasksScreen.tsx
@@ -2,8 +2,8 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { LinearGradient } from 'expo-linear-gradient';
-import React, { useCallback, useState } from 'react';
-import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import React, { useCallback, useMemo, useState } from 'react';
+import { FlatList, Pressable, RefreshControl, StyleSheet, Text, TextInput, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { listTasks } from '../api/client';
 import { Card, EmptyState, ErrorBanner, Loading, ScreenHeader, StatusPill } from '../components/ui';
@@ -24,11 +24,20 @@ function hostLabel(): string {
   }
 }
 
+/** Active = needs attention now; everything else is history. */
+const isActive = (t: TaskSummary) => t.status === 'running' || t.status === 'waiting';
+
+type Segment = 'active' | 'done';
+
 export default function TasksScreen() {
   const nav = useNavigation<TasksNav>();
   const [tasks, setTasks] = useState<TaskSummary[] | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Default to Active: the everyday view is "what's running right now" —
+  // finished tasks live behind the Done segment instead of cluttering it.
+  const [segment, setSegment] = useState<Segment>('active');
+  const [query, setQuery] = useState('');
 
   const load = useCallback(async () => {
     try {
@@ -50,7 +59,18 @@ export default function TasksScreen() {
     setRefreshing(false);
   };
 
-  const running = tasks?.filter((t) => t.status === 'running' || t.status === 'waiting').length ?? 0;
+  const running = tasks?.filter(isActive).length ?? 0;
+  const doneCount = (tasks?.length ?? 0) - running;
+
+  const q = query.trim().toLowerCase();
+  const visible = useMemo(() => {
+    if (!tasks) return null;
+    return tasks.filter((t) => {
+      if (segment === 'active' ? !isActive(t) : isActive(t)) return false;
+      if (!q) return true;
+      return `${t.prompt} ${t.assistant ?? ''} ${t.workdir ?? ''}`.toLowerCase().includes(q);
+    });
+  }, [tasks, segment, q]);
 
   return (
     <SafeAreaView style={styles.safe} edges={['top']}>
@@ -75,6 +95,48 @@ export default function TasksScreen() {
 
       {error && tasks !== null && tasks.length > 0 ? <ErrorBanner message={error} /> : null}
 
+      {tasks !== null && tasks.length > 0 ? (
+        <View style={styles.filters}>
+          <View style={styles.searchWrap}>
+            <Ionicons name="search" size={16} color={colors.textFaint} />
+            <TextInput
+              value={query}
+              onChangeText={setQuery}
+              placeholder="Search tasks…"
+              placeholderTextColor={colors.textFaint}
+              autoCapitalize="none"
+              autoCorrect={false}
+              style={styles.search}
+            />
+            {query ? (
+              <Pressable onPress={() => setQuery('')} hitSlop={10}>
+                <Ionicons name="close-circle" size={16} color={colors.textFaint} />
+              </Pressable>
+            ) : null}
+          </View>
+          <View style={styles.segments} accessibilityRole="tablist">
+            {(
+              [
+                ['active', `Active${running ? ` ${running}` : ''}`],
+                ['done', `Done${doneCount ? ` ${doneCount}` : ''}`],
+              ] as [Segment, string][]
+            ).map(([key, label]) => (
+              <Pressable
+                key={key}
+                onPress={() => setSegment(key)}
+                accessibilityRole="tab"
+                accessibilityState={{ selected: segment === key }}
+                style={[styles.segment, segment === key && styles.segmentOn]}
+              >
+                <Text style={[styles.segmentText, segment === key && styles.segmentTextOn]}>
+                  {label}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      ) : null}
+
       {tasks === null ? (
         <Loading label="Loading tasks…" />
       ) : tasks.length === 0 ? (
@@ -87,12 +149,30 @@ export default function TasksScreen() {
             subtitle="Tap New to start a Claude task on your workspace — it runs remotely and you can follow along here."
           />
         )
+      ) : visible && visible.length === 0 ? (
+        q ? (
+          <EmptyState icon="search-outline" title="No matches" subtitle={`Nothing in ${segment === 'active' ? 'Active' : 'Done'} matches “${query.trim()}”.`} />
+        ) : segment === 'active' ? (
+          <EmptyState
+            icon="cafe-outline"
+            title="Nothing running"
+            subtitle={
+              doneCount
+                ? `All quiet. ${doneCount} finished ${doneCount === 1 ? 'task is' : 'tasks are'} under Done — or tap New to start something.`
+                : 'Tap New to start a Claude task on your workspace.'
+            }
+          />
+        ) : (
+          <EmptyState icon="checkmark-done-outline" title="No finished tasks" subtitle="Tasks that complete, error, or get killed land here." />
+        )
       ) : (
         <FlatList
-          data={tasks}
+          data={visible}
           keyExtractor={(t) => t.id}
           contentContainerStyle={styles.list}
           showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
           refreshControl={
             <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.accent} />
           }
@@ -142,6 +222,37 @@ const styles = StyleSheet.create({
   },
   newBtnText: { color: colors.accentText, fontWeight: '700', fontSize: font.size.sm },
   list: { paddingHorizontal: space.lg, paddingBottom: space.xl, gap: space.md },
+  filters: { paddingHorizontal: space.lg, paddingBottom: space.md, gap: space.sm },
+  searchWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: space.sm,
+    paddingHorizontal: space.md,
+    height: 40,
+    backgroundColor: colors.bgElevated,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  search: { flex: 1, color: colors.text, fontSize: font.size.md, padding: 0 },
+  segments: {
+    flexDirection: 'row',
+    backgroundColor: colors.bgElevated,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 3,
+    gap: 3,
+  },
+  segment: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: 7,
+    borderRadius: radius.sm,
+  },
+  segmentOn: { backgroundColor: colors.card, borderWidth: 1, borderColor: colors.borderStrong },
+  segmentText: { color: colors.textMuted, fontSize: font.size.sm, fontWeight: '600' },
+  segmentTextOn: { color: colors.text, fontWeight: '700' },
   taskCard: { gap: space.md },
   taskTop: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
   time: { color: colors.textFaint, fontSize: font.size.xs },


### PR DESCRIPTION
## Split-pane mode
A **browsers icon** in the task-detail header splits the screen 50/50: the task (header, live output, composer) on top, a **workspace app running in a WebView** below — watch the app change while the assistant works on it.

- **App choice is configurable**: a bottom-sheet picker lists the running apps (from `/api/apps`) and accepts any custom port. The choice persists (AsyncStorage), so after the first pick the split toggles on with one tap.
- The pane has a slim toolbar: app name + port, **swap app**, **close**.
- The WebView embed was extracted from `AppViewScreen` into a reusable `AppEmbed` component (session-cookie bootstrap, loading pill, retryable error state) — both the full-screen Apps tab and the split pane use the same battle-tested embed.

## Task list cleanup
- **Search bar** — matches prompt, assistant, and workdir (same pattern as the Memory tab).
- **Active | Done segments with counts** — defaults to **Active** (running + waiting), so finished/errored/killed tasks no longer clutter the everyday view; they're one tap away under Done.
- Segment-aware empty states ("Nothing running — N finished tasks are under Done", etc.).

## Tests
Mobile `tsc --noEmit` clean. JS-only (no new native modules) — reaches existing builds via the normal update path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)