### PR TITLE
fix(controller): O(1) workspace lookup so the self-serve update option stops vanishing

### DIFF
--- a/charts/workspace-controller/controller.py
+++ b/charts/workspace-controller/controller.py
@@ -274,6 +274,49 @@ def _collect(resource):
     return items
 
 
+def _ws_item(dep, pods, host):
+    """Build one workspace listing entry from its Deployment, its (raw) pods and
+    an optional host. Shared by list_workspaces() and find_workspace() so the
+    fleet listing and a single-workspace lookup produce identical shapes."""
+    name = dep.get('metadata', {}).get('name', '')
+    m = _NAME_RE.match(name)
+    user = m.group(1) if m else name
+    spec = dep.get('spec', {})
+    status = dep.get('status', {})
+    desired = spec.get('replicas', 1)
+    ready = status.get('readyReplicas', 0) or 0
+    gen = dep.get('metadata', {}).get('generation', 0) or 0
+    obs_gen = status.get('observedGeneration', 0) or 0
+    pod_sums = [_pod_summary(p) for p in pods]
+    state = _classify(desired, ready, obs_gen, gen, pod_sums)
+    detail = next((p['reason'] for p in pod_sums if p.get('reason')), None)
+    if detail is None:
+        detail = 'stopped' if desired == 0 else f'{ready}/{desired} ready'
+    image = _workspace_image(dep)
+    image_tag, version = version_from_image(image)
+    ws_ns = dep.get('metadata', {}).get('namespace', NAMESPACE)
+    return {
+        'user': user,
+        'deployment': name,
+        'namespace': ws_ns,
+        # Isolated == migrated to its own per-user namespace (#103). A workspace
+        # still in the control-plane namespace ($NAMESPACE) is either
+        # not-yet-migrated or a leftover scaled-to-0 rollback copy — the SPA
+        # badges these differently so the two don't look like accidental
+        # duplicates during a migration.
+        'isolated': ws_ns != NAMESPACE,
+        'state': state,
+        'desiredReplicas': desired,
+        'readyReplicas': ready,
+        'url': f'https://{host}/' if host else None,
+        'pods': pod_sums,
+        'detail': detail,
+        'image': image,
+        'imageTag': image_tag,
+        'version': version,
+    }
+
+
 def list_workspaces():
     deps = _collect('deployments')
     all_pods = _collect('pods')
@@ -301,66 +344,66 @@ def list_workspaces():
     out = []
     for dep in deps:
         name = dep.get('metadata', {}).get('name', '')
-        m = _NAME_RE.match(name)
-        if not m:
+        if not _NAME_RE.match(name):
             continue
-        user = m.group(1)
-        spec = dep.get('spec', {})
-        status = dep.get('status', {})
-        desired = spec.get('replicas', 1)
-        ready = status.get('readyReplicas', 0) or 0
-        gen = dep.get('metadata', {}).get('generation', 0) or 0
-        obs_gen = status.get('observedGeneration', 0) or 0
-        pods = [_pod_summary(p) for p in pods_by_app.get(name, [])]
-        state = _classify(desired, ready, obs_gen, gen, pods)
-        host = hosts.get(name)
-        detail = next((p['reason'] for p in pods if p.get('reason')), None)
-        if detail is None:
-            detail = 'stopped' if desired == 0 else f'{ready}/{desired} ready'
-        image = _workspace_image(dep)
-        image_tag, version = version_from_image(image)
-        ws_ns = dep.get('metadata', {}).get('namespace', NAMESPACE)
-        out.append({
-            'user': user,
-            'deployment': name,
-            'namespace': ws_ns,
-            # Isolated == migrated to its own per-user namespace (#103). A
-            # workspace still in the control-plane namespace ($NAMESPACE) is
-            # either not-yet-migrated or a leftover scaled-to-0 rollback copy —
-            # the SPA badges these differently so the two don't look like
-            # accidental duplicates during a migration.
-            'isolated': ws_ns != NAMESPACE,
-            'state': state,
-            'desiredReplicas': desired,
-            'readyReplicas': ready,
-            'url': f'https://{host}/' if host else None,
-            'pods': pods,
-            'detail': detail,
-            'image': image,
-            'imageTag': image_tag,
-            'version': version,
-        })
+        out.append(_ws_item(dep, pods_by_app.get(name, []), hosts.get(name)))
     out.sort(key=lambda w: w['user'])
     return {'namespace': NAMESPACE, 'workspaces': out}
 
 
