### PR TITLE
feat(hypervisor): render live app previews + images/videos in chat (backend + web)

### DIFF
--- a/charts/workspace/mcp_dashboard.py
+++ b/charts/workspace/mcp_dashboard.py
@@ -223,6 +223,52 @@ def _t_list_triggers(a):
 
 
 # ───────────────────────────────────────────────────────────────────────────
+# Tool handlers — render (Hypervisor rich content)
+#
+# These don't mutate anything; they exist so the agent can render live app
+# previews / images / videos inline in the Hypervisor chat. The render SIGNAL is
+# the tool CALL itself (name + input), which the chat frontend keys off — the
+# text returned here is just confirmation for the agent.
+# ───────────────────────────────────────────────────────────────────────────
+
+def _t_show_app_preview(a):
+    port = a.get('port')
+    if isinstance(port, str) and port.isdigit():
+        port = int(port)
+    if not isinstance(port, int) or isinstance(port, bool) or port <= 0:
+        return _err('port (a positive number) is required')
+    # Best-effort note about whether a listener is up — still render regardless,
+    # since the app may be mid-startup.
+    _, apps = _api('GET', '/api/apps')
+    status = None
+    if isinstance(apps, dict):
+        for app in apps.get('apps', []) or []:
+            if app.get('port') == port:
+                status = app.get('status')
+                break
+    note = f'Embedding a live preview of the app on port {port} in the chat.'
+    if status and status != 'running':
+        note += f' (/api/apps reports this port as "{status}".)'
+    elif status is None:
+        note += ' (no listener detected yet — it may still be starting.)'
+    return _ok(note)
+
+
+def _t_show_media(a):
+    media_kind = (a.get('media_kind') or a.get('kind') or 'image').strip().lower()
+    if media_kind not in ('image', 'video'):
+        return _err("media_kind must be 'image' or 'video'")
+    path = (a.get('path') or '').strip()
+    url = (a.get('url') or '').strip()
+    if bool(path) == bool(url):
+        return _err('provide exactly one of: path (a file under /home/dev) or url (http[s])')
+    if url and not (url.startswith('http://') or url.startswith('https://')):
+        return _err('url must be http(s)')
+    where = f'file {path}' if path else url
+    return _ok(f'Rendering {media_kind} ({where}) in the chat.')
+
+
+# ───────────────────────────────────────────────────────────────────────────
 # Tool handlers — safe write
 # ───────────────────────────────────────────────────────────────────────────
 
@@ -388,6 +434,40 @@ TOOLS: Dict[str, Any] = {
         'list_triggers',
         'List configured webhooks and cron schedules (the Triggers tab).',
         _t_list_triggers),
