### PR TITLE
feat(hypervisor): attach/upload images in the chat composer (web + mobile)

### DIFF
--- a/charts/workspace/web/src/routes/hypervisor/Chat.tsx
+++ b/charts/workspace/web/src/routes/hypervisor/Chat.tsx
@@ -18,6 +18,17 @@ import { WorkspaceContext } from './WorkspaceContext';
 import { buildTurns, renderMarkdown, type Block } from './transcript';
 import { proxyUrl } from '../../api/apps';
 import { withOauthPrefix } from '../../api/client';
+import { isImageFile, imagesFromClipboard, uploadTaskImage } from '../tasks/imageAttach';
+
+/** A user-attached image being uploaded to the workspace so the agent can read
+ *  it — same mechanism as the Build tab: upload, then the file's absolute path
+ *  is appended to the outgoing message and Claude reads it by path. */
+interface Attachment {
+  id: string;
+  previewUrl: string;
+  path?: string;
+  status: 'uploading' | 'ready' | 'error';
+}
 
 /**
  * The chat transcript + composer. The backend delivers a canonical event stream
@@ -148,8 +159,35 @@ function AgentBlocks({ blocks }: { blocks: Block[] }) {
 
 export function Chat() {
   const [draft, setDraft] = useState('');
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const taRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  function addFiles(files: File[]) {
+    const imgs = files.filter(isImageFile);
+    for (const file of imgs) {
+      const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const previewUrl = URL.createObjectURL(file);
+      setAttachments((a) => [...a, { id, previewUrl, status: 'uploading' }]);
+      // Reuse the Build tab's uploader; 'hypervisor' → .claude-tasks/hypervisor/attachments.
+      void uploadTaskImage('hypervisor', file)
+        .then((path) =>
+          setAttachments((a) => a.map((x) => (x.id === id ? { ...x, path, status: 'ready' } : x))),
+        )
+        .catch(() =>
+          setAttachments((a) => a.map((x) => (x.id === id ? { ...x, status: 'error' } : x))),
+        );
+    }
+  }
+
+  function removeAttachment(id: string) {
+    setAttachments((a) => {
+      const x = a.find((t) => t.id === id);
+      if (x) URL.revokeObjectURL(x.previewUrl);
+      return a.filter((t) => t.id !== id);
+    });
+  }
 
   const active = activeThreadId.value;
   const status = activeStatus.value;
@@ -171,10 +209,19 @@ export function Chat() {
   }, [turns]);
 
   function submit(text?: string) {
+    if (blocked) return;
     const value = (text ?? draft).trim();
-    if (!value || blocked) return;
+    // Append each uploaded image's absolute path on its own line — Claude Code
+    // reads the image by path (same as the Build tab composer).
+    const paths = attachments
+      .filter((a) => a.status === 'ready' && a.path)
+      .map((a) => a.path as string);
+    if (!value && paths.length === 0) return;
+    const finalText = [value, ...paths].filter(Boolean).join('\n');
     setDraft('');
-    void sendMessage(value);
+    attachments.forEach((a) => URL.revokeObjectURL(a.previewUrl));
+    setAttachments([]);
+    void sendMessage(finalText);
     taRef.current?.focus();
   }
 
@@ -197,6 +244,7 @@ export function Chat() {
   // Show the thinking indicator while the agent is working, or right after we
   // sent and no assistant turn has landed yet.
   const thinking = working || (busy && active !== null && !hasAgentTail);
+  const canSend = !!draft.trim() || attachments.some((a) => a.status === 'ready');
 
   return (
     <div class="hv-chat">
@@ -285,13 +333,61 @@ export function Chat() {
 
       {chatError.value && <div class="hv-banner hv-banner-error">{chatError.value}</div>}
 
+      {attachments.length > 0 && (
+        <div class="hv-attachments">
+          {attachments.map((a) => (
+            <div key={a.id} class={`hv-attachment is-${a.status}`}>
+              <img src={a.previewUrl} alt="attachment" />
+              <button
+                type="button"
+                class="hv-attachment-x"
+                onClick={() => removeAttachment(a.id)}
+                title="Remove"
+              >
+                <Icon name="close" size={10} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
       <form
         class="hv-composer"
         onSubmit={(e) => {
           e.preventDefault();
           submit();
         }}
+        onDrop={(e) => {
+          const files = Array.from(e.dataTransfer?.files || []);
+          if (files.some(isImageFile)) {
+            e.preventDefault();
+            addFiles(files);
+          }
+        }}
+        onDragOver={(e) => e.preventDefault()}
       >
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*"
+          multiple
+          style={{ display: 'none' }}
+          onChange={(e) => {
+            const input = e.target as HTMLInputElement;
+            addFiles(Array.from(input.files || []));
+            input.value = '';
+          }}
+        />
+        <button
+          type="button"
+          class="hv-attach-btn"
+          onClick={() => fileRef.current?.click()}
+          disabled={blocked}
+          title="Attach image"
+          aria-label="Attach image"
+        >
+          <Icon name="image" size={16} />
+        </button>
         <textarea
           ref={taRef}
           class="hv-composer-input"
@@ -301,10 +397,17 @@ export function Chat() {
               ? 'Read-only workspace — you can still ask about state'
               : working
                 ? 'Kube-Coder is working… press Stop to interrupt'
-                : 'Message Kube-Coder…  (Enter to send, Shift+Enter for newline)'
+                : 'Message Kube-Coder…  (paste or attach an image, Enter to send)'
           }
           onInput={(e) => setDraft((e.target as HTMLTextAreaElement).value)}
           onKeyDown={onKeyDown}
+          onPaste={(e) => {
+            const imgs = imagesFromClipboard(e.clipboardData);
+            if (imgs.length) {
+              e.preventDefault();
+              addFiles(imgs);
+            }
+          }}
           rows={1}
           disabled={blocked}
         />
@@ -319,7 +422,7 @@ export function Chat() {
             <Icon name="close" size={12} /> {stopping.value ? 'Stopping…' : 'Stop'}
           </Button>
         ) : (
-          <Button type="submit" variant="primary" disabled={blocked || !draft.trim()} title="Send (Enter)">
+          <Button type="submit" variant="primary" disabled={blocked || !canSend} title="Send (Enter)">
             <Icon name="play" size={12} /> Send
           </Button>
         )}

--- a/charts/workspace/web/src/routes/hypervisor/hypervisor.css
+++ b/charts/workspace/web/src/routes/hypervisor/hypervisor.css
@@ -780,3 +780,56 @@
   font-size: 11.5px;
   color: var(--text-subtle);
 }
+
+/* ── Composer image attachments ──────────────────────────────────────────── */
+.hv-attach-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  align-self: flex-end;
+  color: var(--text-subtle);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: color var(--motion-fast), border-color var(--motion-fast);
+}
+.hv-attach-btn:hover:not(:disabled) { color: var(--text); border-color: var(--border-strong, var(--border)); }
+.hv-attach-btn:disabled { opacity: 0.4; cursor: default; }
+
+.hv-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--size-2);
+  padding: var(--size-2) var(--size-3) 0;
+}
+.hv-attachment {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--surface-2);
+}
+.hv-attachment img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.hv-attachment.is-uploading { opacity: 0.6; }
+.hv-attachment.is-error { border-color: var(--danger, #c0392b); }
+.hv-attachment-x {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.6);
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+}

--- a/mobile/src/screens/HypervisorScreen.tsx
+++ b/mobile/src/screens/HypervisorScreen.tsx
@@ -7,6 +7,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  Image,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -19,6 +20,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as ImagePicker from 'expo-image-picker';
 import {
   createThread,
   deleteThread,
@@ -27,6 +29,7 @@ import {
   listThreads,
   sendThreadMessage,
   stopThread,
+  uploadTaskImage,
 } from '../api/client';
 import type { HvEvent, HypervisorConfig, HypervisorThread } from '../api/types';
 import { buildTurns, type HvBlock } from '../util/hvTranscript';
@@ -41,6 +44,15 @@ const SUGGESTIONS = [
   'Remember that I deploy with `make ship`',
 ];
 
+/** A picked image being uploaded so the agent can read it — its saved absolute
+ *  path is appended to the outgoing message (same as the Build tab). */
+interface Attachment {
+  id: string;
+  uri: string;
+  path?: string;
+  status: 'uploading' | 'ready' | 'error';
+}
+
 export default function HypervisorScreen() {
   const insets = useSafeAreaInsets();
   const [config, setConfig] = useState<HypervisorConfig | null>(null);
@@ -50,6 +62,7 @@ export default function HypervisorScreen() {
   const [status, setStatus] = useState<string>('');
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [stopping, setStopping] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
@@ -136,25 +149,66 @@ export default function HypervisorScreen() {
     });
   }
 
+  function uploadAssets(assets: ImagePicker.ImagePickerAsset[]) {
+    for (const asset of assets) {
+      const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      setAttachments((a) => [...a, { id, uri: asset.uri, status: 'uploading' }]);
+      // Reuse the Build tab's uploader; 'hypervisor' → .claude-tasks/hypervisor/attachments.
+      uploadTaskImage('hypervisor', asset)
+        .then((path) =>
+          setAttachments((a) => a.map((x) => (x.id === id ? { ...x, path, status: 'ready' } : x))),
+        )
+        .catch(() =>
+          setAttachments((a) => a.map((x) => (x.id === id ? { ...x, status: 'error' } : x))),
+        );
+    }
+  }
+
+  async function pickImage() {
+    const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!perm.granted) {
+      setError('Photo access is off — enable it in Settings to attach images.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsMultipleSelection: true,
+      quality: 0.9,
+    });
+    if (!result.canceled) uploadAssets(result.assets);
+  }
+
+  function removeAttachment(id: string) {
+    setAttachments((a) => a.filter((x) => x.id !== id));
+  }
+
   async function send(text?: string) {
+    if (sending || attachments.some((a) => a.status === 'uploading')) return;
     const msg = (text ?? draft).trim();
-    if (!msg || sending) return;
+    const paths = attachments
+      .filter((a) => a.status === 'ready' && a.path)
+      .map((a) => a.path as string);
+    if (!msg && paths.length === 0) return;
+    // Append each uploaded image's absolute path on its own line — Claude reads
+    // the image by path (same as the Build tab composer).
+    const finalText = [msg, ...paths].filter(Boolean).join('\n');
     setSending(true);
     setError(null);
     setDraft('');
+    setAttachments([]);
     setStatus('running');
     // Optimistic user turn (negative seq so it never collides with server seqs).
     setEvents((prev) => [
       ...prev,
-      { seq: optimisticSeq.current--, ts: Date.now() / 1000, role: 'user', type: 'message', text: msg },
+      { seq: optimisticSeq.current--, ts: Date.now() / 1000, role: 'user', type: 'message', text: finalText },
     ]);
     try {
       if (!activeId) {
-        const thread = await createThread(msg, config?.defaultAssistant);
+        const thread = await createThread(finalText, config?.defaultAssistant);
         await refreshThreads();
         openThread(thread.id);
       } else {
-        await sendThreadMessage(activeId, msg);
+        await sendThreadMessage(activeId, finalText);
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to send');
@@ -195,6 +249,7 @@ export default function HypervisorScreen() {
   const activeThread = threads.find((t) => t.id === activeId) || null;
   const working = status === 'running';
   const blocked = sending || working;
+  const canSend = !!draft.trim() || attachments.some((a) => a.status === 'ready');
   const empty = !activeId && events.length === 0;
 
   return (
@@ -291,7 +346,34 @@ export default function HypervisorScreen() {
 
         {error && <ErrorBanner message={error} />}
 
+        {attachments.length > 0 && (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.attachStrip}
+            contentContainerStyle={styles.attachStripInner}
+          >
+            {attachments.map((a) => (
+              <View key={a.id} style={[styles.attachThumb, a.status === 'error' && styles.attachThumbErr]}>
+                <Image source={{ uri: a.uri }} style={styles.attachImg} />
+                {a.status === 'uploading' && <View style={styles.attachDim} />}
+                <Pressable style={styles.attachX} onPress={() => removeAttachment(a.id)} hitSlop={6}>
+                  <Ionicons name="close" size={11} color="#fff" />
+                </Pressable>
+              </View>
+            ))}
+          </ScrollView>
+        )}
+
         <View style={[styles.composer, { paddingBottom: Math.max(insets.bottom, space.sm) }]}>
+          <Pressable
+            onPress={() => void pickImage()}
+            disabled={blocked}
+            style={[styles.attachBtn, blocked && styles.sendBtnOff]}
+            hitSlop={6}
+          >
+            <Ionicons name="image-outline" size={20} color={colors.textMuted} />
+          </Pressable>
           <TextInput
             style={styles.input}
             value={draft}
@@ -314,8 +396,8 @@ export default function HypervisorScreen() {
           ) : (
             <Pressable
               onPress={() => void send()}
-              disabled={blocked || !draft.trim()}
-              style={[styles.sendBtn, (blocked || !draft.trim()) && styles.sendBtnOff]}
+              disabled={blocked || !canSend}
+              style={[styles.sendBtn, (blocked || !canSend) && styles.sendBtnOff]}
             >
               <Ionicons name="arrow-up" size={20} color={colors.accentText} />
             </Pressable>
@@ -595,4 +677,51 @@ const styles = StyleSheet.create({
   },
   sendBtnOff: { opacity: 0.4 },
   stopBtn: { backgroundColor: colors.danger },
+  attachBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface2,
+  },
+  attachStrip: {
+    maxHeight: 72,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    backgroundColor: colors.bgElevated,
+  },
+  attachStripInner: { gap: space.sm, padding: space.sm },
+  attachThumb: {
+    width: 56,
+    height: 56,
+    borderRadius: radius.sm,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface2,
+  },
+  attachThumbErr: { borderColor: colors.danger },
+  attachImg: { width: '100%', height: '100%' },
+  attachDim: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  attachX: {
+    position: 'absolute',
+    top: 2,
+    right: 2,
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
 });


### PR DESCRIPTION
## What

Adds **image upload to the Hypervisor composer** (web + mobile), like the Build tab's send-message composer — so the user can show the agent an image.

## How

Same proven mechanism as the Build tab: the picked/pasted/dropped image is uploaded to the workspace via the existing `POST /api/files/upload` (into `.claude-tasks/hypervisor/attachments`), and each saved **absolute path is appended to the outgoing message** on its own line. Headless `claude -p` then reads the image by path (its `Read` tool views images).

**Verified in-pod:** headless Claude, asked about `/home/dev/<img>.png`, calls `Read` on it and answers about the image — so the path-append approach works for the Hypervisor's headless runner, not just the Build tab's interactive Claude.

## Web (`Chat.tsx`)

- Attach button + hidden file input; `onPaste` on the textarea; `onDrop` on the form. Reuses `imageAttach.ts` (`isImageFile`, `imagesFromClipboard`, `uploadTaskImage`).
- Thumbnail strip with per-image upload state + remove.
- Send enabled when there's text **or** a ready image; uploads that aren't done yet are skipped (mirrors Build tab).

## Mobile (`HypervisorScreen.tsx`)

- `expo-image-picker` (already a dependency) attach button → library pick (multiple), uploads via the existing `uploadTaskImage` client helper.
- Thumbnail strip; holds send while an upload is in flight so paths always make it into the prompt.

## Verification

- `tsc --noEmit` clean on both web and mobile.
- Reuses the existing, already-tested `/api/files/upload` endpoint (no backend change).

## Stacking

Based on **#226** (the rich-content branch, since both touch `Chat.tsx`). Retarget to `main` after #226 merges. No dependency on the mobile-render PRs.

Refs #212.