-def _find_workspace(user):
-    """The workspace dict (incl. its namespace) for a user from the live
-    listing, or LookupError. Ensures we only ever mutate something the console
-    would actually show, and in the namespace it really lives in (#103)."""
+def find_workspace(user):
+    """One workspace's entry (same shape as a list_workspaces() item), read
+    directly from its own namespace — falling back to the control-plane
+    namespace for a not-yet-migrated (#103) workspace. Raises ValueError on a
+    bad name, LookupError if absent.
+
+    This is deliberately O(1): it reads just this user's Deployment (+ pods,
+    ingress) instead of the all-namespaces fan-out of list_workspaces(). The
+    self-serve version/update path runs on every workspace's Settings page load,
+    and list_workspaces() had grown to ~12s across the fleet — past the
+    workspace's controller-call timeout, which silently hid the update option.
+    A single-namespace read keeps it well under a second regardless of fleet
+    size."""
     if not _USER_RE.match(user):
         raise ValueError('invalid workspace name')
     name = f'{WORKSPACE_PREFIX}{user}'
-    for w in list_workspaces()['workspaces']:
-        if w['deployment'] == name:
-            return w
+    selector = f'app={name}'
+    # Prefer the isolated ws-<user> namespace; fall back to the control plane.
+    for ns in dict.fromkeys([ns_for_user(user), NAMESPACE]):
+        try:
+            deps = _kubectl_json(['get', 'deployments', '-l', selector],
+                                 namespace=ns).get('items', [])
+        except KubectlError:
+            continue
+        dep = next((d for d in deps
+                    if d.get('metadata', {}).get('name') == name), None)
+        if dep is None:
+            continue
+        try:
+            pods = _kubectl_json(['get', 'pods', '-l', selector],
+                                 namespace=ns).get('items', [])
+        except KubectlError:
+            pods = []
+        host = None
+        try:
+            for ing in _kubectl_json(['get', 'ingress', '-l', selector],
+                                     namespace=ns).get('items', []):
+                for rule in ing.get('spec', {}).get('rules', []):
+                    if rule.get('host'):
+                        host = rule['host']
+                        break
+                if host:
+                    break
+        except KubectlError:
+            pass
+        return _ws_item(dep, pods, host)
     raise LookupError(name)
 
 
 def scale_workspace(user, replicas):
     # Confirm the deployment exists (and is actually a workspace) before
     # touching it — never scale something the listing wouldn't show.
-    ws = _find_workspace(user)
+    ws = find_workspace(user)
     name = ws['deployment']
     _kubectl_run(['scale', f'deployment/{name}', f'--replicas={replicas}'],
                  namespace=ws['namespace'])
@@ -425,7 +468,7 @@ def set_workspace_resources(user, cpu_limit, mem_limit, persist=True):
         limits['memory'] = _validate_mem(mem_limit)
     if not limits:
         raise ValueError('provide a cpu and/or memory limit')
-    ws = _find_workspace(user)
+    ws = find_workspace(user)
     name = ws['deployment']
     # Strategic merge: containers are merged by `name`, and the limits map merges
     # key-wise, so only the keys we send change and `requests` stays as-is.
@@ -688,11 +731,7 @@ def set_workspace_image(user, target_version=None, persist=True):
     target = (target_version or latest_version() or '').strip()
     if not parse_version(target):
         raise ValueError('no target version available (latest release unknown)')