+
+    # ── render (Hypervisor rich content) ────────────────────────────────────
+    'show_app_preview': _tool(
+        'show_app_preview',
+        'Embed a LIVE preview (iframe) of an app running on a local port inline '
+        'in the Hypervisor chat. Call this when you start, build, or want to show '
+        'a running web app — e.g. after launching a dev server. Use list_apps to '
+        'find the port if unsure.',
+        _t_show_app_preview,
+        properties={
+            'port': {'type': 'number',
+                     'description': 'The local port the app is listening on.'},
+            'title': {'type': 'string',
+                      'description': 'Optional caption shown above the preview.'},
+            'height': {'type': 'number',
+                       'description': 'Optional preview height in px (default ~280).'},
+        }, required=['port']),
+    'show_media': _tool(
+        'show_media',
+        'Render an image or video inline in the Hypervisor chat. Source is either '
+        'a workspace file path under /home/dev (e.g. a screenshot you just saved) '
+        'or an http(s) URL. Call this proactively when you produce or reference a '
+        'visual.',
+        _t_show_media,
+        properties={
+            'media_kind': {'type': 'string',
+                           'description': "'image' or 'video'."},
+            'path': {'type': 'string',
+                     'description': 'A file under /home/dev (relative), e.g. shot.png.'},
+            'url': {'type': 'string',
+                    'description': 'An http(s) URL (use instead of path).'},
+            'title': {'type': 'string', 'description': 'Optional caption.'},
+            'height': {'type': 'number', 'description': 'Optional max height in px.'},
+        }, required=['media_kind']),
 
     # ── safe write ────────────────────────────────────────────────────────
     'create_task': _tool(

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -92,9 +92,14 @@ HYPERVISOR_PREAMBLE = (
     "to act on it (create_task, send_task_message, add_memory, pin_app). "
     "Destructive tools (kill_task, delete_memory) require confirm=true — first "
     "tell the user exactly what you'll do and get their explicit approval in the "
-    "chat, then call again with confirm=true. Prefer these tools for any question "
-    "about, or action on, the workspace. Answer from tool results, not memory. Be "
-    "concise and conversational.]\n\n"
+    "chat, then call again with confirm=true. "
+    "You can also render rich content inline in this chat: call show_app_preview "
+    "with a running app's port to embed a LIVE preview of it, and show_media to "
+    "display an image or video (a workspace file path under /home/dev, or an http "
+    "URL). Do this proactively — when you start or build an app, show its preview; "
+    "when you produce a screenshot or image, show it. "
+    "Prefer these tools for any question about, or action on, the workspace. "
+    "Answer from tool results, not memory. Be concise and conversational.]\n\n"
 )
 # TRUSTED_PROXY=true tells check_claude_auth it's safe to honor
 # X-Auth-Request-User / X-Auth-Request-Email / Remote-User headers from the
@@ -3701,6 +3706,10 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         if claude_path == '/api/files/list':
             self.handle_files_list()
             return
+        # Stream a workspace media file (Hypervisor image/video rendering).
+        if claude_path == '/api/files/raw':
+            self.handle_file_raw()
+            return
 
         super().do_GET()
 
@@ -5683,6 +5692,86 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         if rel == '.':
             rel = ''
         self.send_json({'path': rel, 'entries': entries})
+
+    def handle_file_raw(self):
+        """GET /api/files/raw?path=<rel> — stream a workspace MEDIA file.
+
+        Auth-gated + traversal-guarded (reuses _resolve_under_home_dev). Powers
+        the Hypervisor chat's image/video rendering: the agent saves a file under
+        /home/dev and shows it via show_media(path=...), and the client fetches
+        the bytes here.
+
+        SECURITY: restricted to image/* and video/* by content type. The
+        dashboard is served from this same origin with no CSP, so serving an
+        arbitrary /home/dev HTML/JS file here would be stored XSS — refuse
+        anything that isn't media, and send nosniff + inline disposition.
+        Supports a single Range request so <video> seeking works.
+        """
+        if not self.check_claude_auth():
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        qs = urllib.parse.urlparse(self.path).query
+        rel = (urllib.parse.parse_qs(qs).get('path', [''])[0] or '').strip()
+        try:
+            target = self._resolve_under_home_dev(rel)
+        except ValueError as e:
+            self.send_json({'error': str(e)}, 400)
+            return
+        if not os.path.isfile(target):
+            self.send_json({'error': 'not a file'}, 404)
+            return
+        ctype = mimetypes.guess_type(target)[0] or ''
+        if not (ctype.startswith('image/') or ctype.startswith('video/')):
+            self.send_json(
+                {'error': 'only image/* and video/* files can be served here'}, 415)
+            return
+        try:
+            size = os.path.getsize(target)
+            start, end = 0, size - 1
+            is_range = False
+            rng = self.headers.get('Range', '')
+            m = re.match(r'^bytes=(\d*)-(\d*)$', rng.strip()) if rng else None
+            if m and size > 0:
+                s, e = m.group(1), m.group(2)
+                if s:
+                    start = int(s)
+                    end = int(e) if e else size - 1
+                elif e:  # suffix range: last N bytes
+                    start = max(0, size - int(e))
+                    end = size - 1
+                if start > end or start >= size:
+                    self.send_response(416)
+                    self.send_header('Content-Range', f'bytes */{size}')
+                    self.end_headers()
+                    return
+                is_range = True
+            length = end - start + 1
+            with open(target, 'rb') as fh:
+                self.send_response(206 if is_range else 200)
+                self.send_header('Content-Type', ctype)
+                self.send_header('Content-Length', str(length))
+                self.send_header('Accept-Ranges', 'bytes')
+                if is_range:
+                    self.send_header('Content-Range', f'bytes {start}-{end}/{size}')
+                self.send_header('Content-Disposition', 'inline')
+                self.send_header('X-Content-Type-Options', 'nosniff')
+                self.send_header('Cache-Control', 'private, max-age=60')
+                self.end_headers()
+                fh.seek(start)
+                remaining = length
+                while remaining > 0:
+                    chunk = fh.read(min(64 * 1024, remaining))
+                    if not chunk:
+                        break
+                    self.wfile.write(chunk)
+                    remaining -= len(chunk)
+        except (BrokenPipeError, ConnectionResetError):
+            pass  # client went away mid-stream; headers already sent
+        except OSError as e:
+            try:
+                self.send_json({'error': f'read failed: {e}'}, 500)
+            except Exception:
+                pass
 
     def handle_file_upload(self):
         if not self.check_claude_auth():

--- a/charts/workspace/tests/mcp_dashboard_test.py
+++ b/charts/workspace/tests/mcp_dashboard_test.py
@@ -1,0 +1,51 @@
+"""Unit tests for the Hypervisor render tools in mcp_dashboard.py.
+
+The render tools (show_app_preview, show_media) exist so the agent can render
+live app previews / images / videos inline in the chat. The render signal is the
+tool CALL (name + input) which the frontend keys off; these tests cover the
+argument validation and registration.
+
+Run with:    python3 -m unittest tests.mcp_dashboard_test
+(from charts/workspace/)
+"""
+
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+import mcp_dashboard as m  # noqa: E402
+
+
+class RenderToolsTest(unittest.TestCase):
+    def test_tools_registered_as_read(self):
+        for name in ('show_app_preview', 'show_media'):
+            self.assertIn(name, m.TOOLS)
+            self.assertEqual(m.TOOLS[name]['kind'], 'read')  # available under READONLY_MODE
+
+    def test_show_media_requires_exactly_one_source(self):
+        self.assertTrue(m._t_show_media({'media_kind': 'image'}).get('isError'))
+        self.assertTrue(m._t_show_media(
+            {'media_kind': 'image', 'path': 'a.png', 'url': 'http://x/a.png'}).get('isError'))
+
+    def test_show_media_rejects_bad_kind_and_scheme(self):
+        self.assertTrue(m._t_show_media({'media_kind': 'gif', 'path': 'a.gif'}).get('isError'))
+        self.assertTrue(m._t_show_media(
+            {'media_kind': 'image', 'url': 'ftp://x/a.png'}).get('isError'))
+
+    def test_show_media_accepts_path_and_url(self):
+        self.assertFalse(m._t_show_media({'media_kind': 'image', 'path': 'shot.png'}).get('isError'))
+        self.assertFalse(m._t_show_media(
+            {'media_kind': 'video', 'url': 'https://x/clip.mp4'}).get('isError'))
+
+    def test_show_app_preview_requires_positive_port(self):
+        self.assertTrue(m._t_show_app_preview({}).get('isError'))
+        self.assertTrue(m._t_show_app_preview({'port': 'abc'}).get('isError'))
+        self.assertTrue(m._t_show_app_preview({'port': 0}).get('isError'))
+        # A valid port doesn't error even when /api/apps is unreachable in tests.
+        self.assertFalse(m._t_show_app_preview({'port': 3000}).get('isError'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/web/src/routes/hypervisor/Chat.tsx
+++ b/charts/workspace/web/src/routes/hypervisor/Chat.tsx
@@ -16,6 +16,8 @@ import {
 } from '../../store/hypervisor';
 import { WorkspaceContext } from './WorkspaceContext';
 import { buildTurns, renderMarkdown, type Block } from './transcript';
+import { proxyUrl } from '../../api/apps';
+import { withOauthPrefix } from '../../api/client';
 
 /**
  * The chat transcript + composer. The backend delivers a canonical event stream
@@ -48,21 +50,98 @@ function ActivityChip({ label, detail, error }: { label: string; detail: string;
   );
 }
 
+/** Live preview of a running app, embedded via the app-proxy iframe (same
+ *  machinery as the Apps page). Falls back to an "Open in Apps" link when the
+ *  frame can't authenticate (non-oauth2 deployments). */
+function EmbedBlock({ port, title, height }: { port: number; title?: string; height?: number }) {
+  const [key, setKey] = useState(0);
+  const h = height && height >= 80 ? height : 280;
+  return (
+    <figure class="hv-embed">
+      <figcaption class="hv-embed-head">
+        <span class="hv-embed-title">{title || `App on :${port}`}</span>
+        <span class="hv-embed-actions">
+          <button type="button" class="hv-embed-btn" onClick={() => setKey((k) => k + 1)}>
+            Reload
+          </button>
+          <a class="hv-embed-btn" href={`/apps/${port}`}>
+            Open <Icon name="link" size={11} />
+          </a>
+        </span>
+      </figcaption>
+      <iframe
+        key={key}
+        class="hv-embed-frame"
+        style={{ height: `${h}px` }}
+        src={proxyUrl(port)}
+        title={title || `Application on port ${port}`}
+        sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-downloads"
+      />
+    </figure>
+  );
+}
+
+/** An inline image or video. Workspace files go through the authed
+ *  /api/files/raw endpoint; external URLs are used directly. */
+function MediaBlock({
+  mediaKind,
+  path,
+  url,
+  title,
+  height,
+}: {
+  mediaKind: 'image' | 'video';
+  path?: string;
+  url?: string;
+  title?: string;
+  height?: number;
+}) {
+  const src = url || (path ? `${withOauthPrefix('/api/files/raw')}?path=${encodeURIComponent(path)}` : '');
+  if (!src) return null;
+  const maxH = height && height >= 40 ? height : 420;
+  return (
+    <figure class="hv-media">
+      {mediaKind === 'video' ? (
+        <video class="hv-media-el" src={src} controls preload="metadata" style={{ maxHeight: `${maxH}px` }} />
+      ) : (
+        <img class="hv-media-el" src={src} alt={title || 'image'} loading="lazy" style={{ maxHeight: `${maxH}px` }} />
+      )}
+      {title && <figcaption class="hv-media-cap">{title}</figcaption>}
+    </figure>
+  );
+}
+
 function AgentBlocks({ blocks }: { blocks: Block[] }) {
   return (
     <>
-      {blocks.map((b, i) =>
-        b.kind === 'prose' ? (
-          <div
-            key={i}
-            class="hv-prose"
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: renderMarkdown(b.text) }}
-          />
-        ) : (
-          <ActivityChip key={i} label={b.label} detail={b.detail} error={b.error} />
-        ),
-      )}
+      {blocks.map((b, i) => {
+        switch (b.kind) {
+          case 'prose':
+            return (
+              <div
+                key={i}
+                class="hv-prose"
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{ __html: renderMarkdown(b.text) }}
+              />
+            );
+          case 'embed':
+            return <EmbedBlock key={i} port={b.port} title={b.title} height={b.height} />;
+          case 'media':
+            return (
+              <MediaBlock
+                key={i}
+                mediaKind={b.mediaKind}
+                path={b.path}
+                url={b.url}
+                title={b.title}
+                height={b.height}
+              />
+            );
+          default:
+            return <ActivityChip key={i} label={b.label} detail={b.detail} error={b.error} />;
+        }
+      })}
     </>
   );
 }

