### PR TITLE
feat(mobile): Desktop tab — the web dashboard's launcher grid, same config

### DIFF
--- a/charts/workspace/templates/ingress-claude-api.yaml
+++ b/charts/workspace/templates/ingress-claude-api.yaml
@@ -59,7 +59,7 @@ spec:
       # surface (list + reverse proxy + the WebView session bootstrap under
       # api/claude/) — the app proxy accepts a Bearer token or the scoped
       # kc_app_session cookie it mints (see server.py check_app_proxy_auth).
-      - path: /(api/claude/.*|api/memory.*|api/apps|api/app-proxy/.*|metrics|health)
+      - path: /(api/claude/.*|api/memory.*|api/apps|api/app-proxy/.*|api/desktop.*|metrics|health)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -21,6 +21,7 @@ import TaskDetailScreen from './src/screens/TaskDetailScreen';
 import NewTaskScreen from './src/screens/NewTaskScreen';
 import AppsScreen from './src/screens/AppsScreen';
 import AppViewScreen from './src/screens/AppViewScreen';
+import DesktopScreen from './src/screens/DesktopScreen';
 import MemoryScreen from './src/screens/MemoryScreen';
 import MetricsScreen from './src/screens/MetricsScreen';
 import SettingsScreen from './src/screens/SettingsScreen';
@@ -78,6 +79,7 @@ const Tab = createBottomTabNavigator();
 
 const TAB_ICONS: Record<string, [keyof typeof Ionicons.glyphMap, keyof typeof Ionicons.glyphMap]> = {
   Tasks: ['layers-outline', 'layers'],
+  Desktop: ['grid-outline', 'grid'],
   Apps: ['globe-outline', 'globe'],
   Memory: ['bookmark-outline', 'bookmark'],
   Metrics: ['stats-chart-outline', 'stats-chart'],
@@ -100,6 +102,7 @@ function MainTabs() {
       })}
     >
       <Tab.Screen name="Tasks" component={TasksStack} />
+      <Tab.Screen name="Desktop" component={DesktopScreen} />
       <Tab.Screen name="Apps" component={AppsStack} />
       <Tab.Screen name="Memory" component={MemoryScreen} />
       <Tab.Screen name="Metrics" component={MetricsScreen} />

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -16,13 +16,24 @@
 import { getConfig } from '../store/config';
 import {
   mockApps,
+  mockDesktop,
   mockHealth,
   mockMemory,
   mockMetrics,
   mockTaskDetail,
   mockTasks,
 } from '../mock/mockData';
