### PR TITLE
fix(controller): provision new workspaces on the latest release, not a stale pin

### DIFF
--- a/charts/workspace-controller/controller.py
+++ b/charts/workspace-controller/controller.py
@@ -1506,7 +1506,12 @@ def render_values_yaml(opts, client_id, cookie_secret):
     image ships only this file via ConfigMap."""
     slug = opts['slug']
     host = opts['host']
-    tag = opts.get('imageTag') or WORKSPACE_IMAGE_TAG or 'v1.0.0'
+    # Default new workspaces to the latest published release so they aren't
+    # pinned to a stale version at create time. Precedence: an explicit
+    # per-request imageTag wins (admin pinned a specific version); otherwise the
+    # latest release; WORKSPACE_IMAGE_TAG is only a fallback for when the release
+    # lookup is unavailable (e.g. GitHub unreachable), and 'v1.0.0' a last resort.
+    tag = opts.get('imageTag') or latest_version() or WORKSPACE_IMAGE_TAG or 'v1.0.0'
     pvc = opts.get('pvcSize') or '20Gi'
     res = opts.get('resources') or {}
     req_cpu = (res.get('requests') or {}).get('cpu', '250m')

--- a/charts/workspace-controller/tests/controller_test.py
+++ b/charts/workspace-controller/tests/controller_test.py
@@ -282,6 +282,35 @@ class ProvisionPureLogicTest(unittest.TestCase):
         self.assertEqual(len(s), 32)
         self.assertTrue(s.isalnum())
 
+    def test_render_values_defaults_to_latest_release_when_no_tag_given(self):
+        # No explicit imageTag => the workspace is pinned to the latest release,
+        # not a stale WORKSPACE_IMAGE_TAG. Regression: new workspaces were coming
+        # up on an old version because the static env pin won over the release.
+        opts = {'login': 'octo', 'slug': 'octo', 'host': 'octo.dev.scalebase.io'}
+        orig_latest, orig_env = controller.latest_version, controller.WORKSPACE_IMAGE_TAG
+        controller.NAMESPACE = 'coder'
+        controller.latest_version = lambda: 'v1.11.0'
+        controller.WORKSPACE_IMAGE_TAG = 'v1.6.0'   # stale pin must NOT win
+        try:
+            text = controller.render_values_yaml(opts, 'Ov23liclientid', 'cookiesecret32xxxxxxxxxxxxxxxxxxx')
+        finally:
+            controller.latest_version, controller.WORKSPACE_IMAGE_TAG = orig_latest, orig_env
+        self.assertIn('tag: devlaptop-v1.11.0', text)
+        self.assertNotIn('devlaptop-v1.6.0', text)
+
+    def test_render_values_falls_back_to_env_when_release_lookup_fails(self):
+        # If the release lookup is unavailable, WORKSPACE_IMAGE_TAG is the fallback.
+        opts = {'login': 'octo', 'slug': 'octo', 'host': 'octo.dev.scalebase.io'}
+        orig_latest, orig_env = controller.latest_version, controller.WORKSPACE_IMAGE_TAG
+        controller.NAMESPACE = 'coder'
+        controller.latest_version = lambda: None
+        controller.WORKSPACE_IMAGE_TAG = 'v1.6.0'
+        try:
+            text = controller.render_values_yaml(opts, 'Ov23liclientid', 'cookiesecret32xxxxxxxxxxxxxxxxxxx')
+        finally:
+            controller.latest_version, controller.WORKSPACE_IMAGE_TAG = orig_latest, orig_env
+        self.assertIn('tag: devlaptop-v1.6.0', text)
+
     def test_render_values_yaml_is_valid_and_has_fields(self):
         opts = {'login': 'Octo', 'slug': 'octo', 'host': 'octo.dev.scalebase.io',
                 'pvcSize': '30Gi', 'gitName': 'Octo Cat', 'gitEmail': 'octo@example.com',

--- a/charts/workspace-controller/values.yaml
+++ b/charts/workspace-controller/values.yaml
@@ -141,7 +141,10 @@ provision:
   # installs helm on the fly). Override only if you bake a dedicated tool image.
   image: ""
 
-  # Default tag new workspaces run; the chart prefixes it with `devlaptop-`.
+  # Fallback image tag for new workspaces (chart prefixes it with `devlaptop-`).
+  # New workspaces default to the latest published release; this is used only
+  # when that release lookup is unavailable (e.g. GitHub unreachable). Leave
+  # empty unless you need a specific offline fallback.
   workspaceImageTag: ""
 
   # Shared cluster Secret names projected into every provisioned workspace so the


### PR DESCRIPTION
## Problem

Workspaces provisioned through the console come up on a **stale image version** rather than the latest release — e.g. `whydoescheeseexist` was created on `devlaptop-v1.6.0` while the latest release is v1.11.0.

### Root cause

`render_values_yaml()` resolved the workspace image tag as:

```python
tag = opts.get('imageTag') or WORKSPACE_IMAGE_TAG or 'v1.0.0'
```

`WORKSPACE_IMAGE_TAG` is a **static env pin** (`provision.workspaceImageTag`, currently `v1.6.0` in the live controller). With no explicit per-request `imageTag`, every new workspace got that static value — so provisioning never tracked new releases, and each release would have required manually bumping the pin.

## Fix

Reorder precedence so new workspaces default to the **latest published release**:

```python
tag = opts.get('imageTag') or latest_version() or WORKSPACE_IMAGE_TAG or 'v1.0.0'
```

- An explicit per-request `imageTag` still wins (admin can pin a specific version).
- Otherwise `latest_version()` — the same GitHub `releases/latest` lookup already used for the "update available" feature (cached, best-effort).
- `WORKSPACE_IMAGE_TAG` is demoted to a **fallback** for when the release lookup is unavailable (GitHub unreachable); `'v1.0.0'` remains the last resort.

New workspaces now auto-track the latest release with no per-release config bump.

## Testing

`make controller-python-tests` — **68 pass**, including two new tests: defaults to the latest release when no tag is given (stale env pin must not win), and falls back to `WORKSPACE_IMAGE_TAG` when the release lookup returns nothing.

## Deploy

Ships via the controller ConfigMap: `make ship-controller-config`. (The live `provision.workspaceImageTag=v1.6.0` can then be cleared in the private controller values, since it's only a fallback now.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