--- a/charts/workspace/web/src/routes/hypervisor/hypervisor.css
+++ b/charts/workspace/web/src/routes/hypervisor/hypervisor.css
@@ -717,3 +717,66 @@
   .hv-msg { max-width: 92%; }
   .hv-transcript { padding: var(--size-3) var(--size-3) var(--size-4); }
 }
+
+/* ── Rich content: live app preview (iframe) + media (image/video) ───────── */
+.hv-embed {
+  margin: 2px 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--surface);
+}
+.hv-embed-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--size-2);
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+}
+.hv-embed-title {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.hv-embed-actions { display: flex; gap: 4px; flex-shrink: 0; }
+.hv-embed-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px 8px;
+  font: inherit;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-decoration: none;
+}
+.hv-embed-btn:hover { color: var(--text); border-color: var(--border-strong, var(--border)); }
+.hv-embed-frame {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: #fff;
+}
+
+.hv-media { margin: 2px 0; }
+.hv-media-el {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+}
+.hv-media-cap {
+  margin-top: 4px;
+  font-size: 11.5px;
+  color: var(--text-subtle);
+}

--- a/charts/workspace/web/src/routes/hypervisor/transcript.test.ts
+++ b/charts/workspace/web/src/routes/hypervisor/transcript.test.ts
@@ -10,6 +10,54 @@ describe('buildTurns', () => {
     expect(buildTurns([])).toEqual([]);
   });
 
