### PR TITLE
feat(hypervisor): structured ante + opencode adapters

### DIFF
--- a/charts/workspace/hypervisor_session.py
+++ b/charts/workspace/hypervisor_session.py
@@ -261,14 +261,210 @@ class FallbackAdapter(Adapter):
         return [{'role': 'assistant', 'type': 'message', 'text': text}]
 
 
+# ── Structured-CLI adapters (ante, opencode) ────────────────────────────────
+# Both emit line-delimited JSON with a resumable session id, so they slot into
+# the same pattern as Claude. BUT their exact event schema varies by version and
+# couldn't be fully captured in the test pod (ante's provider creds errored;
+# opencode ran on a slow endpoint). So these parse PERMISSIVELY — capture a
+# session id for resume, lift assistant text / tool activity from common field
+# shapes — and ALWAYS fall back to the raw (ANSI-stripped) stdout for a turn if
+# nothing structured was recognized, so the user still sees the response.
+# NEEDS a live smoke-test in a workspace where these CLIs actually respond.
+_TEXT_FIELDS = ('text', 'content', 'message', 'output_text', 'response')
+
+
+def _lift_text(inner: Any) -> str:
+    if isinstance(inner, str):
+        return inner
+    if isinstance(inner, dict):
+        for f in _TEXT_FIELDS:
+            v = inner.get(f)
+            if isinstance(v, str) and v.strip():
+                return v
+            if isinstance(v, list):  # Claude-style content blocks
+                t = _stringify(v)
+                if t.strip():
+                    return t
+    return ''
+
+
+def _dig_session_id(o: Any) -> Optional[str]:
+    """Find a session id in common shapes: session_id / sessionID / session.id."""
+    if not isinstance(o, dict):
+        return None
+    for k in ('session_id', 'sessionID', 'sessionId'):
+        if isinstance(o.get(k), str):
+            return o[k]
+    sess = o.get('session')
+    if isinstance(sess, dict) and isinstance(sess.get('id'), str):
+        return sess['id']
+    return None
+
+
+class _StructuredCliAdapter(Adapter):
+    """Base for line-delimited-JSON CLIs: permissive parse + raw-text fallback."""
+
+    kind = 'structured'
+
+    def _reset_turn(self, ctx):
+        ctx['_emitted'] = False
+        ctx['_raw'] = []
+
+    def parse(self, ctx, line):
+        if not line.strip():
+            return []
+        try:
+            o = json.loads(line.strip())
+        except json.JSONDecodeError:
+            ctx.setdefault('_raw', []).append(line.rstrip('\n'))  # → raw fallback
+            return []
+        return self._parse_obj(ctx, o)
+
+    def _parse_obj(self, ctx, o):
+        raise NotImplementedError
+
+    def finalize(self, ctx, rc):
+        # If we recognized structured content this turn, we're done. Otherwise
+        # surface the raw stdout so the response is never lost to a schema miss.
+        if ctx.get('_emitted'):
+            return []
+        raw = strip_ansi('\n'.join(ctx.get('_raw', []) or [])).strip()
+        if raw:
+            return [{'role': 'assistant', 'type': 'message', 'text': raw}]
+        if rc not in (0, None):
+            return [{'role': 'system', 'type': 'error',
+                     'text': f'{self.kind} exited with code {rc}'}]
+        return []
+
+
+class AnteAdapter(_StructuredCliAdapter):
+    """`ante -p --output-format json --permission-mode yolo` (headless).
+
+    Ante wraps each event as {"event": {"<Type>": <inner>}}; multi-turn via
+    `-r <session_id>` captured from SessionStart.
+    """
+
+    kind = 'ante'
+    _NOISE = frozenset({'ExtensionRefreshed', 'InfoBlockStart', 'InfoBlockAppend',
+                        'InfoBlockEnd', 'UserInput', 'TurnStart', 'TurnEnd',
+                        'SessionEnd', 'Usage', 'TokenUsage', 'Reasoning'})
+
+    def build(self, ctx, text, first):
+        self._reset_turn(ctx)
+        argv = ['ante', '-p', text, '--output-format', 'json',
+                '--permission-mode', 'yolo']
+        sid = ctx.get('ante_session_id')
+        if sid:
+            argv += ['-r', sid]
+        elif ctx.get('preamble'):
+            argv += ['--append-system-prompt', ctx['preamble']]
+        return {'argv': argv, 'cwd': ctx.get('workdir') or WORKSPACE_HOME}
+
+    def _parse_obj(self, ctx, o):
+        ev = o.get('event')
+        if not isinstance(ev, dict) or not ev:
+            return []
+        k = next(iter(ev))
+        inner = ev[k] if isinstance(ev[k], dict) else {}
+        if k == 'SessionStart':
+            sid = _dig_session_id(inner)
+            if sid:
+                ctx['ante_session_id'] = sid
+            return []
+        if k in self._NOISE:
+            return []
+        lk = k.lower()
+        if 'tool' in lk and 'result' in lk:
+            ctx['_emitted'] = True
+            return [{'role': 'system', 'type': 'tool_result',
+                     'tool_use_id': inner.get('id') or inner.get('tool_call_id') or '',
+                     'is_error': bool(inner.get('is_error') or inner.get('error')),
+                     'text': _stringify(inner.get('output') or inner.get('result')
+                                        or inner.get('content'))}]
+        if 'tool' in lk and (inner.get('name') or inner.get('tool')):
+            ctx['_emitted'] = True
+            return [{'role': 'assistant', 'type': 'tool_call',
+                     'tool_id': inner.get('id', ''),
+                     'tool': {'name': inner.get('name') or inner.get('tool') or 'tool',
+                              'input': inner.get('input') or inner.get('arguments') or {}}}]
+        if 'delta' in lk:  # skip partial-text spam; full events carry the text
+            return []
+        txt = _lift_text(inner)
+        if txt:
+            ctx['_emitted'] = True
+            return [{'role': 'assistant', 'type': 'message', 'text': txt}]
+        return []
+
+
+class OpencodeAdapter(_StructuredCliAdapter):
+    """`opencode run --format json` (headless); multi-turn via `-s <session_id>`."""
+
+    kind = 'opencode'
+    _NOISE = frozenset({'step-start', 'step-finish', 'stepstart', 'stepfinish'})
+
+    def build(self, ctx, text, first):
+        self._reset_turn(ctx)
+        msg = text if not (first and ctx.get('preamble')) \
+            else ctx['preamble'] + '\n\n' + text
+        argv = ['opencode', 'run', msg, '--format', 'json']
+        # Reuse the model the workspace configured (assistant_command builds
+        # `opencode --model '<provider>/<model>'`).
+        m = re.search(r"--model\s+'?([^'\s]+)", ctx.get('cli_cmd', '') or '')
+        if m:
+            argv += ['--model', m.group(1)]
+        sid = ctx.get('opencode_session_id')
+        if sid:
+            argv += ['-s', sid]
+        return {'argv': argv, 'cwd': ctx.get('workdir') or WORKSPACE_HOME}
+
+    def _parse_obj(self, ctx, o):
+        sid = _dig_session_id(o)
+        if sid:
+            ctx['opencode_session_id'] = sid
+        t = str(o.get('type') or o.get('event') or '').lower()
+        if t in self._NOISE:
+            return []
+        part = o.get('part') if isinstance(o.get('part'), dict) else {}
+        if 'tool' in t:
+            name = o.get('tool') or o.get('name') or part.get('tool')
+            if 'result' in t or o.get('state') == 'completed':
+                out = o.get('output') or o.get('result') or part.get('output')
+                if out is not None:
+                    ctx['_emitted'] = True
+                    return [{'role': 'system', 'type': 'tool_result',
+                             'tool_use_id': o.get('callID') or o.get('id') or '',
+                             'is_error': bool(o.get('error')),
+                             'text': _stringify(out)}]
+            if name:
+                ctx['_emitted'] = True
+                return [{'role': 'assistant', 'type': 'tool_call',
+                         'tool_id': o.get('callID') or o.get('id') or '',
+                         'tool': {'name': name,
+                                  'input': o.get('input') or o.get('args') or {}}}]
+            return []
+        txt = _lift_text(o) or _lift_text(part)
+        if txt:
+            ctx['_emitted'] = True
+            return [{'role': 'assistant', 'type': 'message', 'text': txt}]
+        return []
+
+
 _ADAPTERS: Dict[str, Adapter] = {
     'claude': ClaudeAdapter(),
+    'ante': AnteAdapter(),
+    'opencode': OpencodeAdapter(),
     'fallback': FallbackAdapter(),
 }
 
 
 def _adapter_for(assistant: str) -> Adapter:
-    return _ADAPTERS.get(assistant, _ADAPTERS['fallback'])
+    if assistant == 'claude':
+        return _ADAPTERS['claude']
+    if assistant == 'ante':
+        return _ADAPTERS['ante']
+    if assistant.startswith('opencode'):
+        return _ADAPTERS['opencode']
+    return _ADAPTERS['fallback']
 
 
 def _stringify(v: Any) -> str:

--- a/charts/workspace/tests/hypervisor_session_test.py
+++ b/charts/workspace/tests/hypervisor_session_test.py
@@ -128,11 +128,81 @@ class SessionEventsTest(unittest.TestCase):
         # since-cursor returns only newer events.
         self.assertEqual(len(s.read_events(since_seq=1)), 1)
 
-    def test_unknown_assistant_uses_fallback_adapter(self):
-        s = hs.HypervisorSession.create(
-            assistant='opencode-openrouter', workdir='/home/dev',
-            cli_cmd='opencode', preamble='', title='x')
-        self.assertEqual(s.read_meta()['adapter_kind'], 'fallback')
+    def test_assistant_adapter_routing(self):
+        cases = {'claude': 'claude', 'ante': 'ante',
+                 'opencode-openrouter': 'opencode', 'opencode-deepseek': 'opencode',
+                 'librefang': 'fallback', 'kc-harness': 'fallback'}
+        for assistant, kind in cases.items():
+            s = hs.HypervisorSession.create(
+                assistant=assistant, workdir='/home/dev', cli_cmd=assistant,
+                preamble='', title='x')
+            self.assertEqual(s.read_meta()['adapter_kind'], kind, assistant)
+
+
+class AnteAdapterTest(unittest.TestCase):
+    def setUp(self):
+        self.a = hs.AnteAdapter()
+
+    def test_captures_session_id_and_lifts_text(self):
+        ctx = {'workdir': '/home/dev'}
+        self.assertEqual(self.a.parse(ctx, json.dumps(
+            {'event': {'SessionStart': {'session_id': 'ses_1'}}}), ), [])
+        self.assertEqual(ctx['ante_session_id'], 'ses_1')
+        out = self.a.parse(ctx, json.dumps(
+            {'event': {'AssistantMessage': {'text': 'hello'}}}))
+        self.assertEqual(out, [{'role': 'assistant', 'type': 'message', 'text': 'hello'}])
+
+    def test_tool_call_and_result(self):
+        ctx = {}
+        call = self.a.parse(ctx, json.dumps(
+            {'event': {'ToolCall': {'id': 't1', 'name': 'bash', 'input': {'command': 'ls'}}}}))
+        self.assertEqual(call[0]['type'], 'tool_call')
+        self.assertEqual(call[0]['tool']['name'], 'bash')
+        res = self.a.parse(ctx, json.dumps(
+            {'event': {'ToolResult': {'id': 't1', 'output': 'ok'}}}))
+        self.assertEqual(res[0]['type'], 'tool_result')
+
+    def test_noise_ignored_and_resume_flag(self):
+        ctx = {'ante_session_id': 'ses_9', 'workdir': '/home/dev'}
+        self.assertEqual(self.a.parse(ctx, json.dumps({'event': {'TurnStart': {}}})), [])
+        spec = self.a.build(ctx, 'hi', first=False)
+        self.assertIn('-r', spec['argv'])
+        self.assertIn('ses_9', spec['argv'])
+        self.assertIn('--output-format', spec['argv'])
+
+    def test_raw_fallback_when_no_structured_events(self):
+        ctx = {}
+        self.a.build(ctx, 'hi', first=True)       # resets per-turn state
+        self.a.parse(ctx, 'plain non-json line')  # accumulates raw
+        out = self.a.finalize(ctx, 0)
+        self.assertEqual(out, [{'role': 'assistant', 'type': 'message',
+                                'text': 'plain non-json line'}])
+
+
+class OpencodeAdapterTest(unittest.TestCase):
+    def setUp(self):
+        self.a = hs.OpencodeAdapter()
+
+    def test_build_uses_run_json_and_model_from_cli_cmd(self):
+        ctx = {'cli_cmd': "opencode --model 'openrouter/anthropic/claude-sonnet-4'",
+               'workdir': '/home/dev'}
+        spec = self.a.build(ctx, 'hi', first=True)
+        self.assertEqual(spec['argv'][:4], ['opencode', 'run', 'hi', '--format'])
+        self.assertIn('--model', spec['argv'])
+        self.assertIn('openrouter/anthropic/claude-sonnet-4', spec['argv'])
+
+    def test_captures_session_id_and_text(self):
+        ctx = {}
+        self.a.parse(ctx, json.dumps({'session': {'id': 'ses_x'}, 'type': 'session'}))
+        self.assertEqual(ctx['opencode_session_id'], 'ses_x')
+        out = self.a.parse(ctx, json.dumps({'type': 'text', 'text': 'yo'}))
+        self.assertEqual(out, [{'role': 'assistant', 'type': 'message', 'text': 'yo'}])
+
+    def test_resume_flag_on_later_turn(self):
+        ctx = {'opencode_session_id': 'ses_x', 'cli_cmd': 'opencode'}
+        spec = self.a.build(ctx, 'again', first=False)
+        self.assertIn('-s', spec['argv'])
+        self.assertIn('ses_x', spec['argv'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Makes **ante** and **opencode** use the correct headless Hypervisor flow instead of today's fallback (which ran their *interactive REPL* commands piped with stdin — the wrong shape for a headless session).

Both have proper headless JSON modes with session resume, like Claude:

| CLI | headless invocation | multi-turn |
|---|---|---|
| ante | `ante -p <text> --output-format json --permission-mode yolo` (+ `--append-system-prompt`) | `-r <session_id>` |
| opencode | `opencode run <text> --format json` (model reused from `assistant_command`) | `-s <session_id>` |

New `AnteAdapter` + `OpencodeAdapter` parse those event streams into the canonical event schema and resume the session across turns.

## Honesty about validation ⚠️

Each CLI's exact event schema varies by version and **couldn't be fully captured in the test pod**:
- **ante** → `Task failed: authentication error` (its OpenRouter/deepseek creds aren't working in the workspace I tested).
- **opencode** → ran on a slow Ollama droplet (`qwen3-coder:30b`) and didn't emit completed events within timeout.

So the shared `_StructuredCliAdapter` base parses **permissively** (session id + text/tool lifted from common field shapes) and **always falls back to the raw ANSI-stripped stdout** for a turn when nothing structured is recognized — so the response is never lost to a schema miss.

**This needs a live smoke-test in a workspace where ante/opencode actually respond**, to confirm (or refine) the event-field mapping. The raw fallback means it degrades to clean prose rather than breaking in the meantime.

## Tests

21 module tests (adapter routing, ante/opencode parse, resume flags, raw fallback); **114 total** green.

## Stacking

Based on **#216** (uses `WORKSPACE_HOME` + forced `HOME=/home/dev`). Retarget to `main` once #216 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)