### PR TITLE
feat(mobile): real ttyd terminal in task detail + redesigned composer

### DIFF
--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -4302,9 +4302,9 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         token = ClaudeTaskManager.get_or_create_token()
         self.send_json({'token': token})
 
-    # Only ever bounce the WebView into the app proxy — anything else would be
-    # an open redirect on an authenticated endpoint.
-    _APP_SESSION_NEXT_RE = re.compile(r'^/api/app-proxy/\d+(/.*)?$')
+    # Only ever bounce the WebView into the app proxy or the terminal proxy —
+    # anything else would be an open redirect on an authenticated endpoint.
+    _APP_SESSION_NEXT_RE = re.compile(r'^/api/(app-proxy/\d+|terminal-proxy)(/.*)?$')
 
     def handle_app_session_mint(self):
         """GET /api/claude/apps/session?next=/api/app-proxy/<port>/
@@ -5792,7 +5792,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         """
         m = re.match(r'^/api/app-proxy/(\d+)(/.*)?$', claude_path)
         if not m:
-            return False
+            return self._dispatch_terminal_proxy(claude_path, method)
         port = int(m.group(1))
         upstream_path = m.group(2) or '/'
         # Preserve the original query string (stripped from claude_path
@@ -5808,7 +5808,29 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         self._proxy_app_request(port, upstream_path, method=method)
         return True
 
-    def _proxy_app_websocket(self, port, upstream_path):
+    # ttyd's in-pod port. Reserved in AppsManager.INTERNAL_PORTS (users can't
+    # pin/expose it via the generic app proxy); this dedicated route is how the
+    # mobile app embeds the live terminal, behind the same Bearer/app-session
+    # auth as the app proxy.
+    TTYD_PORT = 7681
+
+    def _dispatch_terminal_proxy(self, claude_path, method):
+        """Match /api/terminal-proxy/... and forward to ttyd (HTTP + WS)."""
+        m = re.match(r'^/api/terminal-proxy(/.*)?$', claude_path)
+        if not m:
+            return False
+        upstream_path = m.group(1) or '/'
+        qs = self.path.split('?', 1)
+        if len(qs) == 2:
+            upstream_path = upstream_path + '?' + qs[1]
+        if method == 'GET' and self.headers.get('Upgrade', '').lower() == 'websocket':
+            self._proxy_app_websocket(self.TTYD_PORT, upstream_path, allow_internal=True)
+            return True
+        self._proxy_app_request(self.TTYD_PORT, upstream_path, method=method,
+                                prefix='/api/terminal-proxy', allow_internal=True)
+        return True
+
+    def _proxy_app_websocket(self, port, upstream_path, allow_internal=False):
         """Hijack the underlying TCP socket and relay a WebSocket session
         between the client and the upstream app.
 
@@ -5818,12 +5840,16 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         the socket. We never call `self.send_response()` ourselves — the
         upstream's 101 response is relayed verbatim so the client sees the
         real Sec-WebSocket-Accept handshake.
+
+        allow_internal backs the fixed internal routes (ttyd via
+        /api/terminal-proxy): skips the is_proxyable reserved-port gate and
+        always strips the route prefix (internal upstreams serve from root).
         """
         if not self.check_app_proxy_auth():
             self.send_response(401)
             self.end_headers()
             return
-        ok, reason = AppsManager.is_proxyable(port)
+        ok, reason = (True, '') if allow_internal else AppsManager.is_proxyable(port)
         if not ok:
             self.send_response(403)
             self.send_header('Content-Type', 'text/plain; charset=utf-8')
@@ -5833,7 +5859,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
 
         # Compute the forwarded path the same way the HTTP proxy does.
         prefix = f'/api/app-proxy/{port}'
-        pin = AppsManager.get_pin(port) or {}
+        pin = {} if allow_internal else (AppsManager.get_pin(port) or {})
         keep_prefix = bool(pin.get('strip_prefix', False))
         if not keep_prefix:
             forwarded_path = upstream_path or '/'
@@ -5966,7 +5992,8 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         except Exception:
             pass
 
-    def _proxy_app_request(self, port, upstream_path, method='GET'):
+    def _proxy_app_request(self, port, upstream_path, method='GET', prefix=None,
+                           allow_internal=False):
         """Reverse-proxy a request to http://127.0.0.1:<port><upstream_path>.
 
         Streams the response body via read1+flush so SSE/chunked responses
@@ -5982,31 +6009,41 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         - pinned port with strip_prefix=False: pass the full path through
           (the Vite-style case where the dev server only matches its own
           --base prefix).
+
+        `prefix` + `allow_internal` back the fixed internal routes (the
+        /api/terminal-proxy → ttyd:7681 path the mobile app embeds): a custom
+        prefix keeps the trailing-slash normalization honest, allow_internal
+        skips the is_proxyable listener/reserved-port gate (the route is
+        pinned server-side to a workspace service, never user input), and the
+        HTML/Location rewrites are skipped — ttyd's assets are relative.
         """
         if not self.check_app_proxy_auth():
             self.send_response(401)
             self.end_headers()
             return