+  it('renders show_app_preview as an embed block', () => {
+    const turns = buildTurns([
+      ev({ role: 'assistant', type: 'tool_call', tool_id: 'p1',
+           tool: { name: 'mcp__dashboard__show_app_preview', input: { port: '3000', title: 'Vite', height: 320 } } }, 1),
+      ev({ role: 'system', type: 'tool_result', tool_use_id: 'p1', text: 'Embedding…' }, 2),
+    ]);
+    if (turns[0].role === 'agent') {
+      expect(turns[0].blocks).toHaveLength(1); // result swallowed
+      const b = turns[0].blocks[0];
+      expect(b).toEqual({ kind: 'embed', port: 3000, title: 'Vite', height: 320 });
+    }
+  });
+
+  it('renders show_media (path/image) and (url/video) as media blocks', () => {
+    const turns = buildTurns([
+      ev({ role: 'assistant', type: 'tool_call', tool_id: 'm1',
+           tool: { name: 'mcp__dashboard__show_media', input: { media_kind: 'image', path: 'shot.png' } } }, 1),
+      ev({ role: 'assistant', type: 'tool_call', tool_id: 'm2',
+           tool: { name: 'mcp__dashboard__show_media', input: { media_kind: 'video', url: 'https://x/c.mp4' } } }, 2),
+    ]);
+    if (turns[0].role === 'agent') {
+      expect(turns[0].blocks[0]).toEqual({ kind: 'media', mediaKind: 'image', path: 'shot.png', url: undefined, title: undefined, height: undefined });
+      expect(turns[0].blocks[1]).toEqual({ kind: 'media', mediaKind: 'video', path: undefined, url: 'https://x/c.mp4', title: undefined, height: undefined });
+    }
+  });
+
+  it('keeps a render tool error visible instead of swallowing it', () => {
+    const turns = buildTurns([
+      ev({ role: 'assistant', type: 'tool_call', tool_id: 'm1',
+           tool: { name: 'mcp__dashboard__show_media', input: { media_kind: 'image', path: 'x.png' } } }, 1),
+      ev({ role: 'system', type: 'tool_result', tool_use_id: 'm1', is_error: true, text: 'file not found' }, 2),
+    ]);
+    if (turns[0].role === 'agent') {
+      const hasError = turns[0].blocks.some((b) => b.kind === 'activity' && b.error);
+      expect(hasError).toBe(true);
+    }
+  });
+
+  it('falls back to an activity chip for an unrenderable render call (missing port)', () => {
+    const turns = buildTurns([
+      ev({ role: 'assistant', type: 'tool_call', tool_id: 'p1',
+           tool: { name: 'mcp__dashboard__show_app_preview', input: {} } }, 1),
+    ]);
+    if (turns[0].role === 'agent') {
+      expect(turns[0].blocks[0].kind).toBe('activity');
+    }
+  });
+
   it('groups a user turn then an agent prose turn', () => {
     const turns = buildTurns([
       ev({ role: 'user', type: 'message', text: 'hi' }, 1),

--- a/charts/workspace/web/src/routes/hypervisor/transcript.ts
+++ b/charts/workspace/web/src/routes/hypervisor/transcript.ts
@@ -31,10 +31,44 @@ export interface HvEvent {
   status?: string;
 }
 
-/** A block inside an agent turn: prose (markdown) or a tool/command activity. */
+/** A block inside an agent turn. Besides prose + tool-activity, the agent can
+ *  render rich content by calling the dashboard MCP render tools (show_app_preview
+ *  / show_media) — those tool_calls become `embed` / `media` blocks here. */
 export type Block =
   | { kind: 'prose'; text: string }
-  | { kind: 'activity'; label: string; detail: string; error?: boolean };
+  | { kind: 'activity'; label: string; detail: string; error?: boolean }
+  | { kind: 'embed'; port: number; title?: string; height?: number }
+  | { kind: 'media'; mediaKind: 'image' | 'video'; path?: string; url?: string; title?: string; height?: number };
+
+/** MCP render tools whose tool_call renders inline instead of a text chip. */
+const APP_PREVIEW_TOOL = 'mcp__dashboard__show_app_preview';
+const MEDIA_TOOL = 'mcp__dashboard__show_media';
+
+function num(v: unknown): number | undefined {
+  const n = typeof v === 'string' ? Number(v) : (v as number);
+  return typeof n === 'number' && Number.isFinite(n) ? n : undefined;
+}
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim() ? v : undefined;
+}
+
+/** Map a render tool_call to its block, or null if it isn't a render tool. */
+function renderBlock(name: string, input: unknown): Block | null {
+  const a = (input || {}) as Record<string, unknown>;
+  if (name === APP_PREVIEW_TOOL) {
+    const port = num(a.port);
+    if (port === undefined) return null;
+    return { kind: 'embed', port, title: str(a.title), height: num(a.height) };
+  }
+  if (name === MEDIA_TOOL) {
+    const mediaKind = a.media_kind === 'video' ? 'video' : 'image';
+    const path = str(a.path);
+    const url = str(a.url);
+    if (!path && !url) return null;
+    return { kind: 'media', mediaKind, path, url, title: str(a.title), height: num(a.height) };
+  }
+  return null;
+}
 
 /** A rendered turn: a user bubble or an agent turn made of blocks. */
 export type Turn =
@@ -85,6 +119,9 @@ function toolLabel(name: string): string {
 export function buildTurns(events: HvEvent[]): Turn[] {
   const turns: Turn[] = [];
   let agent: { role: 'agent'; blocks: Block[] } | null = null;
+  // tool_use_ids of render tool_calls — their tool_result is confirmation text
+  // we swallow (the rendered block is the real output), unless it errored.
+  const renderIds = new Set<string>();
 
   const openAgent = () => {
     if (!agent) {
@@ -103,12 +140,20 @@ export function buildTurns(events: HvEvent[]): Turn[] {
     if (e.type === 'message' && (e.text || '').trim()) {
       openAgent().blocks.push({ kind: 'prose', text: e.text || '' });
     } else if (e.type === 'tool_call') {
-      openAgent().blocks.push({
-        kind: 'activity',
-        label: toolLabel(e.tool?.name || 'tool'),
-        detail: prettyInput(e.tool?.input),
-      });
+      const rendered = renderBlock(e.tool?.name || '', e.tool?.input);
+      if (rendered) {
+        if (e.tool_id) renderIds.add(e.tool_id);
+        openAgent().blocks.push(rendered);
+      } else {
+        openAgent().blocks.push({
+          kind: 'activity',
+          label: toolLabel(e.tool?.name || 'tool'),
+          detail: prettyInput(e.tool?.input),
+        });
+      }
     } else if (e.type === 'tool_result') {
+      // Swallow a render tool's confirmation result (unless it failed).
+      if (e.tool_use_id && renderIds.has(e.tool_use_id) && !e.is_error) continue;
       const blocks = openAgent().blocks;
       const last = [...blocks].reverse().find((b) => b.kind === 'activity') as
         | { kind: 'activity'; label: string; detail: string; error?: boolean }


### PR DESCRIPTION
## What

Lets the Hypervisor LLM render **rich content inline in the chat**: a **live app preview** (iframe of a running port), and **images/videos** (workspace files or external URLs). Backend + web here; **mobile parity and video are follow-up PRs** (this stack).

## How it works (no new transport)

Two new **read-only** dashboard MCP tools. When the agent calls one, it appears in the canonical event stream as a `tool_call` with name `mcp__dashboard__<tool>` + its input — which the frontend already receives. `buildTurns` keys off the tool name to render an embed/media block instead of a text chip. **No new event type, no schema/transport change.**

## Backend

- **`mcp_dashboard.py`** — `show_app_preview(port, title?, height?)` and `show_media(media_kind, path?|url?, title?, height?)`. Both `kind='read'` so they work under `READONLY_MODE`. `HYPERVISOR_PREAMBLE` updated so the agent renders proactively.
- **`server.py`** — `GET /api/files/raw?path=` streams a workspace media file: auth-gated, traversal-guarded (reuses `_resolve_under_home_dev`), **restricted to `image/*` + `video/*`** with `nosniff` + `inline` (a `/home/dev` HTML file can never be served same-origin → prevents stored XSS), plus single-`Range` support so `<video>` seeking works.

## Web

- **`transcript.ts`** — new `embed` / `media` `Block` kinds; `buildTurns` maps the two render tool_calls to them and swallows their confirmation `tool_result` (unless it errored).
- **`Chat.tsx`** — `EmbedBlock` (iframe via `proxyUrl`, reuses the Apps app-proxy; Reload + "Open in Apps") and `MediaBlock` (`<img>`/`<video>`; workspace files via `/api/files/raw` with the oauth prefix, external URLs direct). `hypervisor.css` styling.

## Verification

- **Live in-pod**: headless Claude, given the new tools, calls `mcp__dashboard__show_app_preview({port: 8080, title})` when asked — the exact `tool_call` `buildTurns` renders as an iframe. ✅
- Python **115** tests (incl. new `mcp_dashboard_test`), **11** `buildTurns` tests, `tsc --noEmit`, `npm run build` — all green.
- Security: `/api/files/raw` is media-MIME-restricted + nosniff; render tools are read-only and bounded by the existing `is_proxyable` gate.

## Follow-ups (stacked)

- **PR2**: mobile embed + image (reuses `components/AppEmbed.tsx` + RN `Image`).
- **PR3**: mobile video (`expo-video` — a native/EAS build change).

Refs #212.
