### PR TITLE
feat(hypervisor): composer image upload + mobile rich-content render (bring #227+#228 to main)

### DIFF
--- a/charts/workspace/web/src/routes/hypervisor/Chat.tsx
+++ b/charts/workspace/web/src/routes/hypervisor/Chat.tsx
@@ -18,6 +18,17 @@ import { WorkspaceContext } from './WorkspaceContext';
 import { buildTurns, renderMarkdown, type Block } from './transcript';
 import { proxyUrl } from '../../api/apps';
 import { withOauthPrefix } from '../../api/client';
+import { isImageFile, imagesFromClipboard, uploadTaskImage } from '../tasks/imageAttach';
+
+/** A user-attached image being uploaded to the workspace so the agent can read
+ *  it — same mechanism as the Build tab: upload, then the file's absolute path
+ *  is appended to the outgoing message and Claude reads it by path. */
+interface Attachment {
+  id: string;
+  previewUrl: string;
+  path?: string;
+  status: 'uploading' | 'ready' | 'error';
+}
 
 /**
  * The chat transcript + composer. The backend delivers a canonical event stream
@@ -148,8 +159,35 @@ function AgentBlocks({ blocks }: { blocks: Block[] }) {
 
 export function Chat() {
   const [draft, setDraft] = useState('');
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const taRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  function addFiles(files: File[]) {
+    const imgs = files.filter(isImageFile);
+    for (const file of imgs) {
+      const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const previewUrl = URL.createObjectURL(file);
+      setAttachments((a) => [...a, { id, previewUrl, status: 'uploading' }]);
+      // Reuse the Build tab's uploader; 'hypervisor' → .claude-tasks/hypervisor/attachments.
+      void uploadTaskImage('hypervisor', file)
+        .then((path) =>
+          setAttachments((a) => a.map((x) => (x.id === id ? { ...x, path, status: 'ready' } : x))),
+        )
+        .catch(() =>
+          setAttachments((a) => a.map((x) => (x.id === id ? { ...x, status: 'error' } : x))),
+        );
+    }
+  }
+
+  function removeAttachment(id: string) {
+    setAttachments((a) => {
+      const x = a.find((t) => t.id === id);
+      if (x) URL.revokeObjectURL(x.previewUrl);
+      return a.filter((t) => t.id !== id);
+    });
+  }
 
   const active = activeThreadId.value;
   const status = activeStatus.value;
@@ -171,10 +209,19 @@ export function Chat() {
   }, [turns]);
 
   function submit(text?: string) {
+    if (blocked) return;
     const value = (text ?? draft).trim();
-    if (!value || blocked) return;
+    // Append each uploaded image's absolute path on its own line — Claude Code
+    // reads the image by path (same as the Build tab composer).
+    const paths = attachments
+      .filter((a) => a.status === 'ready' && a.path)
+      .map((a) => a.path as string);
+    if (!value && paths.length === 0) return;
+    const finalText = [value, ...paths].filter(Boolean).join('\n');
     setDraft('');
-    void sendMessage(value);
+    attachments.forEach((a) => URL.revokeObjectURL(a.previewUrl));
+    setAttachments([]);
+    void sendMessage(finalText);
     taRef.current?.focus();
   }
 
@@ -197,6 +244,7 @@ export function Chat() {
   // Show the thinking indicator while the agent is working, or right after we
   // sent and no assistant turn has landed yet.
   const thinking = working || (busy && active !== null && !hasAgentTail);
+  const canSend = !!draft.trim() || attachments.some((a) => a.status === 'ready');
 
   return (
     <div class="hv-chat">
@@ -285,13 +333,61 @@ export function Chat() {
 
       {chatError.value && <div class="hv-banner hv-banner-error">{chatError.value}</div>}
 
+      {attachments.length > 0 && (
+        <div class="hv-attachments">
+          {attachments.map((a) => (
+            <div key={a.id} class={`hv-attachment is-${a.status}`}>
+              <img src={a.previewUrl} alt="attachment" />
+              <button
+                type="button"
+                class="hv-attachment-x"
+                onClick={() => removeAttachment(a.id)}
+                title="Remove"
+              >
+                <Icon name="close" size={10} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
       <form
         class="hv-composer"
         onSubmit={(e) => {
           e.preventDefault();
           submit();
         }}
+        onDrop={(e) => {
+          const files = Array.from(e.dataTransfer?.files || []);
+          if (files.some(isImageFile)) {
+            e.preventDefault();
+            addFiles(files);
+          }
+        }}
+        onDragOver={(e) => e.preventDefault()}
       >
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*"
+          multiple
+          style={{ display: 'none' }}
+          onChange={(e) => {
+            const input = e.target as HTMLInputElement;
+            addFiles(Array.from(input.files || []));
+            input.value = '';
+          }}
+        />
+        <button
+          type="button"
+          class="hv-attach-btn"
+          onClick={() => fileRef.current?.click()}
+          disabled={blocked}
+          title="Attach image"
+          aria-label="Attach image"
+        >
+          <Icon name="image" size={16} />
+        </button>
         <textarea
           ref={taRef}
           class="hv-composer-input"
@@ -301,10 +397,17 @@ export function Chat() {
               ? 'Read-only workspace — you can still ask about state'
               : working
                 ? 'Kube-Coder is working… press Stop to interrupt'
-                : 'Message Kube-Coder…  (Enter to send, Shift+Enter for newline)'
+                : 'Message Kube-Coder…  (paste or attach an image, Enter to send)'
           }
           onInput={(e) => setDraft((e.target as HTMLTextAreaElement).value)}
           onKeyDown={onKeyDown}
+          onPaste={(e) => {
+            const imgs = imagesFromClipboard(e.clipboardData);
+            if (imgs.length) {
+              e.preventDefault();
+              addFiles(imgs);
+            }
+          }}
           rows={1}
           disabled={blocked}
         />
@@ -319,7 +422,7 @@ export function Chat() {
             <Icon name="close" size={12} /> {stopping.value ? 'Stopping…' : 'Stop'}
           </Button>
         ) : (
-          <Button type="submit" variant="primary" disabled={blocked || !draft.trim()} title="Send (Enter)">
+          <Button type="submit" variant="primary" disabled={blocked || !canSend} title="Send (Enter)">
             <Icon name="play" size={12} /> Send
           </Button>
         )}

--- a/charts/workspace/web/src/routes/hypervisor/hypervisor.css
+++ b/charts/workspace/web/src/routes/hypervisor/hypervisor.css
@@ -780,3 +780,56 @@
   font-size: 11.5px;
   color: var(--text-subtle);
 }
+
+/* ── Composer image attachments ──────────────────────────────────────────── */
+.hv-attach-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  align-self: flex-end;
+  color: var(--text-subtle);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: color var(--motion-fast), border-color var(--motion-fast);
+}
+.hv-attach-btn:hover:not(:disabled) { color: var(--text); border-color: var(--border-strong, var(--border)); }
+.hv-attach-btn:disabled { opacity: 0.4; cursor: default; }
+
+.hv-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--size-2);
+  padding: var(--size-2) var(--size-3) 0;
+}
+.hv-attachment {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--surface-2);
+}
+.hv-attachment img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.hv-attachment.is-uploading { opacity: 0.6; }
+.hv-attachment.is-error { border-color: var(--danger, #c0392b); }
+.hv-attachment-x {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.6);
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+}

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -49,6 +49,8 @@ const config: ExpoConfig = {
   },
   plugins: [
     'expo-secure-store',
+    // Inline video playback for the Hypervisor chat's video previews.
+    'expo-video',
     [
       // Allow plain-HTTP requests on Android (self-hosted / localhost minikube
       // workspaces). Production cloud hosts still use HTTPS.

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -22,6 +22,7 @@
         "expo-secure-store": "~56.0.4",
         "expo-splash-screen": "~56.0.10",
         "expo-status-bar": "~56.0.4",
+        "expo-video": "~56.1.4",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-native": "0.85.3",
@@ -3058,6 +3059,17 @@
       "version": "56.0.4",
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-56.0.4.tgz",
       "integrity": "sha512-IGs/fDfkHXofy2ZQrGiXayhFK04HB85FZXorhcEhDZEcqASKgSqpak+HwUtAaR0MeTJwWyHNF7I6VmVbbp8EcA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-video": {
+      "version": "56.1.4",
+      "resolved": "https://registry.npmjs.org/expo-video/-/expo-video-56.1.4.tgz",
+      "integrity": "sha512-8mXZOnb7ZsWneDlcnRf0M2Ox9eb5dGnNiGiCkj9bwLPY+3jM2Pc1t5ymNUuhw8lSpT/rOnE0J0/81Y3+0k2Zcw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -17,6 +17,7 @@
     "expo-secure-store": "~56.0.4",
     "expo-splash-screen": "~56.0.10",
     "expo-status-bar": "~56.0.4",
+    "expo-video": "~56.1.4",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.85.3",

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -623,3 +623,16 @@ export async function stopThread(id: string): Promise<void> {
 export async function deleteThread(id: string): Promise<void> {
   await request(`/api/hypervisor/threads/${encodeURIComponent(id)}`, { method: 'DELETE' });
 }
+
+/** Absolute URL for a workspace media file served by /api/files/raw. Pair with
+ *  authHeaders() on an <Image>/<VideoView> so the Bearer token authenticates
+ *  the request (RN Image/expo-video support request headers). */
+export function fileRawUrl(path: string): string {
+  const { host } = getConfig();
+  return `${(host || '').replace(/\/+$/, '')}/api/files/raw?path=${encodeURIComponent(path)}`;
+}
+
+export function authHeaders(): Record<string, string> {
+  const { token } = getConfig();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}

--- a/mobile/src/screens/HypervisorScreen.tsx
+++ b/mobile/src/screens/HypervisorScreen.tsx
@@ -7,6 +7,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  Image,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -19,15 +20,21 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as ImagePicker from 'expo-image-picker';
+import { useVideoPlayer, VideoView } from 'expo-video';
 import {
+  authHeaders,
   createThread,
   deleteThread,
+  fileRawUrl,
   getHypervisorConfig,
   getThreadDetail,
   listThreads,
   sendThreadMessage,
   stopThread,
+  uploadTaskImage,
 } from '../api/client';
+import { AppEmbed } from '../components/AppEmbed';
 import type { HvEvent, HypervisorConfig, HypervisorThread } from '../api/types';
 import { buildTurns, type HvBlock } from '../util/hvTranscript';
 import { EmptyState, ErrorBanner, ScreenHeader } from '../components/ui';
@@ -41,6 +48,15 @@ const SUGGESTIONS = [
   'Remember that I deploy with `make ship`',
 ];
 
+/** A picked image being uploaded so the agent can read it — its saved absolute
+ *  path is appended to the outgoing message (same as the Build tab). */
+interface Attachment {
+  id: string;
+  uri: string;
+  path?: string;
+  status: 'uploading' | 'ready' | 'error';
+}
+
 export default function HypervisorScreen() {
   const insets = useSafeAreaInsets();
   const [config, setConfig] = useState<HypervisorConfig | null>(null);
@@ -50,6 +66,7 @@ export default function HypervisorScreen() {
   const [status, setStatus] = useState<string>('');
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [stopping, setStopping] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
@@ -136,25 +153,66 @@ export default function HypervisorScreen() {
     });
   }
 
+  function uploadAssets(assets: ImagePicker.ImagePickerAsset[]) {
+    for (const asset of assets) {
+      const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      setAttachments((a) => [...a, { id, uri: asset.uri, status: 'uploading' }]);
+      // Reuse the Build tab's uploader; 'hypervisor' → .claude-tasks/hypervisor/attachments.
+      uploadTaskImage('hypervisor', asset)
+        .then((path) =>
+          setAttachments((a) => a.map((x) => (x.id === id ? { ...x, path, status: 'ready' } : x))),
+        )
+        .catch(() =>
+          setAttachments((a) => a.map((x) => (x.id === id ? { ...x, status: 'error' } : x))),
+        );
+    }
+  }
+
+  async function pickImage() {
+    const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!perm.granted) {
+      setError('Photo access is off — enable it in Settings to attach images.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsMultipleSelection: true,
+      quality: 0.9,
+    });
+    if (!result.canceled) uploadAssets(result.assets);
+  }
+
+  function removeAttachment(id: string) {
+    setAttachments((a) => a.filter((x) => x.id !== id));
+  }
+
   async function send(text?: string) {
+    if (sending || attachments.some((a) => a.status === 'uploading')) return;
     const msg = (text ?? draft).trim();
-    if (!msg || sending) return;
+    const paths = attachments
+      .filter((a) => a.status === 'ready' && a.path)
+      .map((a) => a.path as string);
+    if (!msg && paths.length === 0) return;
+    // Append each uploaded image's absolute path on its own line — Claude reads
+    // the image by path (same as the Build tab composer).
+    const finalText = [msg, ...paths].filter(Boolean).join('\n');
     setSending(true);
     setError(null);
     setDraft('');
+    setAttachments([]);
     setStatus('running');
     // Optimistic user turn (negative seq so it never collides with server seqs).
     setEvents((prev) => [
       ...prev,
-      { seq: optimisticSeq.current--, ts: Date.now() / 1000, role: 'user', type: 'message', text: msg },
+      { seq: optimisticSeq.current--, ts: Date.now() / 1000, role: 'user', type: 'message', text: finalText },
     ]);
     try {
       if (!activeId) {
-        const thread = await createThread(msg, config?.defaultAssistant);
+        const thread = await createThread(finalText, config?.defaultAssistant);
         await refreshThreads();
         openThread(thread.id);
       } else {
-        await sendThreadMessage(activeId, msg);
+        await sendThreadMessage(activeId, finalText);
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to send');
@@ -195,6 +253,7 @@ export default function HypervisorScreen() {
   const activeThread = threads.find((t) => t.id === activeId) || null;
   const working = status === 'running';
   const blocked = sending || working;
+  const canSend = !!draft.trim() || attachments.some((a) => a.status === 'ready');
   const empty = !activeId && events.length === 0;
 
   return (
@@ -291,7 +350,34 @@ export default function HypervisorScreen() {
 
         {error && <ErrorBanner message={error} />}
 
+        {attachments.length > 0 && (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.attachStrip}
+            contentContainerStyle={styles.attachStripInner}
+          >
+            {attachments.map((a) => (
+              <View key={a.id} style={[styles.attachThumb, a.status === 'error' && styles.attachThumbErr]}>
+                <Image source={{ uri: a.uri }} style={styles.attachImg} />
+                {a.status === 'uploading' && <View style={styles.attachDim} />}
+                <Pressable style={styles.attachX} onPress={() => removeAttachment(a.id)} hitSlop={6}>
+                  <Ionicons name="close" size={11} color="#fff" />
+                </Pressable>
+              </View>
+            ))}
+          </ScrollView>
+        )}
+
         <View style={[styles.composer, { paddingBottom: Math.max(insets.bottom, space.sm) }]}>
+          <Pressable
+            onPress={() => void pickImage()}
+            disabled={blocked}
+            style={[styles.attachBtn, blocked && styles.sendBtnOff]}
+            hitSlop={6}
+          >
+            <Ionicons name="image-outline" size={20} color={colors.textMuted} />
+          </Pressable>
           <TextInput
             style={styles.input}
             value={draft}
@@ -314,8 +400,8 @@ export default function HypervisorScreen() {
           ) : (
             <Pressable
               onPress={() => void send()}
-              disabled={blocked || !draft.trim()}
-              style={[styles.sendBtn, (blocked || !draft.trim()) && styles.sendBtnOff]}
+              disabled={blocked || !canSend}
+              style={[styles.sendBtn, (blocked || !canSend) && styles.sendBtnOff]}
             >
               <Ionicons name="arrow-up" size={20} color={colors.accentText} />
             </Pressable>
@@ -411,6 +497,12 @@ function Block({
   if (block.kind === 'prose') {
     return <Text style={styles.prose}>{block.text}</Text>;
   }
+  if (block.kind === 'embed') {
+    return <EmbedBlock port={block.port} title={block.title} height={block.height} />;
+  }
+  if (block.kind === 'media') {
+    return <MediaBlock block={block} />;
+  }
   const open = expanded.has(id);
   const toggle = () => {
     const next = new Set(expanded);
@@ -427,6 +519,65 @@ function Block({
         <Ionicons name={open ? 'chevron-up' : 'chevron-down'} size={14} color={colors.textFaint} />
       </Pressable>
       {open && block.detail ? <Text style={styles.activityDetail}>{block.detail}</Text> : null}
+    </View>
+  );
+}
+
+/** Live app preview: the existing AppEmbed WebView in a fixed-height box so it
+ *  lays out inside the scrolling transcript. */
+function EmbedBlock({ port, title, height }: { port: number; title?: string; height?: number }) {
+  const h = height && height >= 120 ? height : 260;
+  return (
+    <View style={styles.embed}>
+      <View style={styles.embedHead}>
+        <Ionicons name="globe-outline" size={12} color={colors.textMuted} />
+        <Text style={styles.embedTitle} numberOfLines={1}>
+          {title || `App on :${port}`}
+        </Text>
+      </View>
+      <View style={{ height: h }}>
+        <AppEmbed port={port} name={title || `App :${port}`} compact />
+      </View>
+    </View>
+  );
+}
+
+/** An inline image or video. Workspace files go through the authed
+ *  /api/files/raw endpoint (Bearer header); external URLs are used directly. */
+function MediaBlock({ block }: { block: Extract<HvBlock, { kind: 'media' }> }) {
+  const src = block.url || (block.path ? fileRawUrl(block.path) : '');
+  if (!src) return null;
+  const headers = block.url ? undefined : authHeaders();
+  const h = block.height && block.height >= 80 ? block.height : 320;
+  if (block.mediaKind === 'video') {
+    return <VideoBlock uri={src} headers={headers} height={h} title={block.title} />;
+  }
+  return (
+    <View>
+      <Image source={{ uri: src, headers }} style={[styles.mediaImg, { height: h }]} resizeMode="contain" />
+      {block.title ? <Text style={styles.mediaCap}>{block.title}</Text> : null}
+    </View>
+  );
+}
+
+function VideoBlock({
+  uri,
+  headers,
+  height,
+  title,
+}: {
+  uri: string;
+  headers?: Record<string, string>;
+  height: number;
+  title?: string;
+}) {
+  const player = useVideoPlayer({ uri, headers }, (p) => {
+    p.loop = false;
+  });
+  return (
+    <View>
+      <VideoView player={player} style={[styles.mediaImg, { height }]} contentFit="contain" nativeControls />
+      {title ? <Text style={styles.mediaCap}>{title}</Text> : null}
     </View>
   );
 }
@@ -595,4 +746,77 @@ const styles = StyleSheet.create({
   },
   sendBtnOff: { opacity: 0.4 },
   stopBtn: { backgroundColor: colors.danger },
+  attachBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface2,
+  },
+  attachStrip: {
+    maxHeight: 72,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    backgroundColor: colors.bgElevated,
+  },
+  attachStripInner: { gap: space.sm, padding: space.sm },
+  attachThumb: {
+    width: 56,
+    height: 56,
+    borderRadius: radius.sm,
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface2,
+  },
+  attachThumbErr: { borderColor: colors.danger },
+  attachImg: { width: '100%', height: '100%' },
+  attachDim: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  attachX: {
+    position: 'absolute',
+    top: 2,
+    right: 2,
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  embed: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    overflow: 'hidden',
+    backgroundColor: colors.card,
+  },
+  embedHead: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: space.md,
+    paddingVertical: 6,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    backgroundColor: colors.surface2,
+  },
+  embedTitle: { flex: 1, color: colors.textMuted, fontSize: font.size.sm, fontWeight: '600' },
+  mediaImg: {
+    width: '100%',
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    backgroundColor: colors.surface2,
+  },
+  mediaCap: { marginTop: 4, color: colors.textFaint, fontSize: font.size.xs },
 });

--- a/mobile/src/util/hvTranscript.ts
+++ b/mobile/src/util/hvTranscript.ts
@@ -9,11 +9,43 @@ import type { HvEvent } from '../api/types';
 
 export type HvBlock =
   | { kind: 'prose'; text: string }
-  | { kind: 'activity'; label: string; detail: string; error?: boolean };
+  | { kind: 'activity'; label: string; detail: string; error?: boolean }
+  | { kind: 'embed'; port: number; title?: string; height?: number }
+  | { kind: 'media'; mediaKind: 'image' | 'video'; path?: string; url?: string; title?: string; height?: number };
 
 export type HvTurn =
   | { role: 'user'; text: string }
   | { role: 'agent'; blocks: HvBlock[] };
+
+/** MCP render tools whose tool_call renders inline instead of a text chip. */
+const APP_PREVIEW_TOOL = 'mcp__dashboard__show_app_preview';
+const MEDIA_TOOL = 'mcp__dashboard__show_media';
+
+function num(v: unknown): number | undefined {
+  const n = typeof v === 'string' ? Number(v) : (v as number);
+  return typeof n === 'number' && Number.isFinite(n) ? n : undefined;
+}
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim() ? v : undefined;
+}
+
+/** Map a render tool_call to its block, or null if it isn't a render tool. */
+function renderBlock(name: string, input: unknown): HvBlock | null {
+  const a = (input || {}) as Record<string, unknown>;
+  if (name === APP_PREVIEW_TOOL) {
+    const port = num(a.port);
+    if (port === undefined) return null;
+    return { kind: 'embed', port, title: str(a.title), height: num(a.height) };
+  }
+  if (name === MEDIA_TOOL) {
+    const mediaKind = a.media_kind === 'video' ? 'video' : 'image';
+    const path = str(a.path);
+    const url = str(a.url);
+    if (!path && !url) return null;
+    return { kind: 'media', mediaKind, path, url, title: str(a.title), height: num(a.height) };
+  }
+  return null;
+}
 
 function prettyInput(input: unknown): string {
   if (input == null) return '';
@@ -55,6 +87,9 @@ function toolLabel(name: string): string {
 export function buildTurns(events: HvEvent[]): HvTurn[] {
   const turns: HvTurn[] = [];
   let agent: { role: 'agent'; blocks: HvBlock[] } | null = null;
+  // tool_use_ids of render tool_calls — their tool_result is confirmation text
+  // we swallow (the rendered block is the real output), unless it errored.
+  const renderIds = new Set<string>();
 
   const openAgent = () => {
     if (!agent) {
@@ -73,12 +108,19 @@ export function buildTurns(events: HvEvent[]): HvTurn[] {
     if (e.type === 'message' && (e.text || '').trim()) {
       openAgent().blocks.push({ kind: 'prose', text: e.text || '' });
     } else if (e.type === 'tool_call') {
-      openAgent().blocks.push({
-        kind: 'activity',
-        label: toolLabel(e.tool?.name || 'tool'),
-        detail: prettyInput(e.tool?.input),
-      });
+      const rendered = renderBlock(e.tool?.name || '', e.tool?.input);
+      if (rendered) {
+        if (e.tool_id) renderIds.add(e.tool_id);
+        openAgent().blocks.push(rendered);
+      } else {
+        openAgent().blocks.push({
+          kind: 'activity',
+          label: toolLabel(e.tool?.name || 'tool'),
+          detail: prettyInput(e.tool?.input),
+        });
+      }
     } else if (e.type === 'tool_result') {
+      if (e.tool_use_id && renderIds.has(e.tool_use_id) && !e.is_error) continue;
       const blocks = openAgent().blocks;
       const last = [...blocks].reverse().find((b) => b.kind === 'activity') as
         | { kind: 'activity'; label: string; detail: string; error?: boolean }


### PR DESCRIPTION
## Why

PRs #227 and #228 show "merged" but their **base was the stacked branch, not `main`** — so when #226 was squash-merged to `main`, #227+#228 did not come along. Their code is currently only in the intermediate branches.

This PR lands the exact **#227 + #228 delta** on top of the merged #226 (backend + web that IS on main): the composer image upload (web + mobile) and the mobile app-preview/image/video render (+ `expo-video`).

## Verification

- Web `tsc` + `build` + 11 `buildTurns` vitest tests, mobile `tsc` — all green on the combined tree.
- Content is byte-identical to what was reviewed in #227/#228; no new code.

## Note

Mobile video (`expo-video`) is a native dep → needs an EAS rebuild to reach devices. Everything else (web + mobile app-preview/image) is JS/ConfigMap-deliverable.

Refs #212.