-        ok, reason = AppsManager.is_proxyable(port)
-        if not ok:
-            self.send_response(403)
-            self.send_header('Content-Type', 'text/plain; charset=utf-8')
-            self.end_headers()
-            self.wfile.write((reason + '\n').encode())
-            return
+        internal_route = prefix is not None
+        if not allow_internal:
+            ok, reason = AppsManager.is_proxyable(port)
+            if not ok:
+                self.send_response(403)
+                self.send_header('Content-Type', 'text/plain; charset=utf-8')
+                self.end_headers()
+                self.wfile.write((reason + '\n').encode())
+                return
+        prefix = prefix or f'/api/app-proxy/{port}'
 
         # Trailing-slash 301 so relative URLs resolve against the prefix root.
         if upstream_path in ('', '/'):
             normalized = self.path.split('?', 1)[0].replace('/oauth', '').replace('/browser', '')
-            if normalized == f'/api/app-proxy/{port}':
+            if normalized == prefix:
                 self.send_response(301)
-                self.send_header('Location', f'/api/app-proxy/{port}/')
+                self.send_header('Location', f'{prefix}/')
                 self.end_headers()
                 return
 
-        # Apply the prefix-stripping rule based on the pin's flag.
-        prefix = f'/api/app-proxy/{port}'
-        pin = AppsManager.get_pin(port) or {}
+        # Apply the prefix-stripping rule based on the pin's flag. Internal
+        # routes always strip — their upstreams serve from the root.
+        pin = {} if internal_route else (AppsManager.get_pin(port) or {})
         keep_prefix = bool(pin.get('strip_prefix', False))  # default: strip
         if not keep_prefix:
             # Strip the proxy prefix from the path we forward upstream.
@@ -6079,6 +6116,9 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             method != 'HEAD'
             and resp.status == 200
             and 'text/html' in ctype.lower()
+            # Internal routes (ttyd) serve relative assets; the rewriter
+            # would re-prefix them onto /api/app-proxy/<port> — wrong route.
+            and not internal_route
         )
         rewritten = self._rewrite_proxied_html(resp.read(), port) if rewrite_body else None
 
@@ -6114,7 +6154,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
                     if not has_script_src:
                         parts.append("script-src 'self' 'unsafe-inline'")
                     v = '; '.join(parts)
-            if kl == 'location':
+            if kl == 'location' and not internal_route:
                 v = self._rewrite_location_header(v, port)
             self.send_header(k, v)
         if rewritten is not None:

--- a/charts/workspace/templates/ingress-claude-api.yaml
+++ b/charts/workspace/templates/ingress-claude-api.yaml
@@ -59,7 +59,7 @@ spec:
       # surface (list + reverse proxy + the WebView session bootstrap under
       # api/claude/) — the app proxy accepts a Bearer token or the scoped
       # kc_app_session cookie it mints (see server.py check_app_proxy_auth).
-      - path: /(api/claude/.*|api/memory.*|api/apps|api/app-proxy/.*|api/desktop.*|metrics|health)
+      - path: /(api/claude/.*|api/memory.*|api/apps|api/app-proxy/.*|api/desktop.*|api/terminal-proxy.*|metrics|health)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/charts/workspace/tests/app_session_test.py
+++ b/charts/workspace/tests/app_session_test.py
@@ -106,9 +106,14 @@ class NextPathGuardUnit(unittest.TestCase):
                   '/api/app-proxy/3000/deep/path'):
             self.assertIsNotNone(self.RE.match(p), p)
 
+    def test_accepts_terminal_proxy_paths(self):
+        for p in ('/api/terminal-proxy', '/api/terminal-proxy/', '/api/terminal-proxy/?t=1'):
+            self.assertIsNotNone(self.RE.match(p), p)
+
     def test_rejects_everything_else(self):
         for p in ('/', '/api/claude/tasks', '//evil.com/', 'https://evil.com',
-                  '/api/app-proxy/notaport/', '', '/api/app-proxyx/1/'):
+                  '/api/app-proxy/notaport/', '', '/api/app-proxyx/1/',
+                  '/api/terminal-proxyx/', '/api/terminal-proxy-evil/'):
             self.assertIsNone(self.RE.match(p), p)
 
 

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -180,6 +180,36 @@ export async function sendKey(id: string, key: string): Promise<void> {
   await request(`/api/claude/tasks/${id}/key`, { method: 'POST', body: { key } });
 }
 