-    name = f'{WORKSPACE_PREFIX}{user}'
-    wss = {w['deployment']: w for w in list_workspaces()['workspaces']}
-    ws = wss.get(name)
-    if ws is None:
-        raise LookupError(name)
+    ws = find_workspace(user)   # targeted; raises LookupError if absent
     current_image = ws.get('image') or ''
     current_ver = ws.get('version')
     repo = current_image.rsplit(':', 1)[0] if ':' in current_image else (
@@ -703,7 +742,7 @@ def set_workspace_image(user, target_version=None, persist=True):
     if not already:
         patch = {'spec': {'template': {'spec': {'containers': [
             {'name': WORKSPACE_CONTAINER, 'image': new_image}]}}}}
-        _kubectl_run(['patch', f'deployment/{name}', '--type=strategic', '-p', json.dumps(patch)],
+        _kubectl_run(['patch', f"deployment/{ws['deployment']}", '--type=strategic', '-p', json.dumps(patch)],
                      namespace=ws.get('namespace'))
     persisted = False
     persist_error = None
@@ -727,12 +766,7 @@ def set_workspace_image(user, target_version=None, persist=True):
 
 def workspace_version_info(user):
     """Current vs latest version for one workspace (for the self-serve GET)."""
-    if not _USER_RE.match(user):
-        raise ValueError('invalid workspace name')
-    name = f'{WORKSPACE_PREFIX}{user}'
-    ws = {w['deployment']: w for w in list_workspaces()['workspaces']}.get(name)
-    if ws is None:
-        raise LookupError(name)
+    ws = find_workspace(user)   # targeted single-namespace read, not the fleet
     latest = latest_version()
     return {
         'user': user,

--- a/charts/workspace-controller/tests/controller_test.py
+++ b/charts/workspace-controller/tests/controller_test.py
@@ -387,10 +387,14 @@ class ResourceLimitTest(unittest.TestCase):
         controller.WORKSPACE_CONTAINER = 'ide'
         controller.WORKSPACE_PREFIX = 'ws-'
         controller.GITOPS_REPO = ''        # persistence off by default in tests
+        self._orig_find = controller.find_workspace
         # Pretend the workspace exists so the existence guard passes. Under
         # per-workspace namespaces (#103) it lives in its own ws-octo namespace.
-        controller.list_workspaces = lambda: {'namespace': 'coder', 'workspaces': [
-            {'deployment': 'ws-octo', 'namespace': 'ws-octo'}]}
+        controller.find_workspace = lambda user: {
+            'deployment': f'ws-{user}', 'namespace': f'ws-{user}'}
+
+    def tearDown(self):
+        controller.find_workspace = self._orig_find
 
     def test_validate_cpu_accepts_cores_and_millicores(self):
         self.assertEqual(controller._validate_cpu('2'), '2')
@@ -436,7 +440,9 @@ class ResourceLimitTest(unittest.TestCase):
             controller.set_workspace_resources('octo', None, None)
 
     def test_set_resources_unknown_workspace_raises_lookup(self):
-        controller.list_workspaces = lambda: {'namespace': 'coder', 'workspaces': []}
+        def _absent(user):
+            raise LookupError(user)
+        controller.find_workspace = _absent
         with self.assertRaises(LookupError):
             controller.set_workspace_resources('octo', '2', None)
 
@@ -599,7 +605,7 @@ class SetWorkspaceImageTest(unittest.TestCase):
         controller.WORKSPACE_CONTAINER = 'ide'
         controller.WORKSPACE_PREFIX = 'ws-'
         controller.IMAGE_TAG_PREFIX = 'devlaptop-'
-        self._orig_list = controller.list_workspaces
+        self._orig_find = controller.find_workspace
         self._orig_run = controller._kubectl_run
         self._orig_latest = controller.latest_version
         self._orig_gitops_repo = controller.GITOPS_REPO
@@ -607,12 +613,12 @@ class SetWorkspaceImageTest(unittest.TestCase):
         controller.GITOPS_REPO = ''       # persistence off by default in tests
         controller.GITOPS_TOKEN = ''
         controller.latest_version = lambda: 'v1.4.0'
-        controller.list_workspaces = lambda: {'namespace': 'coder', 'workspaces': [
-            {'deployment': 'ws-octo', 'namespace': 'ws-octo', 'version': 'v1.3.0',
-             'image': 'registry/coder:devlaptop-v1.3.0', 'imageTag': 'devlaptop-v1.3.0'}]}
+        controller.find_workspace = lambda user: {
+            'deployment': f'ws-{user}', 'namespace': f'ws-{user}', 'version': 'v1.3.0',
+            'image': 'registry/coder:devlaptop-v1.3.0', 'imageTag': 'devlaptop-v1.3.0'}
 
     def tearDown(self):
-        controller.list_workspaces = self._orig_list
+        controller.find_workspace = self._orig_find
         controller._kubectl_run = self._orig_run
         controller.latest_version = self._orig_latest
         controller.GITOPS_REPO = self._orig_gitops_repo
@@ -658,7 +664,9 @@ class SetWorkspaceImageTest(unittest.TestCase):
             controller.set_workspace_image('octo')          # no version anywhere
 
     def test_unknown_workspace_raises_lookup(self):
-        controller.list_workspaces = lambda: {'namespace': 'coder', 'workspaces': []}
+        def _absent(user):
+            raise LookupError(user)
+        controller.find_workspace = _absent
         with self.assertRaises(LookupError):
             controller.set_workspace_image('octo', 'v1.4.0')
 
@@ -787,6 +795,31 @@ class PerWorkspaceNamespaceTest(unittest.TestCase):
         self.assertEqual(set(by_user), {'alice', 'bob'})
         self.assertEqual(by_user['alice']['namespace'], 'ws-alice')
         self.assertEqual(by_user['bob']['namespace'], 'ws-bob')
+
+    def test_find_workspace_reads_only_its_own_namespace(self):
+        # Targeted O(1) lookup: reads ws-<user> directly, never the
+        # all-namespaces fan-out (no 'get namespaces', no foreign-tenant reads).
+        # Regression: workspace_version_info() used list_workspaces() and grew to
+        # ~12s across the fleet, past the workspace's controller-call timeout, so
+        # the self-serve update option silently vanished from Settings.
+        seen = []
+        def fake(args, namespace=None):
+            seen.append((list(args), namespace))
+            if args[:2] == ['get', 'deployments'] and namespace == 'ws-alice':
+                return {'items': [_dep('ws-alice')]}
+            return {'items': []}
+        controller._kubectl_json = fake
+        ws = controller.find_workspace('alice')
+        self.assertEqual(ws['deployment'], 'ws-alice')
+        self.assertEqual(ws['namespace'], 'ws-alice')
+        self.assertEqual(ws['version'], 'v1.0.0')
+        self.assertNotIn(['get', 'namespaces'], [a for a, _ in seen])   # never enumerated
+        self.assertTrue(all(ns in ('ws-alice', 'coder') for _, ns in seen))
+
+    def test_find_workspace_absent_raises_lookup(self):
+        controller._kubectl_json = lambda args, namespace=None: {'items': []}
+        with self.assertRaises(LookupError):
+            controller.find_workspace('ghost')
 
     def test_collect_aggregates_items_across_namespaces(self):
         # _collect fans out one read per workspace namespace (now concurrently)


### PR DESCRIPTION
## Symptom

On a workspace's **Settings → Updates**, the "Restart & update" option **disappeared** — even with a newer release available (imran on v1.11.0, latest v1.12.0).

## Root cause

The Settings section is gated on the workspace's `GET /api/workspace/version`, which brokers to the controller's self-serve `GET /api/self/workspaces/<user>/version`. That controller handler (`workspace_version_info`) resolved **one** workspace by calling **`list_workspaces()`** — the all-namespaces `kubectl` fan-out.

Measured live: that endpoint now takes **~12s** (3 runs: 12.4s / 12.4s / 11.6s) because it lists all 15+ workspace namespaces just to read one workspace's image tag. The workspace's controller-call timeout (`CONTROLLER_TIMEOUT`) is **15s**, so it's right at the edge — and tips over under any controller CPU contention (the pod is capped at 500m) or as the fleet grows. When `get_version()` times out, `server.py` returns an error and the SPA **hides** the section. That's the vanished option.

It's a scaling regression: it worked when the fleet was small; ~12s crossed the timeout as namespaces accumulated. (#193's parallelization cut it enough to stop the admin-console 502s, but 12s still blows past the workspace's shorter timeout.) The update action (`set_workspace_image`) and the scale/resource-edit paths had the same O(N) resolve.

## Fix

- **`find_workspace(user)`** — a targeted O(1) lookup that reads just this user's Deployment (+ pods, ingress) in its own namespace, falling back to the control-plane namespace for a not-yet-migrated (#103) workspace. Sub-second regardless of fleet size.
- Extracted a shared **`_ws_item()`** builder so `list_workspaces()` and `find_workspace()` produce identical shapes.
- `workspace_version_info`, `set_workspace_image`, `scale_workspace`, and `set_workspace_resources` all resolve through `find_workspace` now.

## Testing

`make controller-python-tests` — **70 pass**, including new coverage: `find_workspace` reads only its own namespace (never enumerates namespaces / reads foreign tenants) and raises `LookupError` when absent. Mutation tests updated to stub `find_workspace`.

Verified live after deploy: the self-serve version endpoint drops from ~12s to well under 1s, and the workspace's version check returns `updateAvailable: true` again.

## Deploy

`make ship-controller-config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
