### PR TITLE
feat(mobile): add Hypervisor chat screen

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -21,6 +21,7 @@ import NewTaskScreen from './src/screens/NewTaskScreen';
 import AppsScreen from './src/screens/AppsScreen';
 import AppViewScreen from './src/screens/AppViewScreen';
 import DesktopScreen from './src/screens/DesktopScreen';
+import HypervisorScreen from './src/screens/HypervisorScreen';
 import MemoryScreen from './src/screens/MemoryScreen';
 import MetricsScreen from './src/screens/MetricsScreen';
 import SettingsScreen from './src/screens/SettingsScreen';
@@ -120,6 +121,7 @@ function MainTabs() {
         }}
       >
         <Tab.Screen name="Desktop" component={DesktopScreen} />
+        <Tab.Screen name="Hypervisor" component={HypervisorScreen} />
         <Tab.Screen name="Tasks" component={TasksStack} />
         <Tab.Screen name="Apps" component={AppsStack} />
         <Tab.Screen name="Memory" component={MemoryScreen} />

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -28,6 +28,9 @@ import type {
   DesktopItem,
   DesktopItemDraft,
   Health,
+  HypervisorConfig,
+  HypervisorThread,
+  HypervisorThreadDetail,
   LaunchResult,
   MemoryRecord,
   Metrics,
@@ -559,4 +562,60 @@ export async function getHealth(): Promise<Health> {
     browser: d.services?.browser,
     ok: d.status === 'healthy',
   };
+}
+
+// ---- Hypervisor chat -------------------------------------------------------
+// Threads are structured agent sessions; the server returns a canonical event
+// stream we poll with ?since (see charts/workspace/hypervisor_session.py). No
+// SSE — same polling model as the task screens.
+
+export async function getHypervisorConfig(): Promise<HypervisorConfig> {
+  if (getConfig().mock) {
+    await delay(80);
+    return {
+      enabled: true,
+      defaultAssistant: 'claude',
+      workdir: '/home/dev',
+      readOnly: false,
+      assistants: [{ id: 'claude', label: 'Claude Code', default: true }],
+    };
+  }
+  return request<HypervisorConfig>('/api/hypervisor/config');
+}
+
+export async function listThreads(): Promise<HypervisorThread[]> {
+  if (getConfig().mock) {
+    await delay(80);
+    return [];
+  }
+  const d = await request<{ threads?: HypervisorThread[] }>('/api/hypervisor/threads');
+  return d.threads ?? [];
+}
+
+export async function createThread(
+  message: string,
+  assistant?: string,
+): Promise<HypervisorThread> {
+  const d = await request<{ thread: HypervisorThread }>('/api/hypervisor/threads', {
+    method: 'POST',
+    body: { message, assistant },
+  });
+  return d.thread;
+}
+
+export async function getThreadDetail(id: string, since = 0): Promise<HypervisorThreadDetail> {
+  return request<HypervisorThreadDetail>(`/api/hypervisor/threads/${encodeURIComponent(id)}`, {
+    query: { since },
+  });
+}
+
+export async function sendThreadMessage(id: string, message: string): Promise<void> {
+  await request(`/api/hypervisor/threads/${encodeURIComponent(id)}/messages`, {
+    method: 'POST',
+    body: { message },
+  });
+}
+
+export async function deleteThread(id: string): Promise<void> {
+  await request(`/api/hypervisor/threads/${encodeURIComponent(id)}`, { method: 'DELETE' });
 }

--- a/mobile/src/api/types.ts
+++ b/mobile/src/api/types.ts
@@ -136,3 +136,51 @@ export interface ControllerCapacity {
     memory: CapacityResource;
   } | null;
 }