+/** Point the workspace's shared ttyd entrypoint at this task's tmux session
+ * (writes the one-shot pending file terminal-entry.sh claims). Call right
+ * before mounting the terminal WebView. session_ready=false ⇒ the tmux
+ * session is gone (finished task) and the caller should render the archived
+ * output instead. */
+export async function prepareTerminal(
+  id: string,
+): Promise<{ ok: boolean; session?: string; session_ready?: boolean }> {
+  if (getConfig().mock) {
+    await delay(80);
+    return { ok: true, session: `claude-${id}`, session_ready: false };
+  }
+  return request(`/api/claude/tasks/${id}/prepare-terminal`, { method: 'POST', body: {} });
+}
+
+/**
+ * URL + headers for embedding the live ttyd terminal in a WebView — same
+ * session-cookie bootstrap as appEmbedSource, landing on /api/terminal-proxy/
+ * (server.py's fixed proxy to ttyd:7681). Cache-busted so ttyd re-runs its
+ * entrypoint (which attaches the pending tmux session) on every mount.
+ */
+export function terminalEmbedSource(): { uri: string; headers: Record<string, string> } {
+  const { host, token } = getConfig();
+  const next = encodeURIComponent(`/api/terminal-proxy/?t=${Date.now()}`);
+  return {
+    uri: `${host.replace(/\/+$/, '')}/api/claude/apps/session?next=${next}`,
+    headers: { Authorization: `Bearer ${token}` },
+  };
+}
+
 export async function createTask(input: {
   prompt: string;
   workdir?: string;

--- a/mobile/src/components/TerminalView.tsx
+++ b/mobile/src/components/TerminalView.tsx
@@ -1,0 +1,260 @@
+/** The task-detail output surface.
+ *
+ *  Live mode renders the workspace's real ttyd terminal (xterm.js) in a
+ *  WebView — the exact same session the web dashboard shows, so Claude's TUI
+ *  renders pixel-faithfully instead of through a lossy ANSI re-implementation.
+ *  Flow: POST prepare-terminal (marks this task's tmux session as pending) →
+ *  session-cookie bootstrap → /api/terminal-proxy (server-side proxy to ttyd)
+ *  → terminal-entry.sh attaches the pending session.
+ *
+ *  When the tmux session no longer exists (finished/old tasks) there is
+ *  nothing live to attach, so it falls back to the archived output record,
+ *  rendered with the lightweight ANSI parser under an "archived" notice.
+ */
+import { Ionicons } from '@expo/vector-icons';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { WebView } from 'react-native-webview';
+import { prepareTerminal, terminalEmbedSource } from '../api/client';
+import { getConfig } from '../store/config';
+import { parseAnsiLines } from '../util/ansi';
+import { colors, font, radius, space } from '../theme';
+import { Button } from './ui';
+
+type Mode = 'connecting' | 'live' | 'archived' | 'error';
+
+export function TerminalView({ taskId, output }: { taskId: string; output: string }) {
+  const [mode, setMode] = useState<Mode>('connecting');
+  const [errMsg, setErrMsg] = useState('');
+  const [attempt, setAttempt] = useState(0);
+  const [webviewLoading, setWebviewLoading] = useState(true);
+  // Computed once per attempt: the bootstrap URL is cache-busted (ttyd re-runs
+  // its entrypoint per connection), so it must not change on re-renders or the
+  // WebView reconnects in a loop.
+  const source = useMemo(
+    () => terminalEmbedSource(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [attempt],
+  );
+
+  const connect = useCallback(async () => {
+    setMode('connecting');
+    if (getConfig().mock) {
+      setMode('archived');
+      return;
+    }
+    try {
+      const r = await prepareTerminal(taskId);
+      if (r.session_ready) {
+        setWebviewLoading(true);
+        setAttempt((a) => a + 1);
+        setMode('live');
+      } else {
+        // Session gone — finished task; the record is all there is.
+        setMode('archived');
+      }
+    } catch (e) {
+      setErrMsg((e as Error).message);
+      setMode('error');
+    }
+  }, [taskId]);
+
+  useEffect(() => {
+    void connect();
+  }, [connect]);
+
+  if (mode === 'connecting') {
+    return (
+      <View style={styles.center}>
+        <View style={styles.pill}>
+          <Text style={styles.pillText}>Attaching to session…</Text>
+        </View>
+      </View>
+    );
+  }
+
+  if (mode === 'error') {
+    return (
+      <View style={styles.center}>
+        <View style={styles.errIcon}>
+          <Ionicons name="cloud-offline-outline" size={26} color={colors.danger} />
+        </View>
+        <Text style={styles.errTitle}>Couldn't open the session</Text>
+        <Text style={styles.errMsg}>{errMsg}</Text>
+        <View style={styles.errBtns}>
+          <Button title="Try again" icon="refresh" onPress={() => void connect()} style={{ flex: 1 }} />
+          <Button
+            title="Archived output"
+            variant="secondary"
+            onPress={() => setMode('archived')}
+            style={{ flex: 1 }}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  if (mode === 'archived') {
+    return <ArchivedOutput output={output} />;
+  }
+
+  return (
+    <View style={styles.wrap}>
+      <WebView
+        key={attempt}
+        source={source}
+        style={styles.web}
+        sharedCookiesEnabled
+        thirdPartyCookiesEnabled
+        originWhitelist={['*']}
+        // The terminal owns every gesture: no rubber-banding or pull-to-refresh
+        // fighting xterm.js scrollback.
+        bounces={false}
+        overScrollMode="never"
+        pullToRefreshEnabled={false}
+        setSupportMultipleWindows={false}
+        allowsBackForwardNavigationGestures={false}
+        onLoadEnd={() => setWebviewLoading(false)}
+        onError={(e) => {
+          setErrMsg(e.nativeEvent.description || 'The terminal did not respond.');
+          setMode('error');
+        }}
+        onHttpError={(e) => {
+          if (e.nativeEvent.statusCode >= 500) {
+            setErrMsg(`Terminal returned HTTP ${e.nativeEvent.statusCode}.`);
+            setMode('error');
+          }
+        }}
+      />
+      {webviewLoading ? (
+        <View style={styles.centerOverlay} pointerEvents="none">
+          <View style={styles.pill}>
+            <Text style={styles.pillText}>Attaching to session…</Text>
+          </View>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+/** Finished/old tasks: the recorded output, ANSI-colored, pinned to bottom. */
+function ArchivedOutput({ output }: { output: string }) {
+  const scrollRef = useRef<ScrollView>(null);
+  const pinnedToBottom = useRef(true);
+  const lines = useMemo(() => parseAnsiLines(output), [output]);
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.archivedBar}>
+        <Ionicons name="time-outline" size={13} color={colors.textFaint} />
+        <Text style={styles.archivedText}>Archived output — the live session has ended</Text>
+      </View>
+      <ScrollView
+        ref={scrollRef}
+        style={styles.term}
+        contentContainerStyle={styles.termContent}
+        scrollEventThrottle={64}
+        onScroll={(e) => {
+          const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
+          pinnedToBottom.current =
+            contentOffset.y + layoutMeasurement.height >= contentSize.height - 40;
+        }}
+        onContentSizeChange={() => {
+          if (pinnedToBottom.current) scrollRef.current?.scrollToEnd({ animated: false });
+        }}
+      >
+        {lines.length === 0 ? (
+          <Text style={styles.termText}>(no output recorded)</Text>
+        ) : (
+          lines.map((line, i) => (
+            <Text key={i} style={styles.termText}>
+              {line.length === 0
+                ? ' '
+                : line.map((seg, j) => (
+                    <Text
+                      key={j}
+                      style={{
+                        color: seg.color ?? '#c8d3df',
+                        fontWeight: seg.bold ? '700' : '400',
+                        opacity: seg.dim ? 0.6 : 1,
+                      }}
+                    >
+                      {seg.text}
+                    </Text>
+                  ))}
+            </Text>
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { flex: 1, backgroundColor: '#08090b' },
+  web: { flex: 1, backgroundColor: '#08090b' },
+  center: {
+    flex: 1,
+    backgroundColor: '#08090b',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: space.xl,
+    gap: space.sm,
+  },
+  centerOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pill: {
+    backgroundColor: colors.bgElevated,
+    borderColor: colors.border,
+    borderWidth: 1,
+    borderRadius: radius.pill,
+    paddingHorizontal: space.lg,
+    paddingVertical: space.sm,
+  },
+  pillText: { color: colors.textMuted, fontSize: font.size.sm, fontWeight: '600' },
+  errIcon: {
+    width: 56,
+    height: 56,
+    borderRadius: radius.xl,
+    backgroundColor: colors.danger + '1a',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: space.xs,
+  },
+  errTitle: { color: colors.text, fontSize: font.size.md, fontWeight: '700' },
+  errMsg: {
+    color: colors.textMuted,
+    fontSize: font.size.sm,
+    textAlign: 'center',
+    maxWidth: 300,
+    lineHeight: 19,
+  },
+  errBtns: { flexDirection: 'row', gap: space.sm, marginTop: space.md, alignSelf: 'stretch' },
+  archivedBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 6,
+    backgroundColor: colors.bgElevated,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  archivedText: {
+    color: colors.textFaint,
+    fontSize: font.size.xs,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  term: { flex: 1 },
+  termContent: { padding: space.lg },
+  termText: { color: '#c8d3df', fontFamily: font.mono, fontSize: font.size.sm, lineHeight: 19 },
+});

--- a/mobile/src/screens/TaskDetailScreen.tsx
+++ b/mobile/src/screens/TaskDetailScreen.tsx
@@ -1,15 +1,19 @@
-/** Task detail: live-tailed output + follow-up composer. */
+/** Task detail: the live ttyd session (or archived output) + follow-up composer. */
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
-import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { LinearGradient } from 'expo-linear-gradient';
+import React, { useCallback, useLayoutEffect, useState } from 'react';
 import {
+  ActivityIndicator,
   KeyboardAvoidingView,
+  LayoutAnimation,
   Platform,
   Pressable,
   ScrollView,
   StyleSheet,
   Text,
   TextInput,
+  UIManager,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -17,13 +21,32 @@ import * as Clipboard from 'expo-clipboard';
 import { getTask, getTaskOutput, killTask, sendKey, sendMessage } from '../api/client';
 import { AppEmbed } from '../components/AppEmbed';
 import { AppPickerSheet } from '../components/AppPickerSheet';
-import { Button, Loading, StatusPill } from '../components/ui';
+import { Loading, StatusPill } from '../components/ui';
+import { TerminalView } from '../components/TerminalView';
 import { getItem, setItem } from '../store/storage';
 import type { TaskDetail } from '../api/types';
 import type { TasksStackParams } from '../navigation';
-import { parseAnsiLines } from '../util/ansi';
-import { colors, font, radius, space, statusColor } from '../theme';
+import { colors, font, gradients, radius, space, statusColor } from '../theme';
+import { confirmAction } from '../util/confirm';
+import { relativeTime } from '../util/format';
 import { usePolling } from '../util/usePolling';
+
+if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+// Control keys you can't type into the composer — tucked behind the keypad
+// toggle beside Send so they never crowd the screen. Paste pulls the clipboard
+// into the input; the rest go straight to the live tmux session.
+const KEY_TRAY: { label: string; key?: string; paste?: boolean; hint: string }[] = [
+  { label: 'Paste', paste: true, hint: 'Paste clipboard into the composer' },
+  { label: '⇧⇥', key: 'shift-tab', hint: 'Cycle assistant mode' },
+  { label: 'Esc', key: 'escape', hint: 'Escape' },
+  { label: '↑', key: 'up', hint: 'Arrow up' },
+  { label: '↓', key: 'down', hint: 'Arrow down' },
+  { label: '⏎', key: 'enter', hint: 'Enter' },
+  { label: '⌃C', key: 'ctrl-c', hint: 'Interrupt' },
+];
 
 // Last app shown in the split pane, remembered across tasks/restarts so the
 // toggle is one tap once you've picked your dev server.
@@ -32,19 +55,6 @@ interface SplitApp {
   port: number;
   name: string;
 }
-
-// Mobile key bar: control keys you can't type into the composer. Paste pulls the
-// clipboard into the input; the rest go straight to the live tmux session.
-const KEY_BAR: { label: string; key?: string; paste?: boolean }[] = [
-  { label: 'Paste', paste: true },
-  { label: '⇧⇥ Mode', key: 'shift-tab' },
-  { label: 'Esc', key: 'escape' },
-  { label: '↑', key: 'up' },
-  { label: '↓', key: 'down' },
-  { label: '⏎', key: 'enter' },
-  { label: '⌃C', key: 'ctrl-c' },
-];
-import { confirmAction } from '../util/confirm';
 
 function finishedNote(status: string): { icon: keyof typeof Ionicons.glyphMap; text: string } {
   switch (status) {
@@ -67,14 +77,50 @@ export default function TaskDetailScreen() {
   const [sending, setSending] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [sendErr, setSendErr] = useState<string | null>(null);
-  const scrollRef = useRef<ScrollView>(null);
-  // Only auto-follow new output while the user is pinned near the bottom —
-  // force-scrolling while they read scrollback makes the log unreadable.
-  const pinnedToBottom = useRef(true);
+  const [promptExpanded, setPromptExpanded] = useState(false);
+  // The control-key tray, hidden behind the keypad button beside Send.
+  const [keysOpen, setKeysOpen] = useState(false);
   // Split view: watch an app run in the lower half while the task streams in
   // the upper half. null = off. The picker chooses which app/port.
   const [splitApp, setSplitApp] = useState<SplitApp | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const [t, o] = await Promise.all([getTask(id), getTaskOutput(id)]);
+      setTask(t);
+      setOutput(o);
+      setErr(null);
+    } catch (e) {
+      // Keep the last good data during polling; surface a message only so the
+      // initial load doesn't hang on "Loading…" forever if it genuinely fails.
+      setErr(e instanceof Error ? e.message : 'Failed to load task');
+    }
+  }, [id]);
+
+  usePolling(load, 3000);
+
+  const active = task?.status === 'running' || task?.status === 'waiting';
+
+  function toggleKeys() {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setKeysOpen((v) => !v);
+  }
+
+  async function onTrayKey(item: (typeof KEY_TRAY)[number]) {
+    if (item.paste) {
+      const clip = await Clipboard.getStringAsync().catch(() => '');
+      if (clip) setMsg((m) => (m ? `${m}${clip}` : clip));
+      return;
+    }
+    if (item.key) {
+      try {
+        await sendKey(id, item.key);
+      } catch {
+        /* transient — the live terminal shows the session's real state */
+      }
+    }
+  }
 
   async function toggleSplit() {
     if (splitApp) {
@@ -102,40 +148,6 @@ export default function TaskDetailScreen() {
     setSplitApp(app);
     setPickerOpen(false);
     void setItem(SPLIT_APP_KEY, JSON.stringify(app));
-  }
-
-  const load = useCallback(async () => {
-    try {
-      const [t, o] = await Promise.all([getTask(id), getTaskOutput(id)]);
-      setTask(t);
-      setOutput(o);
-      setErr(null);
-    } catch (e) {
-      // Keep the last good data during polling; surface a message only so the
-      // initial load doesn't hang on "Loading…" forever if it genuinely fails.
-      setErr(e instanceof Error ? e.message : 'Failed to load task');
-    }
-  }, [id]);
-
-  usePolling(load, 3000);
-
-  const active = task?.status === 'running' || task?.status === 'waiting';
-  const lines = useMemo(() => parseAnsiLines(output), [output]);
-
-  async function onKeyBar(item: (typeof KEY_BAR)[number]) {
-    if (item.paste) {
-      const clip = await Clipboard.getStringAsync().catch(() => '');
-      if (clip) setMsg((m) => (m ? `${m}${clip}` : clip));
-      return;
-    }
-    if (item.key) {
-      try {
-        await sendKey(id, item.key);
-        await load(); // reflect the session's reaction quickly
-      } catch {
-        /* transient — the next poll will catch up */
-      }
-    }
   }
 
   const promptKill = useCallback(() => {
@@ -207,6 +219,7 @@ export default function TaskDetailScreen() {
   if (!task) return <Loading label={err ? "Couldn't load task — retrying…" : 'Loading task…'} />;
 
   const note = finishedNote(task.status);
+  const canSend = !!msg.trim() && !sending;
 
   return (
     <SafeAreaView style={styles.safe} edges={['bottom']}>
@@ -218,99 +231,125 @@ export default function TaskDetailScreen() {
         {/* Top pane: the task itself. With the split open it takes half the
             screen; the app pane below takes the other half. */}
         <View style={{ flex: 1 }}>
-        <View style={styles.head}>
-          <View style={styles.headTop}>
-            <StatusPill status={task.status} />
-            <Text style={styles.id}>#{task.id}</Text>
-          </View>
-          <Text style={styles.prompt}>{task.prompt}</Text>
-          <Text style={styles.meta}>
-            {(task.assistant ?? 'claude') + '  ·  ' + (task.workdir ?? '/home/dev')}
-          </Text>
-        </View>
-
-        <ScrollView
-          ref={scrollRef}
-          style={styles.term}
-          contentContainerStyle={styles.termContent}
-          scrollEventThrottle={64}
-          onScroll={(e) => {
-            const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
-            pinnedToBottom.current =
-              contentOffset.y + layoutMeasurement.height >= contentSize.height - 40;
-          }}
-          onContentSizeChange={() => {
-            if (pinnedToBottom.current) scrollRef.current?.scrollToEnd({ animated: false });
-          }}
-        >
-          {lines.length === 0 ? (
-            <Text style={styles.termText}>(no output yet)</Text>
-          ) : (
-            lines.map((line, i) => (
-              <Text key={i} style={styles.termText}>
-                {line.length === 0
-                  ? ' '
-                  : line.map((seg, j) => (
-                      <Text
-                        key={j}
-                        style={{
-                          color: seg.color ?? '#c8d3df',
-                          fontWeight: seg.bold ? '700' : '400',
-                          opacity: seg.dim ? 0.6 : 1,
-                        }}
-                      >
-                        {seg.text}
-                      </Text>
-                    ))}
-              </Text>
-            ))
-          )}
-        </ScrollView>
-
-        {active ? (
-          <View>
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              keyboardShouldPersistTaps="handled"
-              contentContainerStyle={styles.keyBar}
+          <View style={styles.head}>
+            <View style={styles.headTop}>
+              <StatusPill status={task.status} />
+              <View style={styles.headTopRight}>
+                <Text style={styles.time}>{relativeTime(task.created_at)}</Text>
+                <Text style={styles.id}>#{task.id}</Text>
+              </View>
+            </View>
+            <Pressable
+              onPress={() => setPromptExpanded((v) => !v)}
+              hitSlop={4}
+              accessibilityRole="button"
+              accessibilityLabel={promptExpanded ? 'Collapse prompt' : 'Expand prompt'}
             >
-              {KEY_BAR.map((k) => (
-                <Pressable key={k.label} style={styles.keyBtn} onPress={() => onKeyBar(k)}>
-                  <Text style={styles.keyBtnText}>{k.label}</Text>
-                </Pressable>
-              ))}
-            </ScrollView>
-            {sendErr ? (
-              <Text style={styles.sendErr} accessibilityRole="alert">
-                Couldn't send: {sendErr}
+              <Text style={styles.prompt} numberOfLines={promptExpanded ? undefined : 2}>
+                {task.prompt}
               </Text>
-            ) : null}
-            <View style={styles.composer}>
-              <TextInput
-                value={msg}
-                onChangeText={setMsg}
-                placeholder="Send a follow-up…"
-                placeholderTextColor={colors.textFaint}
-                style={styles.composerInput}
-                multiline
-              />
-              <Button
-                title="Send"
-                icon="arrow-up"
-                onPress={send}
-                loading={sending}
-                disabled={!msg.trim()}
-                style={styles.sendBtn}
-              />
+            </Pressable>
+            <View style={styles.metaRow}>
+              <View style={styles.assistantChip}>
+                <Ionicons name="hardware-chip-outline" size={11} color={colors.accent} />
+                <Text style={styles.assistantText}>{task.assistant ?? 'claude'}</Text>
+              </View>
+              <Text style={styles.workdir} numberOfLines={1}>
+                {task.workdir ?? '/home/dev'}
+              </Text>
             </View>
           </View>
-        ) : (
-          <View style={styles.finishedBar}>
-            <Ionicons name={note.icon} size={18} color={statusColor(task.status)} />
-            <Text style={styles.finishedText}>{note.text}</Text>
-          </View>
-        )}
+
+          {/* The real workspace terminal (ttyd/xterm.js) — the same session the
+              web dashboard renders — with an archived-output fallback for
+              finished tasks whose tmux session is gone. */}
+          <TerminalView taskId={id} output={output} />
+
+          {active ? (
+            <View style={styles.composerZone}>
+              {keysOpen ? (
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  keyboardShouldPersistTaps="handled"
+                  contentContainerStyle={styles.keyTray}
+                >
+                  {KEY_TRAY.map((k) => (
+                    <Pressable
+                      key={k.label}
+                      onPress={() => void onTrayKey(k)}
+                      accessibilityRole="button"
+                      accessibilityLabel={k.hint}
+                      style={({ pressed }) => [styles.keyChip, pressed && styles.keyChipPressed]}
+                    >
+                      <Text style={styles.keyChipText}>{k.label}</Text>
+                    </Pressable>
+                  ))}
+                </ScrollView>
+              ) : null}
+
+              {sendErr ? (
+                <Text style={styles.sendErr} accessibilityRole="alert">
+                  Couldn't send: {sendErr}
+                </Text>
+              ) : null}
+
+              <View style={styles.composer}>
+                <Pressable
+                  onPress={toggleKeys}
+                  accessibilityRole="button"
+                  accessibilityLabel={keysOpen ? 'Hide control keys' : 'Show control keys'}
+                  accessibilityState={{ expanded: keysOpen }}
+                  style={[styles.keysBtn, keysOpen && styles.keysBtnActive]}
+                >
+                  <Ionicons
+                    name={keysOpen ? 'keypad' : 'keypad-outline'}
+                    size={20}
+                    color={keysOpen ? colors.accent : colors.textMuted}
+                  />
+                </Pressable>
+                <TextInput
+                  value={msg}
+                  onChangeText={setMsg}
+                  placeholder="Send a follow-up…"
+                  placeholderTextColor={colors.textFaint}
+                  style={styles.composerInput}
+                  multiline
+                />
+                <Pressable
+                  onPress={() => void send()}
+                  disabled={!canSend}
+                  accessibilityRole="button"
+                  accessibilityLabel="Send follow-up"
+                  style={({ pressed }) => [
+                    styles.sendWrap,
+                    { opacity: !canSend ? 0.35 : pressed ? 0.85 : 1 },
+                    pressed && canSend ? { transform: [{ scale: 0.94 }] } : null,
+                  ]}
+                >
+                  <LinearGradient
+                    colors={gradients.primary}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 1 }}
+                    style={styles.sendBtn}
+                  >
+                    {sending ? (
+                      <ActivityIndicator size="small" color={colors.accentText} />
+                    ) : (
+                      <Ionicons name="arrow-up" size={20} color={colors.accentText} />
+                    )}
+                  </LinearGradient>
+                </Pressable>
+              </View>
+            </View>
+          ) : (
+            <View
+              style={[styles.finishedBar, { backgroundColor: statusColor(task.status) + '14' }]}
+            >
+              <Ionicons name={note.icon} size={17} color={statusColor(task.status)} />
+              <Text style={styles.finishedText}>{note.text}</Text>
+            </View>
+          )}
         </View>
 
         {splitApp ? (
@@ -358,8 +397,117 @@ const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: colors.bg },
   headerBtns: { flexDirection: 'row', alignItems: 'center' },
   headerBtn: { paddingHorizontal: space.sm, paddingVertical: 2 },
-  // Split view: the app pane mirrors the top pane's flex so the screen splits
-  // 50/50, with a slim toolbar naming the app + change/close actions.
+
+  // ---- task summary zone ----
+  head: {
+    paddingHorizontal: space.lg,
+    paddingTop: space.md,
+    paddingBottom: space.md,
+    gap: space.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headTop: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  headTopRight: { flexDirection: 'row', alignItems: 'center', gap: space.sm },
+  time: { color: colors.textFaint, fontSize: font.size.xs },
+  id: { color: colors.textFaint, fontSize: font.size.xs, fontFamily: font.mono },
+  prompt: { color: colors.text, fontSize: 16, fontWeight: '600', lineHeight: 22 },
+  metaRow: { flexDirection: 'row', alignItems: 'center', gap: space.sm },
+  assistantChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: colors.accent + '14',
+    borderRadius: radius.pill,
+    paddingHorizontal: space.sm,
+    paddingVertical: 3,
+  },
+  assistantText: { color: colors.accent, fontSize: font.size.xs, fontWeight: '700' },
+  workdir: { flex: 1, color: colors.textFaint, fontSize: font.size.xs, fontFamily: font.mono },
+
+  // ---- composer ----
+  composerZone: { borderTopWidth: 1, borderTopColor: colors.border, backgroundColor: colors.bg },
+  keyTray: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    flexDirection: 'row',
+    gap: space.sm,
+    paddingHorizontal: space.lg,
+    paddingTop: space.sm,
+  },
+  keyChip: {
+    height: 34,
+    borderRadius: 17,
+    paddingHorizontal: space.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bgElevated,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  keyChipPressed: { backgroundColor: colors.cardHover, borderColor: colors.borderStrong },
+  keyChipText: { color: colors.text, fontSize: font.size.sm, fontWeight: '600' },
+  sendErr: {
+    color: colors.danger,
+    fontSize: font.size.xs,
+    paddingHorizontal: space.lg,
+    paddingTop: space.sm,
+  },
+  composer: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: space.sm,
+    paddingHorizontal: space.md,
+    paddingVertical: space.md,
+  },
+  keysBtn: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bgElevated,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  keysBtnActive: { backgroundColor: colors.accent + '1f', borderColor: colors.accent + '66' },
+  composerInput: {
+    flex: 1,
+    minHeight: 44,
+    maxHeight: 120,
+    backgroundColor: colors.bgElevated,
+    borderRadius: 22,
+    borderWidth: 1,
+    borderColor: colors.border,
+    color: colors.text,
+    paddingHorizontal: space.lg,
+    paddingTop: 12,
+    paddingBottom: 12,
+    fontSize: font.size.md,
+    lineHeight: 20,
+  },
+  sendWrap: { borderRadius: 22 },
+  sendBtn: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+
+  // ---- finished ----
+  finishedBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: space.sm,
+    paddingVertical: space.lg,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  finishedText: { color: colors.textMuted, fontSize: font.size.sm, fontWeight: '600' },
+
+  // ---- split view ----
   appPane: { flex: 1, borderTopWidth: 2, borderTopColor: colors.borderStrong },
   paneBar: {
     flexDirection: 'row',
@@ -374,65 +522,4 @@ const styles = StyleSheet.create({
   paneTitle: { flex: 1, color: colors.text, fontSize: font.size.sm, fontWeight: '700' },
   panePort: { color: colors.textFaint, fontWeight: '400', fontFamily: font.mono },
   paneBtn: { padding: 4 },
-  head: { padding: space.lg, gap: space.sm, borderBottomWidth: 1, borderBottomColor: colors.border },
-  headTop: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-  id: { color: colors.textFaint, fontSize: font.size.sm, fontFamily: font.mono },
-  prompt: { color: colors.text, fontSize: font.size.lg, fontWeight: '600', lineHeight: 24 },
-  meta: { color: colors.textMuted, fontSize: font.size.xs },
-  term: { flex: 1, backgroundColor: '#08090b' },
-  termContent: { padding: space.lg },
-  termText: { color: '#c8d3df', fontFamily: font.mono, fontSize: font.size.sm, lineHeight: 19 },
-  keyBar: {
-    flexDirection: 'row',
-    gap: space.sm,
-    paddingHorizontal: space.md,
-    paddingTop: space.sm,
-  },
-  keyBtn: {
-    paddingHorizontal: space.md,
-    paddingVertical: 7,
-    borderRadius: radius.pill,
-    backgroundColor: colors.bgElevated,
-    borderWidth: 1,
-    borderColor: colors.border,
-  },
-  keyBtnText: { color: colors.text, fontSize: font.size.sm, fontWeight: '600' },
-  composer: {
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    gap: space.sm,
-    padding: space.md,
-    borderTopWidth: 1,
-    borderTopColor: colors.border,
-  },
-  composerInput: {
-    flex: 1,
-    minHeight: 50,
-    maxHeight: 120,
-    backgroundColor: colors.bgElevated,
-    borderRadius: radius.md,
-    borderWidth: 1,
-    borderColor: colors.border,
-    color: colors.text,
-    paddingHorizontal: space.md,
-    paddingTop: space.md,
-    fontSize: font.size.md,
-  },
-  sendBtn: { paddingHorizontal: space.lg },
-  sendErr: {
-    color: colors.danger,
-    fontSize: font.size.xs,
-    paddingHorizontal: space.lg,
-    paddingTop: space.sm,
-  },
-  finishedBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: space.sm,
-    paddingVertical: space.lg,
-    borderTopWidth: 1,
-    borderTopColor: colors.border,
-  },
-  finishedText: { color: colors.textMuted, fontSize: font.size.sm, fontWeight: '500' },
 });


### PR DESCRIPTION
## The real terminal, not a re-implementation
The task screen re-rendered Claude's TUI through a hand-rolled ANSI parser — lossy, and visibly jumbled on historical sessions. It now embeds the **workspace's real terminal (ttyd/xterm.js)** — the exact same session the web dashboard shows:

1. `POST prepare-terminal` marks the task's tmux session (existing endpoint, already Bearer-routed)
2. the session-cookie bootstrap 302s into **`/api/terminal-proxy`** (new: server-side fixed proxy to ttyd:7681, HTTP + websocket, behind the same Bearer/app-session auth as the app proxy)
3. `terminal-entry.sh` attaches the pending session — pixel-faithful xterm.js rendering, 10k-line scrollback, live.

**Finished tasks** whose tmux session is gone fall back to the archived output record under an explicit "Archived output — the live session has ended" notice (the ANSI renderer is kept only for that read-only path).

Proxy internals: `_proxy_app_request`/`_proxy_app_websocket` gained `prefix`/`allow_internal` params — internal routes skip the `is_proxyable` reserved-port gate and the HTML/Location rewrites (ttyd's assets are relative). The mint's `next` guard now admits the terminal proxy; the Bearer ingress routes `api/terminal-proxy.*`.

## Composer redesign
The quick-action key bar was off-center and always visible. Now:
- Control keys (Paste, ⇧⇥, Esc, ↑, ↓, ⏎, ⌃C) live in a **tray behind a keypad toggle beside Send** — centered chips, animated reveal, 34pt chips with pressed states.
- **Circular gradient Send** (44pt) with disabled/pressed/loading states.
- Refined task header: status pill + relative time + id, **tap-to-expand prompt**, assistant chip + mono workdir.
- Split-pane and kill behaviors unchanged.

## Verified live (ws-imran, redeployed)
prepare-terminal 200 via Bearer · mint 302 + scoped cookie · **ttyd xterm client (730KB) served through the proxy with cookie-only auth**, incl. its `/token` endpoint. `tsc` clean · helm unittest **71** · python suite **606** (new terminal-proxy next-guard tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)