### PR TITLE
fix(hypervisor): serve the SPA on a /hypervisor hard reload (was 404)

### DIFF
--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -3444,7 +3444,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             path in ('/', '/dashboard', '/dashboard/', '/browser', '/browser/', '/next', '/next/')
             or path.startswith('/next/')
             or any(path == r or path.startswith(r + '/')
-                   for r in ('/tasks', '/memory', '/apps', '/triggers', '/files', '/docs', '/settings'))
+                   for r in ('/tasks', '/memory', '/apps', '/triggers', '/files', '/docs', '/settings', '/desktop', '/hypervisor'))
         )
         if is_html or is_spa_route:
             self.send_header('Cache-Control', 'no-cache, must-revalidate')
@@ -3477,7 +3477,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         # client-side routing handles deep links. The legacy dashboard.html
         # has been removed; if /opt/dashboard-dist is missing we return 503
         # rather than fall back to anything stale.
-        SPA_TOP_LEVEL = {'/', '/tasks', '/memory', '/apps', '/triggers', '/files', '/docs', '/settings', '/desktop'}
+        SPA_TOP_LEVEL = {'/', '/tasks', '/memory', '/apps', '/triggers', '/files', '/docs', '/settings', '/desktop', '/hypervisor'}
         first_seg = '/' + normalized_path.split('/')[1] if normalized_path != '/' else '/'
         if normalized_path == "/next" or normalized_path == "/next/" or normalized_path.startswith("/next/"):
             rel = normalized_path[len("/next"):] if normalized_path.startswith("/next") else ""


### PR DESCRIPTION
## Problem

Reloading (or returning after a while to) `https://<workspace>/hypervisor` shows a **404**, forcing the user to re-navigate to the page.

## Root cause

`server.py` allowlists which top-level paths serve the SPA's `index.html` so client-side deep links / hard reloads work — `SPA_TOP_LEVEL` (route dispatch) and the Cache-Control revalidation list in `end_headers`. **`/hypervisor` was added to the frontend router but never to these server lists**, so a hard reload of `/hypervisor` fell through to the static-file 404 instead of serving the SPA (which would then route to the chat client-side).

## Fix

Add `/hypervisor` to both `SPA_TOP_LEVEL` and the Cache-Control SPA-route list (also added `/desktop`, which was in `SPA_TOP_LEVEL` but missing from the Cache-Control list — same latent staleness bug). Ships via ConfigMap (no image rebuild).

## Verification

- `server.py` compiles; existing server tests unaffected (110 pass).
- Behavior: `GET /hypervisor` now serves `index.html` → the SPA mounts and routes to the Hypervisor tab, so reload / deep-link works and the page reopens cleanly.

_Note: there's no server-side route unit-test harness to extend; the change is a one-entry addition to two existing allowlists._