+
+// ---- Hypervisor chat -------------------------------------------------------
+// A thread is a structured agent session; the server returns a canonical event
+// stream (see charts/workspace/hypervisor_session.py) the app renders directly.
+export type HvEventRole = 'user' | 'assistant' | 'system';
+export type HvEventType = 'message' | 'tool_call' | 'tool_result' | 'error' | 'status';
+
+export interface HvEvent {
+  seq: number;
+  ts: number;
+  role: HvEventRole;
+  type: HvEventType;
+  text?: string;
+  tool?: { name: string; input: unknown };
+  tool_id?: string;
+  tool_use_id?: string;
+  is_error?: boolean;
+  status?: string;
+}
+
+export interface HypervisorAssistant {
+  id: string;
+  label: string;
+  default?: boolean;
+  model?: string;
+}
+
+export interface HypervisorConfig {
+  enabled: boolean;
+  defaultAssistant: string;
+  workdir: string;
+  readOnly: boolean;
+  assistants: HypervisorAssistant[];
+}
+
+export interface HypervisorThread {
+  id: string;
+  title: string;
+  assistant: string | null;
+  status: string;
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+export interface HypervisorThreadDetail {
+  thread: HypervisorThread;
+  events: HvEvent[];
+}

--- a/mobile/src/components/NavDrawer.tsx
+++ b/mobile/src/components/NavDrawer.tsx
@@ -16,6 +16,7 @@ type Item = { name: string; label: string; icon: keyof typeof Ionicons.glyphMap;
 
 const ITEMS: Item[] = [
   { name: 'Desktop', label: 'Desktop', icon: 'grid-outline' },
+  { name: 'Hypervisor', label: 'Hypervisor', icon: 'chatbubbles-outline' },
   { name: 'Tasks', label: 'Builds', icon: 'layers-outline' },
   { name: 'Apps', label: 'Apps', icon: 'globe-outline' },
   { name: 'Memory', label: 'Memory', icon: 'bookmark-outline' },

--- a/mobile/src/screens/HypervisorScreen.tsx
+++ b/mobile/src/screens/HypervisorScreen.tsx
@@ -1,0 +1,418 @@
+/**
+ * Hypervisor — the workspace-aware chat tab, on mobile. Talks to the same
+ * /api/hypervisor facade as the dashboard SPA: a thread is a structured agent
+ * session and the server returns a canonical event stream (no terminal, no
+ * scraping), which buildTurns() folds into user bubbles + agent turns (prose +
+ * expandable tool-activity chips). See charts/workspace/hypervisor_session.py.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  createThread,
+  deleteThread,
+  getHypervisorConfig,
+  getThreadDetail,
+  listThreads,
+  sendThreadMessage,
+} from '../api/client';
+import type { HvEvent, HypervisorConfig, HypervisorThread } from '../api/types';
+import { buildTurns, type HvBlock } from '../util/hvTranscript';
+import { EmptyState, ErrorBanner, ScreenHeader } from '../components/ui';
+import { colors, font, radius, space } from '../theme';
+
+const SUGGESTIONS = [
+  "What's running and how much CPU am I using?",
+  'Spin up a task to run the tests',
+  'Remember that I deploy with `make ship`',
+];
+
+export default function HypervisorScreen() {
+  const insets = useSafeAreaInsets();
+  const [config, setConfig] = useState<HypervisorConfig | null>(null);
+  const [threads, setThreads] = useState<HypervisorThread[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [events, setEvents] = useState<HvEvent[]>([]);
+  const [status, setStatus] = useState<string>('');
+  const [draft, setDraft] = useState('');
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const scrollRef = useRef<ScrollView | null>(null);
+  const optimisticSeq = useRef(-1);
+
+  const refreshThreads = useCallback(async () => {
+    try {
+      setThreads(await listThreads());
+    } catch {
+      /* keep last-good */
+    }
+  }, []);
+
+  useEffect(() => {
+    void getHypervisorConfig()
+      .then(setConfig)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load config'));
+    void refreshThreads();
+  }, [refreshThreads]);
+
+  // Poll the open thread's canonical events while it's active.
+  useEffect(() => {
+    if (!activeId) return;
+    let alive = true;
+    const tick = async () => {
+      try {
+        const d = await getThreadDetail(activeId, 0);
+        if (!alive || d.thread.id !== activeId) return;
+        setEvents(d.events);
+        setStatus(d.thread.status);
+      } catch {
+        /* transient */
+      }
+    };
+    void tick();
+    const timer = setInterval(tick, 2000);
+    return () => {
+      alive = false;
+      clearInterval(timer);
+    };
+  }, [activeId]);
+
+  useEffect(() => {
+    const t = setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 60);
+    return () => clearTimeout(t);
+  }, [events]);
+
+  function openThread(id: string) {
+    setActiveId(id);
+    setEvents([]);
+    setStatus('');
+    setError(null);
+  }
+
+  function newChat() {
+    setActiveId(null);
+    setEvents([]);
+    setStatus('');
+    setError(null);
+    setDraft('');
+  }
+
+  async function removeThread(id: string) {
+    try {
+      await deleteThread(id);
+    } catch {
+      /* best effort */
+    }
+    if (activeId === id) newChat();
+    void refreshThreads();
+  }
+
+  async function send(text?: string) {
+    const msg = (text ?? draft).trim();
+    if (!msg || sending) return;
+    setSending(true);
+    setError(null);
+    setDraft('');
+    setStatus('running');
+    // Optimistic user turn (negative seq so it never collides with server seqs).
+    setEvents((prev) => [
+      ...prev,
+      { seq: optimisticSeq.current--, ts: Date.now() / 1000, role: 'user', type: 'message', text: msg },
+    ]);
+    try {
+      if (!activeId) {
+        const thread = await createThread(msg, config?.defaultAssistant);
+        await refreshThreads();
+        openThread(thread.id);
+      } else {
+        await sendThreadMessage(activeId, msg);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to send');
+    } finally {
+      setSending(false);
+    }
+  }
+
+  if (config && config.enabled === false) {
+    return (
+      <View style={styles.root}>
+        <ScreenHeader title="Hypervisor" />
+        <EmptyState icon="hardware-chip-outline" title="Hypervisor is disabled" subtitle="Enable it in the workspace chart (hypervisor.enabled)." />
+      </View>
+    );
+  }
+
+  const turns = buildTurns(events);
+  const agentName = config?.defaultAssistant || 'claude';
+  const activeThread = threads.find((t) => t.id === activeId) || null;
+  const working = status === 'running';
+  const empty = !activeId && events.length === 0;
+
+  return (
+    <View style={styles.root}>
+      <ScreenHeader
+        title={activeThread ? activeThread.title || 'Chat' : 'Hypervisor'}
+        subtitle={activeThread ? `via ${activeThread.assistant || agentName}` : 'Talk to your workspace'}
+        right={
+          <Pressable onPress={newChat} hitSlop={8} style={styles.newBtn}>
+            <Ionicons name="add" size={18} color={colors.accentText} />
+            <Text style={styles.newBtnText}>New</Text>
+          </Pressable>
+        }
+      />
+
+      {threads.length > 0 && (
+        <View style={styles.threadBar}>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.threadBarInner}>
+            {threads.map((t) => {
+              const on = t.id === activeId;
+              return (
+                <Pressable
+                  key={t.id}
+                  onPress={() => openThread(t.id)}
+                  onLongPress={() => removeThread(t.id)}
+                  style={[styles.threadChip, on && styles.threadChipOn]}
+                >
+                  <View style={[styles.dot, { backgroundColor: t.status === 'running' ? colors.running : colors.killed }]} />
+                  <Text numberOfLines={1} style={[styles.threadChipText, on && styles.threadChipTextOn]}>
+                    {t.title || 'New chat'}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+        </View>
+      )}
+
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={insets.top + 44}
+      >
+        <ScrollView ref={scrollRef} style={styles.flex} contentContainerStyle={styles.transcript}>
+          {empty ? (
+            <View style={styles.welcome}>
+              <EmptyState
+                icon="hardware-chip-outline"
+                title="Kube-Coder"
+                subtitle="Ask about your workspace or tell it what to do — it reads live state and acts on it through your tools."
+              />
+              <View style={styles.suggests}>
+                {SUGGESTIONS.map((s) => (
+                  <Pressable key={s} onPress={() => void send(s)} style={styles.suggest} disabled={sending}>
+                    <Text style={styles.suggestText}>{s}</Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+          ) : (
+            turns.map((turn, i) =>
+              turn.role === 'user' ? (
+                <View key={i} style={styles.userRow}>
+                  <View style={styles.userBubble}>
+                    <Text style={styles.userText}>{turn.text}</Text>
+                  </View>
+                </View>
+              ) : (
+                <View key={i} style={styles.agentRow}>
+                  <View style={styles.agentHead}>
+                    <Ionicons name="hardware-chip-outline" size={13} color={colors.textMuted} />
+                    <Text style={styles.agentName}>Kube-Coder</Text>
+                    <Text style={styles.agentVia}>via {agentName}</Text>
+                    {working && i === turns.length - 1 && <Text style={styles.working}>· working…</Text>}
+                  </View>
+                  {turn.blocks.map((b, j) => (
+                    <Block key={j} block={b} id={`${i}:${j}`} expanded={expanded} setExpanded={setExpanded} />
+                  ))}
+                </View>
+              ),
+            )
+          )}
+          {!empty && working && turns[turns.length - 1]?.role !== 'agent' && (
+            <View style={styles.agentRow}>
+              <View style={styles.agentHead}>
+                <Ionicons name="hardware-chip-outline" size={13} color={colors.textMuted} />
+                <Text style={styles.agentName}>Kube-Coder</Text>
+                <Text style={styles.working}>· working…</Text>
+              </View>
+            </View>
+          )}
+        </ScrollView>
+
+        {error && <ErrorBanner message={error} />}
+
+        <View style={[styles.composer, { paddingBottom: Math.max(insets.bottom, space.sm) }]}>
+          <TextInput
+            style={styles.input}
+            value={draft}
+            onChangeText={setDraft}
+            placeholder="Message Kube-Coder…"
+            placeholderTextColor={colors.textFaint}
+            multiline
+            editable={!sending}
+          />
+          <Pressable
+            onPress={() => void send()}
+            disabled={sending || !draft.trim()}
+            style={[styles.sendBtn, (sending || !draft.trim()) && styles.sendBtnOff]}
+          >
+            <Ionicons name="arrow-up" size={20} color={colors.accentText} />
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </View>
+  );
+}
+
+function Block({
+  block,
+  id,
+  expanded,
+  setExpanded,
+}: {
+  block: HvBlock;
+  id: string;
+  expanded: Set<string>;
+  setExpanded: (s: Set<string>) => void;
+}) {
+  if (block.kind === 'prose') {
+    return <Text style={styles.prose}>{block.text}</Text>;
+  }
+  const open = expanded.has(id);
+  const toggle = () => {
+    const next = new Set(expanded);
+    open ? next.delete(id) : next.add(id);
+    setExpanded(next);
+  };
+  return (
+    <View style={[styles.activity, block.error && styles.activityErr]}>
+      <Pressable onPress={toggle} style={styles.activityHead}>
+        <Ionicons name="terminal-outline" size={13} color={block.error ? colors.danger : colors.textMuted} />
+        <Text style={[styles.activityLabel, block.error && { color: colors.danger }]} numberOfLines={1}>
+          {block.label}
+        </Text>
+        <Ionicons name={open ? 'chevron-up' : 'chevron-down'} size={14} color={colors.textFaint} />
+      </Pressable>
+      {open && block.detail ? <Text style={styles.activityDetail}>{block.detail}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: colors.bg },
+  flex: { flex: 1 },
+  newBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    backgroundColor: colors.accent,
+    paddingHorizontal: space.md,
+    paddingVertical: space.xs + 2,
+    borderRadius: radius.md,
+  },
+  newBtnText: { color: colors.accentText, fontWeight: '700', fontSize: font.size.sm },
+  threadBar: { borderBottomWidth: 1, borderBottomColor: colors.border },
+  threadBarInner: { paddingHorizontal: space.md, paddingVertical: space.sm, gap: space.sm },
+  threadChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    maxWidth: 180,
+    paddingHorizontal: space.md,
+    paddingVertical: space.xs + 2,
+    borderRadius: radius.sm,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.card,
+  },
+  threadChipOn: { borderColor: colors.borderStrong, backgroundColor: colors.accentSoft },
+  threadChipText: { color: colors.textMuted, fontSize: font.size.sm, flexShrink: 1 },
+  threadChipTextOn: { color: colors.text },
+  dot: { width: 7, height: 7, borderRadius: 4 },
+  transcript: { padding: space.lg, gap: space.md },
+  welcome: { paddingTop: space.xxl, gap: space.lg },
+  suggests: { gap: space.sm, paddingHorizontal: space.lg },
+  suggest: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingHorizontal: space.md,
+    paddingVertical: space.md,
+    backgroundColor: colors.card,
+  },
+  suggestText: { color: colors.textMuted, fontSize: font.size.sm },
+  userRow: { alignItems: 'flex-end' },
+  userBubble: {
+    maxWidth: '86%',
+    backgroundColor: colors.surface2,
+    borderRadius: radius.lg,
+    paddingHorizontal: space.md,
+    paddingVertical: space.sm,
+  },
+  userText: { color: colors.text, fontSize: font.size.md, lineHeight: 21 },
+  agentRow: { gap: space.sm },
+  agentHead: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  agentName: { color: colors.text, fontWeight: '700', fontSize: font.size.sm },
+  agentVia: { color: colors.textFaint, fontSize: font.size.xs },
+  working: { color: colors.textFaint, fontSize: font.size.xs, fontStyle: 'italic' },
+  prose: { color: colors.text, fontSize: font.size.md, lineHeight: 22 },
+  activity: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    backgroundColor: colors.card,
+    overflow: 'hidden',
+  },
+  activityErr: { borderColor: colors.danger },
+  activityHead: { flexDirection: 'row', alignItems: 'center', gap: 8, padding: space.sm },
+  activityLabel: { flex: 1, color: colors.textMuted, fontSize: font.size.sm, fontWeight: '600' },
+  activityDetail: {
+    color: colors.textMuted,
+    fontSize: font.size.xs,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+    padding: space.sm,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  composer: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: space.sm,
+    paddingHorizontal: space.md,
+    paddingTop: space.sm,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    backgroundColor: colors.bgElevated,
+  },
+  input: {
+    flex: 1,
+    maxHeight: 120,
+    color: colors.text,
+    fontSize: font.size.md,
+    backgroundColor: colors.surface2,
+    borderRadius: radius.md,
+    paddingHorizontal: space.md,
+    paddingVertical: space.sm,
+  },
+  sendBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: radius.md,
+    backgroundColor: colors.accent,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  sendBtnOff: { opacity: 0.4 },
+});

--- a/mobile/src/util/hvTranscript.ts
+++ b/mobile/src/util/hvTranscript.ts
@@ -1,0 +1,104 @@
+/**
+ * Group the Hypervisor's canonical event stream (see charts/workspace/
+ * hypervisor_session.py) into render-ready chat turns — the mobile port of the
+ * web app's transcript.ts buildTurns(). The backend delivers structured events
+ * (assistant prose, tool calls/results, errors), so there is NO screen
+ * scraping: we just fold events into user bubbles and agent turns.
+ */
+import type { HvEvent } from '../api/types';
+
+export type HvBlock =
+  | { kind: 'prose'; text: string }
+  | { kind: 'activity'; label: string; detail: string; error?: boolean };
+
+export type HvTurn =
+  | { role: 'user'; text: string }
+  | { role: 'agent'; blocks: HvBlock[] };
+
+function prettyInput(input: unknown): string {
+  if (input == null) return '';
+  if (typeof input === 'string') return input;
+  if (typeof input === 'object') {
+    const o = input as Record<string, unknown>;
+    for (const k of ['command', 'file_path', 'path', 'query', 'pattern', 'url']) {
+      if (typeof o[k] === 'string' && Object.keys(o).length <= 2) return o[k] as string;
+    }
+    try {
+      return JSON.stringify(input, null, 2);
+    } catch {
+      return String(input);
+    }
+  }
+  return String(input);
+}
+
+function toolLabel(name: string): string {
+  const n = (name || 'tool').toLowerCase();
+  const map: Record<string, string> = {
+    bash: 'Ran command',
+    read: 'Read file',
+    write: 'Wrote file',
+    edit: 'Edited file',
+    multiedit: 'Edited file',
+    grep: 'Searched',
+    glob: 'Searched files',
+    task: 'Ran a task',
+    webfetch: 'Fetched a page',
+    websearch: 'Searched the web',
+  };
+  if (map[n]) return map[n];
+  const mcp = name.match(/^mcp__[^_]+__(.+)$/);
+  if (mcp) return mcp[1].replace(/_/g, ' ');
+  return name;
+}
+
+export function buildTurns(events: HvEvent[]): HvTurn[] {
+  const turns: HvTurn[] = [];
+  let agent: { role: 'agent'; blocks: HvBlock[] } | null = null;
+
+  const openAgent = () => {
+    if (!agent) {
+      agent = { role: 'agent', blocks: [] };
+      turns.push(agent);
+    }
+    return agent;
+  };
+
+  for (const e of events) {
+    if (e.role === 'user' && e.type === 'message') {
+      agent = null;
+      turns.push({ role: 'user', text: e.text || '' });
+      continue;
+    }
+    if (e.type === 'message' && (e.text || '').trim()) {
+      openAgent().blocks.push({ kind: 'prose', text: e.text || '' });
+    } else if (e.type === 'tool_call') {
+      openAgent().blocks.push({
+        kind: 'activity',
+        label: toolLabel(e.tool?.name || 'tool'),
+        detail: prettyInput(e.tool?.input),
+      });
+    } else if (e.type === 'tool_result') {
+      const blocks = openAgent().blocks;
+      const last = [...blocks].reverse().find((b) => b.kind === 'activity') as
+        | { kind: 'activity'; label: string; detail: string; error?: boolean }
+        | undefined;
+      const result = (e.text || '').trim();
+      if (last && result) {
+        last.detail = `${last.detail}\n\n— result —\n${result}`.trim();
+        if (e.is_error) last.error = true;
+      } else if (result) {
+        blocks.push({ kind: 'activity', label: 'Result', detail: result, error: e.is_error });
+      }
+    } else if (e.type === 'error') {
+      openAgent().blocks.push({
+        kind: 'activity',
+        label: 'Error',
+        detail: e.text || 'unknown error',
+        error: true,
+      });
+    }
+    // 'status' events carry no chat content.
+  }
+  return turns;
+}


### PR DESCRIPTION
The mobile app had **no Hypervisor tab** (screens were Desktop, Tasks, Apps, Memory, Metrics, Controller, Settings). This adds one, so the new Hypervisor is usable on mobile — talking to the same `/api/hypervisor` facade as the dashboard SPA.

## What's included

- **`api/types.ts` + `api/client.ts`** — `getHypervisorConfig`, `listThreads`, `createThread`, `getThreadDetail(id, since)`, `sendThreadMessage`, `deleteThread`. Polls canonical events with `?since` (no SSE — same model the task screens use; EventSource can't send the bearer token).
- **`util/hvTranscript.ts`** — `buildTurns()` ported from the web `transcript.ts`: folds the canonical event stream into user bubbles + agent turns (prose + tool-activity chips). No screen scraping — the backend already delivers structured events.
- **`screens/HypervisorScreen.tsx`** — thread bar (tap to open, long-press to delete), transcript, welcome + one-tap suggestions, composer with optimistic send + 2s polling. Matches the app's Editorial theme + `ui.tsx` primitives.
- **`App.tsx` + `NavDrawer`** — registers the tab (drawer entry "Hypervisor", chat icon), placed right after Desktop.

## Verification

- `tsc --noEmit` clean.
- ⚠️ **Needs a device/simulator smoke-test** against a live workspace — I couldn't run the React Native app in this environment. The API contract is the same one already verified end-to-end on the deployed backend (#216).

Depends on the backend from #215 (merged/deployed as v1.16.0) + #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)