-import type { AppEntry, Health, MemoryRecord, Metrics, TaskDetail, TaskSummary } from './types';
+import type {
+  AppEntry,
+  DesktopItem,
+  DesktopItemDraft,
+  Health,
+  LaunchResult,
+  MemoryRecord,
+  Metrics,
+  TaskDetail,
+  TaskSummary,
+} from './types';
 
 export class ApiError extends Error {
   status: number;
@@ -241,6 +252,83 @@ function normalizeMemory(m: RawMemory): MemoryRecord {
   return { ...m, tags };
 }
 
+// ---- Desktop launcher --------------------------------------------------------
+
+export async function listDesktop(): Promise<DesktopItem[]> {
+  if (getConfig().mock) {
+    await delay(120);
+    return [...mockDesktop];
+  }
+  const data = await request<{ items?: DesktopItem[] }>('/api/desktop');
+  return data.items ?? [];
+}
+
+export async function createDesktopItem(draft: DesktopItemDraft): Promise<DesktopItem> {
+  if (getConfig().mock) {
+    await delay(120);
+    const item: DesktopItem = { ...draft, id: Math.random().toString(36).slice(2, 10) };
+    mockDesktop.push(item);
+    return item;
+  }
+  return request<DesktopItem>('/api/desktop', { method: 'POST', body: draft });
+}
+
+export async function updateDesktopItem(id: string, draft: DesktopItemDraft): Promise<DesktopItem> {
+  if (getConfig().mock) {
+    await delay(120);
+    const i = mockDesktop.findIndex((d) => d.id === id);
+    const item: DesktopItem = { ...draft, id };
+    if (i >= 0) mockDesktop[i] = item;
+    return item;
+  }
+  return request<DesktopItem>(`/api/desktop/${id}`, { method: 'POST', body: draft });
+}
+
+export async function deleteDesktopItem(id: string): Promise<void> {
+  if (getConfig().mock) {
+    await delay(100);
+    const i = mockDesktop.findIndex((d) => d.id === id);
+    if (i >= 0) mockDesktop.splice(i, 1);
+    return;
+  }
+  await request(`/api/desktop/${id}`, { method: 'DELETE' });
+}
+
+export async function reorderDesktop(orderedIds: string[]): Promise<DesktopItem[]> {
+  if (getConfig().mock) {
+    await delay(100);
+    mockDesktop.sort((a, b) => orderedIds.indexOf(a.id) - orderedIds.indexOf(b.id));
+    return [...mockDesktop];
+  }
+  const data = await request<{ items?: DesktopItem[] }>('/api/desktop/_reorder', {
+    method: 'POST',
+    body: { order: orderedIds },
+  });
+  return data.items ?? [];
+}
+
+/** Run a task/shell icon server-side (url icons open client-side, same as web). */
+export async function launchDesktopItem(id: string): Promise<LaunchResult> {
+  if (getConfig().mock) {
+    await delay(200);
+    const item = mockDesktop.find((d) => d.id === id);
+    if (item?.action.type === 'shell') {
+      return { kind: 'shell', exit_code: 0, stdout: 'ok\n', stderr: '' };
+    }
+    const t: TaskSummary = {
+      id: Math.random().toString(36).slice(2, 8),
+      prompt: item?.action.type === 'task' ? item.action.prompt : 'demo task',
+      status: 'running',
+      assistant: 'claude',
+      workdir: '/home/dev',
+      created_at: Math.floor(Date.now() / 1000),
+    };
+    mockTasks.unshift(t);
+    return { kind: 'task', task_id: t.id };
+  }
+  return request<LaunchResult>(`/api/desktop/${id}/launch`, { method: 'POST', body: {} });
+}
+
 // ---- Applications ------------------------------------------------------------
 
 /** Apps running in the workspace (auto-discovered listeners + pins). */
@@ -284,6 +372,13 @@ export function appProxyUrl(port: number): string {
  *  /oauth/* unauthenticated). */
 export function appBrowserUrl(port: number): string {
   return `${getConfig().host.replace(/\/+$/, '')}/oauth/api/app-proxy/${port}/`;
+}
+
+/** Browser URL for a workspace dashboard route ('/tasks', '/settings', …) —
+ *  the oauth-authenticated SPA. Used by Desktop url-icons that store the web
+ *  dashboard's relative routes. */
+export function dashboardUrl(route: string): string {
+  return `${getConfig().host.replace(/\/+$/, '')}/oauth${route.startsWith('/') ? route : `/${route}`}`;
 }
 
 // ---- Metrics / health ------------------------------------------------------

--- a/mobile/src/api/types.ts
+++ b/mobile/src/api/types.ts
@@ -40,6 +40,44 @@ export interface Health {
   ok?: boolean;
 }
 
+/** Desktop launcher (mirrors /api/desktop — the web dashboard's Desktop tab). */
+export type DesktopActionType = 'task' | 'url' | 'shell';
+
+export interface DesktopActionTask {
+  type: 'task';
+  prompt: string;
+  workdir?: string;
+  assistant?: string;
+}
+export interface DesktopActionUrl {
+  type: 'url';
+  url: string;
+  target: 'blank' | 'self';
+}
+export interface DesktopActionShell {
+  type: 'shell';
+  command: string;
+  timeout?: number;
+}
+export type DesktopAction = DesktopActionTask | DesktopActionUrl | DesktopActionShell;
+
+export interface DesktopItem {
+  id: string;
+  label: string;
+  /** Emoji/text, or "icon:NAME" for a named line icon. */
+  icon: string;
+  /** Web-only keyboard shortcut; preserved (not editable) on mobile. */
+  hotkey?: string;
+  action: DesktopAction;
+}
+
+export type DesktopItemDraft = Omit<DesktopItem, 'id'>;
+
+export type LaunchResult =
+  | { kind: 'task'; task_id: string }
+  | { kind: 'shell'; exit_code: number; stdout: string; stderr: string }
+  | { kind: 'url'; url: string; target: 'blank' | 'self' };
+
 /** One entry on the Applications tab (mirrors /api/apps). */
 export interface AppEntry {
   port: number;

--- a/mobile/src/components/DesktopEditorSheet.tsx
+++ b/mobile/src/components/DesktopEditorSheet.tsx
@@ -1,0 +1,278 @@
+/** Bottom-sheet editor for a Desktop icon — mirrors the web dashboard's
+ *  DesktopEditor: label + icon (emoji or "icon:NAME") + one action of type
+ *  task / url / shell. Hotkeys are a web-keyboard concept, so mobile preserves
+ *  an existing hotkey untouched rather than editing it. */
+import React, { useEffect, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import type { DesktopAction, DesktopActionType, DesktopItem, DesktopItemDraft } from '../api/types';
+import { colors, font, radius, space } from '../theme';
+import { Button, Label } from './ui';
+
+const ACTION_TYPES: { key: DesktopActionType; label: string; hint: string }[] = [
+  { key: 'task', label: 'Task', hint: 'Start an assistant task' },
+  { key: 'url', label: 'URL', hint: 'Open a link' },
+  { key: 'shell', label: 'Shell', hint: 'Run a command' },
+];
+
+export function DesktopEditorSheet({
+  visible,
+  initial,
+  onSave,
+  onClose,
+}: {
+  visible: boolean;
+  /** Existing item to edit, or null for a new icon. */
+  initial: DesktopItem | null;
+  onSave: (draft: DesktopItemDraft) => Promise<string | null>; // -> error message or null
+  onClose: () => void;
+}) {
+  const [label, setLabel] = useState('');
+  const [icon, setIcon] = useState('✨');
+  const [type, setType] = useState<DesktopActionType>('task');
+  const [prompt, setPrompt] = useState('');
+  const [workdir, setWorkdir] = useState('/home/dev');
+  const [url, setUrl] = useState('');
+  const [command, setCommand] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-seed the form whenever the sheet opens for a different item.
+  useEffect(() => {
+    if (!visible) return;
+    setError(null);
+    setLabel(initial?.label ?? '');
+    setIcon(initial?.icon ?? '✨');
+    const a = initial?.action;
+    setType(a?.type ?? 'task');
+    setPrompt(a?.type === 'task' ? a.prompt : '');
+    setWorkdir(a?.type === 'task' ? a.workdir ?? '/home/dev' : '/home/dev');
+    setUrl(a?.type === 'url' ? a.url : '');
+    setCommand(a?.type === 'shell' ? a.command : '');
+  }, [visible, initial]);
+
+  function buildAction(): DesktopAction | null {
+    if (type === 'task') {
+      if (!prompt.trim()) return null;
+      return { type: 'task', prompt: prompt.trim(), workdir: workdir.trim() || undefined };
+    }
+    if (type === 'url') {
+      if (!/^https?:\/\//.test(url.trim())) return null;
+      return { type: 'url', url: url.trim(), target: 'blank' };
+    }
+    if (!command.trim()) return null;
+    return { type: 'shell', command: command.trim() };
+  }
+
+  const action = buildAction();
+  const valid = !!label.trim() && !!icon.trim() && !!action;
+
+  async function save() {
+    if (!valid || !action) return;
+    setBusy(true);
+    setError(null);
+    const err = await onSave({
+      label: label.trim(),
+      icon: icon.trim(),
+      // Hotkeys only fire on web; keep whatever is set rather than dropping it.
+      hotkey: initial?.hotkey,
+      action,
+    });
+    setBusy(false);
+    if (err) setError(err);
+  }
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.backdropWrap}
+      >
+        <Pressable style={styles.backdrop} onPress={onClose} />
+        <View style={styles.sheet}>
+          <View style={styles.grabber} />
+          <Text style={styles.title}>{initial ? 'Edit icon' : 'New icon'}</Text>
+          <ScrollView
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={{ gap: space.md }}
+          >
+            <View style={styles.rowTwo}>
+              <View style={{ flex: 1 }}>
+                <Label>Label</Label>
+                <TextInput
+                  value={label}
+                  onChangeText={setLabel}
+                  placeholder="Run tests"
+                  placeholderTextColor={colors.textFaint}
+                  style={styles.input}
+                />
+              </View>
+              <View style={{ width: 96 }}>
+                <Label>Icon</Label>
+                <TextInput
+                  value={icon}
+                  onChangeText={setIcon}
+                  placeholder="✨"
+                  placeholderTextColor={colors.textFaint}
+                  autoCapitalize="none"
+                  style={[styles.input, { textAlign: 'center' }]}
+                />
+              </View>
+            </View>
+            <Text style={styles.hint}>Any emoji, or icon:NAME for a line icon (icon:terminal, icon:chat…)</Text>
+
+            <Label style={{ marginTop: space.sm }}>Action</Label>
+            <View style={styles.chips}>
+              {ACTION_TYPES.map((a) => (
+                <Pressable
+                  key={a.key}
+                  onPress={() => setType(a.key)}
+                  style={[styles.chip, type === a.key && styles.chipActive]}
+                >
+                  <Text style={[styles.chipText, type === a.key && styles.chipTextActive]}>
+                    {a.label}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+            <Text style={styles.hint}>{ACTION_TYPES.find((a) => a.key === type)?.hint}</Text>
+
+            {type === 'task' ? (
+              <>
+                <Label>Prompt</Label>
+                <TextInput
+                  value={prompt}
+                  onChangeText={setPrompt}
+                  placeholder="Describe the task…"
+                  placeholderTextColor={colors.textFaint}
+                  multiline
+                  style={[styles.input, styles.multiline]}
+                />
+                <Label style={{ marginTop: space.sm }}>Working directory</Label>
+                <TextInput
+                  value={workdir}
+                  onChangeText={setWorkdir}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  style={[styles.input, { fontFamily: font.mono }]}
+                />
+              </>
+            ) : type === 'url' ? (
+              <>
+                <Label>URL</Label>
+                <TextInput
+                  value={url}
+                  onChangeText={setUrl}
+                  placeholder="https://…"
+                  placeholderTextColor={colors.textFaint}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  keyboardType="url"
+                  style={styles.input}
+                />
+              </>
+            ) : (
+              <>
+                <Label>Command</Label>
+                <TextInput
+                  value={command}
+                  onChangeText={setCommand}
+                  placeholder="make test"
+                  placeholderTextColor={colors.textFaint}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  multiline
+                  style={[styles.input, styles.multiline, { fontFamily: font.mono }]}
+                />
+              </>
+            )}
+
+            {error ? (
+              <Text style={styles.error} accessibilityRole="alert">
+                {error}
+              </Text>
+            ) : null}
+
+            <View style={styles.btnRow}>
+              <Button title="Cancel" variant="secondary" onPress={onClose} style={{ flex: 1 }} />
+              <Button
+                title={initial ? 'Save' : 'Create'}
+                onPress={() => void save()}
+                loading={busy}
+                disabled={!valid}
+                style={{ flex: 1 }}
+              />
+            </View>
+          </ScrollView>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdropWrap: { flex: 1, justifyContent: 'flex-end' },
+  backdrop: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: '#000a',
+  },
+  sheet: {
+    maxHeight: '88%',
+    backgroundColor: colors.bgElevated,
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: space.xl,
+    paddingBottom: space.xxl,
+  },
+  grabber: {
+    alignSelf: 'center',
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colors.borderStrong,
+    marginBottom: space.md,
+  },
+  title: { color: colors.text, fontSize: font.size.lg, fontWeight: '800', marginBottom: space.md },
+  rowTwo: { flexDirection: 'row', gap: space.md },
+  input: {
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    color: colors.text,
+    fontSize: font.size.md,
+    paddingHorizontal: space.md,
+    height: 46,
+  },
+  multiline: { height: undefined, minHeight: 80, paddingTop: space.md, textAlignVertical: 'top' },
+  hint: { color: colors.textFaint, fontSize: font.size.xs, lineHeight: 16 },
+  chips: { flexDirection: 'row', gap: space.sm },
+  chip: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.pill,
+    paddingHorizontal: space.lg,
+    paddingVertical: space.sm,
+  },
+  chipActive: { backgroundColor: colors.accent + '22', borderColor: colors.accent },
+  chipText: { color: colors.textMuted, fontSize: font.size.sm, fontWeight: '500' },
+  chipTextActive: { color: colors.accent, fontWeight: '700' },
+  error: { color: colors.danger, fontSize: font.size.sm },
+  btnRow: { flexDirection: 'row', gap: space.md, marginTop: space.md },
+});

--- a/mobile/src/mock/mockData.ts
+++ b/mobile/src/mock/mockData.ts
@@ -6,7 +6,15 @@
  * Timestamps are offsets from load time so the relative labels ("90s ago",
  * "1h ago") read realistically whenever screenshots are regenerated.
  */
-import type { AppEntry, Health, MemoryRecord, Metrics, TaskDetail, TaskSummary } from '../api/types';
+import type {
+  AppEntry,
+  DesktopItem,
+  Health,
+  MemoryRecord,
+  Metrics,
+  TaskDetail,
+  TaskSummary,
+} from '../api/types';
 
 const NOW = Math.floor(Date.now() / 1000);
 
@@ -164,6 +172,28 @@ export const mockHealth: Health = {
   browser: false,
   ok: true,
 };
+
+export const mockDesktop: DesktopItem[] = [
+  {
+    id: 'seed-build',
+    label: 'Fix flaky test',
+    icon: 'icon:chat',
+    action: { type: 'task', prompt: 'Find and fix the flaky integration test', workdir: '/home/dev/kube-coder' },
+  },
+  {
+    id: 'seed-store',
+    label: 'Storefront',
+    icon: '🛍️',
+    action: { type: 'url', url: 'https://demo-public.dev.scalebase.io', target: 'blank' },
+  },
+  {
+    id: 'seed-tests',
+    label: 'Run tests',
+    icon: 'icon:terminal',
+    hotkey: 'cmd+shift+t',
+    action: { type: 'shell', command: 'cd ~/kube-coder && make python-tests' },
+  },
+];
 
 export const mockApps: AppEntry[] = [
   {

--- a/mobile/src/screens/DesktopScreen.tsx
+++ b/mobile/src/screens/DesktopScreen.tsx
@@ -1,0 +1,308 @@
+/** Desktop: the same customizable launcher grid as the web dashboard's
+ *  Desktop tab, backed by the same /api/desktop config (desktop.json on the
+ *  workspace PVC) — icons that start a task, open a URL, or run a shell
+ *  command. Tap to launch; long-press to edit/move/delete; + to add. */
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import React, { useCallback, useState } from 'react';
+import {
+  Alert,
+  FlatList,
+  Linking,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  createDesktopItem,
+  dashboardUrl,
+  deleteDesktopItem,
+  launchDesktopItem,
+  listDesktop,
+  reorderDesktop,
+  updateDesktopItem,
+} from '../api/client';
+import { DesktopEditorSheet } from '../components/DesktopEditorSheet';
+import { EmptyState, ErrorBanner, Loading, ScreenHeader } from '../components/ui';
+import type { DesktopItem, DesktopItemDraft } from '../api/types';
+import { colors, font, radius, shadow, space } from '../theme';
+import { usePolling } from '../util/usePolling';
+
+// The server stores "icon:NAME" for the web SPA's line-icon set; map the
+// common names onto Ionicons equivalents so both clients render the same
+// config. Unknown names fall back to a generic glyph, and anything without
+// the prefix renders as literal text (emoji).
+const ICON_MAP: Record<string, keyof typeof Ionicons.glyphMap> = {
+  chat: 'chatbubbles-outline',
+  tasks: 'layers-outline',
+  memory: 'bookmark-outline',
+  settings: 'settings-outline',
+  terminal: 'terminal-outline',
+  globe: 'globe-outline',
+  url: 'globe-outline',
+  docs: 'document-text-outline',
+  files: 'folder-outline',
+  metrics: 'stats-chart-outline',
+  apps: 'grid-outline',
+  play: 'play-outline',
+  build: 'construct-outline',
+};
+
+function ItemIcon({ icon }: { icon: string }) {
+  if (icon.startsWith('icon:')) {
+    const name = ICON_MAP[icon.slice(5)] ?? 'apps-outline';
+    return <Ionicons name={name} size={26} color={colors.accent} />;
+  }
+  return <Text style={styles.cellEmoji}>{icon}</Text>;
+}
+
+function actionSubtitle(item: DesktopItem): string {
+  const a = item.action;
+  if (a.type === 'task') return a.prompt;
+  if (a.type === 'url') return a.url.replace(/^https?:\/\//, '');
+  return a.command;
+}
+
+export default function DesktopScreen() {
+  // Cross-tab navigation (launched tasks open in the Tasks stack).
+  const nav = useNavigation<{ navigate: (tab: string, opts?: object) => void }>();
+  const [items, setItems] = useState<DesktopItem[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editing, setEditing] = useState<DesktopItem | null>(null);
+  const [launching, setLaunching] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setItems(await listDesktop());
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+      setItems((prev) => prev ?? []);
+    }
+  }, []);
+
+  // The desktop is shared with the web dashboard — pick up edits made there.
+  usePolling(load, 15000);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await load();
+    setRefreshing(false);
+  };
+
+  async function launch(item: DesktopItem) {
+    // URL icons open directly, same as the web (no server roundtrip). Relative
+    // URLs are dashboard routes (the web seeds '/tasks', '/settings', …) —
+    // resolve them against the workspace's oauth-authenticated dashboard.
+    if (item.action.type === 'url') {
+      const u = item.action.url;
+      void Linking.openURL(u.startsWith('/') ? dashboardUrl(u) : u);
+      return;
+    }
+    setLaunching(item.id);
+    try {
+      const r = await launchDesktopItem(item.id);
+      if (r.kind === 'task') {
+        nav.navigate('Tasks', { screen: 'TaskDetail', params: { id: r.task_id } });
+      } else if (r.kind === 'shell') {
+        const ok = r.exit_code === 0;
+        const tail = (ok ? r.stdout : r.stderr || r.stdout).trim().split('\n').slice(-6).join('\n');
+        Alert.alert(
+          ok ? `${item.label} — exit 0` : `${item.label} — exit ${r.exit_code}`,
+          tail || '(no output)',
+        );
+      }
+    } catch (e) {
+      Alert.alert(`Couldn't launch ${item.label}`, (e as Error).message);
+    } finally {
+      setLaunching(null);
+    }
+  }
+
+  function itemMenu(item: DesktopItem) {
+    if (!items) return;
+    const idx = items.findIndex((i) => i.id === item.id);
+    Alert.alert(item.label, actionSubtitle(item), [
+      { text: 'Edit', onPress: () => { setEditing(item); setEditorOpen(true); } },
+      ...(idx > 0
+        ? [{ text: 'Move up', onPress: () => void move(item.id, -1) }]
+        : []),
+      ...(idx >= 0 && idx < items.length - 1
+        ? [{ text: 'Move down', onPress: () => void move(item.id, 1) }]
+        : []),
+      {
+        text: 'Delete',
+        style: 'destructive' as const,
+        onPress: () =>
+          Alert.alert('Delete icon?', `Remove "${item.label}"? You can re-create it any time.`, [
+            { text: 'Cancel', style: 'cancel' },
+            { text: 'Delete', style: 'destructive', onPress: () => void remove(item.id) },
+          ]),
+      },
+      { text: 'Cancel', style: 'cancel' },
+    ]);
+  }
+
+  async function move(id: string, dir: -1 | 1) {
+    if (!items) return;
+    const order = items.map((i) => i.id);
+    const idx = order.indexOf(id);
+    const to = idx + dir;
+    if (idx < 0 || to < 0 || to >= order.length) return;
+    [order[idx], order[to]] = [order[to], order[idx]];
+    try {
+      setItems(await reorderDesktop(order));
+    } catch (e) {
+      Alert.alert("Couldn't reorder", (e as Error).message);
+    }
+  }
+
+  async function remove(id: string) {
+    try {
+      await deleteDesktopItem(id);
+      await load();
+    } catch (e) {
+      Alert.alert("Couldn't delete", (e as Error).message);
+    }
+  }
+
+  async function save(draft: DesktopItemDraft): Promise<string | null> {
+    try {
+      if (editing) await updateDesktopItem(editing.id, draft);
+      else await createDesktopItem(draft);
+      setEditorOpen(false);
+      setEditing(null);
+      await load();
+      return null;
+    } catch (e) {
+      return (e as Error).message;
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      <ScreenHeader
+        title="Desktop"
+        subtitle="One-tap launchers, shared with the web dashboard"
+        right={
+          <Pressable
+            onPress={() => { setEditing(null); setEditorOpen(true); }}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel="New icon"
+            style={styles.addBtn}
+          >
+            <Ionicons name="add" size={22} color={colors.accent} />
+          </Pressable>
+        }
+      />
+
+      {error && items !== null && items.length > 0 ? <ErrorBanner message={error} /> : null}
+
+      {items === null ? (
+        <Loading label="Loading desktop…" />
+      ) : items.length === 0 ? (
+        error ? (
+          <EmptyState icon="cloud-offline-outline" title="Couldn't load the desktop" subtitle={error} />
+        ) : (
+          <EmptyState
+            icon="grid-outline"
+            title="No icons yet"
+            subtitle="Pin a build prompt, a URL, or a shell command for one-tap launch. Tap + to create your first icon."
+          />
+        )
+      ) : (
+        <FlatList
+          data={items}
+          key="grid-3"
+          numColumns={3}
+          keyExtractor={(i) => i.id}
+          contentContainerStyle={styles.grid}
+          columnWrapperStyle={styles.gridRow}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.accent} />
+          }
+          renderItem={({ item }) => (
+            <Pressable
+              style={({ pressed }) => [styles.cell, pressed && styles.cellPressed]}
+              onPress={() => void launch(item)}
+              onLongPress={() => itemMenu(item)}
+              delayLongPress={350}
+              accessibilityRole="button"
+              accessibilityLabel={`Launch ${item.label}`}
+              accessibilityHint="Long press for edit, move and delete"
+            >
+              <View style={styles.cellIcon}>
+                {launching === item.id ? (
+                  <Ionicons name="hourglass-outline" size={26} color={colors.textMuted} />
+                ) : (
+                  <ItemIcon icon={item.icon} />
+                )}
+              </View>
+              <Text style={styles.cellLabel} numberOfLines={1}>
+                {item.label}
+              </Text>
+              <Text style={styles.cellSub} numberOfLines={1}>
+                {actionSubtitle(item)}
+              </Text>
+            </Pressable>
+          )}
+        />
+      )}
+
+      <DesktopEditorSheet
+        visible={editorOpen}
+        initial={editing}
+        onSave={save}
+        onClose={() => { setEditorOpen(false); setEditing(null); }}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  addBtn: {
+    width: 38,
+    height: 38,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.bgElevated,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  grid: { paddingHorizontal: space.lg, paddingBottom: space.xl, gap: space.md },
+  gridRow: { gap: space.md },
+  cell: {
+    flex: 1,
+    maxWidth: '31.5%',
+    backgroundColor: colors.card,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingVertical: space.lg,
+    paddingHorizontal: space.sm,
+    alignItems: 'center',
+    gap: 6,
+    ...shadow.card,
+  },
+  cellPressed: { opacity: 0.7, transform: [{ scale: 0.97 }] },
+  cellIcon: {
+    width: 52,
+    height: 52,
+    borderRadius: radius.md,
+    backgroundColor: colors.accent + '14',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cellEmoji: { fontSize: 26 },
+  cellLabel: { color: colors.text, fontSize: font.size.sm, fontWeight: '700' },
+  cellSub: { color: colors.textFaint, fontSize: font.size.xs, maxWidth: '95%' },
+});


### PR DESCRIPTION
Replicates the web dashboard's **Desktop** on mobile, against the **same `/api/desktop` backend** (`desktop.json` on the workspace PVC) — so web and mobile show and edit one shared desktop.

## What it does
- **3-column launcher grid**, tap to launch:
  - **Task** icons start the assistant task and jump straight into its detail view (cross-tab).
  - **Shell** icons run the command and show exit code + output tail.
  - **URL** icons open the browser; web-relative dashboard routes (`/tasks`, `/settings`…) resolve to the oauth-authenticated dashboard so the seeded icons work.
- **Long-press** an icon → Edit / Move up / Move down / Delete (reorder via the same `_reorder` endpoint).
- **Bottom-sheet editor**: label, icon (emoji or `icon:NAME` — named icons map to Ionicons equivalents so both clients render the same config), action type + per-type fields. Web-only **hotkeys are preserved untouched** rather than edited on mobile.
- Polls (focused-only) so edits made on the web show up.
- The tasks-derived **DesktopBulletin is intentionally not replicated** — the mobile Tasks tab already serves that role.

## Server/chart
Desktop endpoints already accept Bearer (`check_claude_auth`); only the Bearer-ingress route was missing — added `api/desktop.*` to the path regex.

## Verified
Against live `ws-imran` (redeployed): `GET /api/desktop` via Bearer returns the same 7 icons the web dashboard shows. Mobile `tsc` clean; `helm unittest` 71 pass. JS-only on the app side — reaches existing builds via the normal update path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)