### PR TITLE
feat(hypervisor): render app previews + images + video on mobile

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -49,6 +49,8 @@ const config: ExpoConfig = {
   },
   plugins: [
     'expo-secure-store',
+    // Inline video playback for the Hypervisor chat's video previews.
+    'expo-video',
     [
       // Allow plain-HTTP requests on Android (self-hosted / localhost minikube
       // workspaces). Production cloud hosts still use HTTPS.

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -22,6 +22,7 @@
         "expo-secure-store": "~56.0.4",
         "expo-splash-screen": "~56.0.10",
         "expo-status-bar": "~56.0.4",
+        "expo-video": "~56.1.4",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-native": "0.85.3",
@@ -3058,6 +3059,17 @@
       "version": "56.0.4",
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-56.0.4.tgz",
       "integrity": "sha512-IGs/fDfkHXofy2ZQrGiXayhFK04HB85FZXorhcEhDZEcqASKgSqpak+HwUtAaR0MeTJwWyHNF7I6VmVbbp8EcA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-video": {
+      "version": "56.1.4",
+      "resolved": "https://registry.npmjs.org/expo-video/-/expo-video-56.1.4.tgz",
+      "integrity": "sha512-8mXZOnb7ZsWneDlcnRf0M2Ox9eb5dGnNiGiCkj9bwLPY+3jM2Pc1t5ymNUuhw8lSpT/rOnE0J0/81Y3+0k2Zcw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -17,6 +17,7 @@
     "expo-secure-store": "~56.0.4",
     "expo-splash-screen": "~56.0.10",
     "expo-status-bar": "~56.0.4",
+    "expo-video": "~56.1.4",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.85.3",

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -623,3 +623,16 @@ export async function stopThread(id: string): Promise<void> {
 export async function deleteThread(id: string): Promise<void> {
   await request(`/api/hypervisor/threads/${encodeURIComponent(id)}`, { method: 'DELETE' });
 }
+
+/** Absolute URL for a workspace media file served by /api/files/raw. Pair with
+ *  authHeaders() on an <Image>/<VideoView> so the Bearer token authenticates
+ *  the request (RN Image/expo-video support request headers). */
+export function fileRawUrl(path: string): string {
+  const { host } = getConfig();
+  return `${(host || '').replace(/\/+$/, '')}/api/files/raw?path=${encodeURIComponent(path)}`;
+}
+
+export function authHeaders(): Record<string, string> {
+  const { token } = getConfig();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}

--- a/mobile/src/screens/HypervisorScreen.tsx
+++ b/mobile/src/screens/HypervisorScreen.tsx
@@ -21,9 +21,12 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
+import { useVideoPlayer, VideoView } from 'expo-video';
 import {
+  authHeaders,
   createThread,
   deleteThread,
+  fileRawUrl,
   getHypervisorConfig,
   getThreadDetail,
   listThreads,
@@ -31,6 +34,7 @@ import {
   stopThread,
   uploadTaskImage,
 } from '../api/client';
+import { AppEmbed } from '../components/AppEmbed';
 import type { HvEvent, HypervisorConfig, HypervisorThread } from '../api/types';
 import { buildTurns, type HvBlock } from '../util/hvTranscript';
 import { EmptyState, ErrorBanner, ScreenHeader } from '../components/ui';
@@ -493,6 +497,12 @@ function Block({
   if (block.kind === 'prose') {
     return <Text style={styles.prose}>{block.text}</Text>;
   }
+  if (block.kind === 'embed') {
+    return <EmbedBlock port={block.port} title={block.title} height={block.height} />;
+  }
+  if (block.kind === 'media') {
+    return <MediaBlock block={block} />;
+  }
   const open = expanded.has(id);
   const toggle = () => {
     const next = new Set(expanded);
@@ -509,6 +519,65 @@ function Block({
         <Ionicons name={open ? 'chevron-up' : 'chevron-down'} size={14} color={colors.textFaint} />
       </Pressable>
       {open && block.detail ? <Text style={styles.activityDetail}>{block.detail}</Text> : null}
+    </View>
+  );
+}
+
+/** Live app preview: the existing AppEmbed WebView in a fixed-height box so it
+ *  lays out inside the scrolling transcript. */
+function EmbedBlock({ port, title, height }: { port: number; title?: string; height?: number }) {
+  const h = height && height >= 120 ? height : 260;
+  return (
+    <View style={styles.embed}>
+      <View style={styles.embedHead}>
+        <Ionicons name="globe-outline" size={12} color={colors.textMuted} />
+        <Text style={styles.embedTitle} numberOfLines={1}>
+          {title || `App on :${port}`}
+        </Text>
+      </View>
+      <View style={{ height: h }}>
+        <AppEmbed port={port} name={title || `App :${port}`} compact />
+      </View>
+    </View>
+  );
+}
+
+/** An inline image or video. Workspace files go through the authed
+ *  /api/files/raw endpoint (Bearer header); external URLs are used directly. */
+function MediaBlock({ block }: { block: Extract<HvBlock, { kind: 'media' }> }) {
+  const src = block.url || (block.path ? fileRawUrl(block.path) : '');
+  if (!src) return null;
+  const headers = block.url ? undefined : authHeaders();
+  const h = block.height && block.height >= 80 ? block.height : 320;
+  if (block.mediaKind === 'video') {
+    return <VideoBlock uri={src} headers={headers} height={h} title={block.title} />;
+  }
+  return (
+    <View>
+      <Image source={{ uri: src, headers }} style={[styles.mediaImg, { height: h }]} resizeMode="contain" />
+      {block.title ? <Text style={styles.mediaCap}>{block.title}</Text> : null}
+    </View>
+  );
+}
+
+function VideoBlock({
+  uri,
+  headers,
+  height,
+  title,
+}: {
+  uri: string;
+  headers?: Record<string, string>;
+  height: number;
+  title?: string;
+}) {
+  const player = useVideoPlayer({ uri, headers }, (p) => {
+    p.loop = false;
+  });
+  return (
+    <View>
+      <VideoView player={player} style={[styles.mediaImg, { height }]} contentFit="contain" nativeControls />
+      {title ? <Text style={styles.mediaCap}>{title}</Text> : null}
     </View>
   );
 }
@@ -724,4 +793,30 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  embed: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    overflow: 'hidden',
+    backgroundColor: colors.card,
+  },
+  embedHead: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: space.md,
+    paddingVertical: 6,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    backgroundColor: colors.surface2,
+  },
+  embedTitle: { flex: 1, color: colors.textMuted, fontSize: font.size.sm, fontWeight: '600' },
+  mediaImg: {
+    width: '100%',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    backgroundColor: colors.surface2,
+  },
+  mediaCap: { marginTop: 4, color: colors.textFaint, fontSize: font.size.xs },
 });

--- a/mobile/src/util/hvTranscript.ts
+++ b/mobile/src/util/hvTranscript.ts
@@ -9,11 +9,43 @@ import type { HvEvent } from '../api/types';
 
 export type HvBlock =
   | { kind: 'prose'; text: string }
-  | { kind: 'activity'; label: string; detail: string; error?: boolean };
+  | { kind: 'activity'; label: string; detail: string; error?: boolean }
+  | { kind: 'embed'; port: number; title?: string; height?: number }
+  | { kind: 'media'; mediaKind: 'image' | 'video'; path?: string; url?: string; title?: string; height?: number };
 
 export type HvTurn =
   | { role: 'user'; text: string }
   | { role: 'agent'; blocks: HvBlock[] };
+
+/** MCP render tools whose tool_call renders inline instead of a text chip. */
+const APP_PREVIEW_TOOL = 'mcp__dashboard__show_app_preview';
+const MEDIA_TOOL = 'mcp__dashboard__show_media';
+
+function num(v: unknown): number | undefined {
+  const n = typeof v === 'string' ? Number(v) : (v as number);
+  return typeof n === 'number' && Number.isFinite(n) ? n : undefined;
+}
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim() ? v : undefined;
+}
+
+/** Map a render tool_call to its block, or null if it isn't a render tool. */
+function renderBlock(name: string, input: unknown): HvBlock | null {
+  const a = (input || {}) as Record<string, unknown>;
+  if (name === APP_PREVIEW_TOOL) {
+    const port = num(a.port);
+    if (port === undefined) return null;
+    return { kind: 'embed', port, title: str(a.title), height: num(a.height) };
+  }
+  if (name === MEDIA_TOOL) {
+    const mediaKind = a.media_kind === 'video' ? 'video' : 'image';
+    const path = str(a.path);
+    const url = str(a.url);
+    if (!path && !url) return null;
+    return { kind: 'media', mediaKind, path, url, title: str(a.title), height: num(a.height) };
+  }
+  return null;
+}
 
 function prettyInput(input: unknown): string {
   if (input == null) return '';
@@ -55,6 +87,9 @@ function toolLabel(name: string): string {
 export function buildTurns(events: HvEvent[]): HvTurn[] {
   const turns: HvTurn[] = [];
   let agent: { role: 'agent'; blocks: HvBlock[] } | null = null;
+  // tool_use_ids of render tool_calls — their tool_result is confirmation text
+  // we swallow (the rendered block is the real output), unless it errored.
+  const renderIds = new Set<string>();
 
   const openAgent = () => {
     if (!agent) {
@@ -73,12 +108,19 @@ export function buildTurns(events: HvEvent[]): HvTurn[] {
     if (e.type === 'message' && (e.text || '').trim()) {
       openAgent().blocks.push({ kind: 'prose', text: e.text || '' });
     } else if (e.type === 'tool_call') {
-      openAgent().blocks.push({
-        kind: 'activity',
-        label: toolLabel(e.tool?.name || 'tool'),
-        detail: prettyInput(e.tool?.input),
-      });
+      const rendered = renderBlock(e.tool?.name || '', e.tool?.input);
+      if (rendered) {
+        if (e.tool_id) renderIds.add(e.tool_id);
+        openAgent().blocks.push(rendered);
+      } else {
+        openAgent().blocks.push({
+          kind: 'activity',
+          label: toolLabel(e.tool?.name || 'tool'),
+          detail: prettyInput(e.tool?.input),
+        });
+      }
     } else if (e.type === 'tool_result') {
+      if (e.tool_use_id && renderIds.has(e.tool_use_id) && !e.is_error) continue;
       const blocks = openAgent().blocks;
       const last = [...blocks].reverse().find((b) => b.kind === 'activity') as
         | { kind: 'activity'; label: string; detail: string; error?: boolean }


### PR DESCRIPTION
## What

**Mobile parity** for the agent→user rich content from #226: live **app previews**, **images**, and **video** now render inline in the mobile Hypervisor chat, driven by the same `show_app_preview` / `show_media` render tool_calls.

## How

- **`util/hvTranscript.ts`** — ports the web `buildTurns` mapping: new `embed` / `media` `HvBlock` kinds from the two render tool_calls (swallowing their confirmation `tool_result` unless it errored). Identical logic to the (unit-tested) web `transcript.ts`.
- **`screens/HypervisorScreen.tsx`**:
  - `EmbedBlock` → reuses the existing **`AppEmbed`** WebView (session-cookie bootstrap) in a fixed-height box so it lays out inside the scrolling transcript.
  - `MediaBlock` → image via RN `Image`, video via **`expo-video`** `VideoView`. Workspace files load from `/api/files/raw` with a **Bearer auth header** (`Image`/`expo-video` support request headers); external URLs load directly.
- **`api/client.ts`** — `fileRawUrl(path)` + `authHeaders()` helpers.

## ⚠️ Native dependency

Adds **`expo-video`** (+ its config plugin in `app.config.ts`). This is a **native module** — it needs an **EAS rebuild + store submission** to reach devices; it can't ship JS-only/OTA. (App-preview + image work JS-only; only video needs the native build.)

## Verification

- `tsc --noEmit` clean. Mobile has no test runner, so this relies on tsc + mirroring the web `buildTurns` (covered by 11 vitest tests in #226).
- ⚠️ Needs a device/simulator smoke-test: WebView-in-ScrollView gesture nesting (embed), authed `Image` load, and `expo-video` playback after the EAS build.

## Stacking

Based on **#227** → **#226**. Retarget to `main` as the stack merges.

Refs #212.
