### PR TITLE
fix(hypervisor): import mimetypes for /api/files/raw (v1.20.0 crash)

### DIFF
--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -12,6 +12,7 @@ import collections
 import hmac
 import hashlib
 import secrets
+import mimetypes
 import shutil
 import threading
 import queue


### PR DESCRIPTION
## Problem

`/api/files/raw` (added in v1.20.0 for Hypervisor image/video rendering) references `mimetypes.guess_type`, but `mimetypes` was only imported **locally inside `serve_next_spa`**, not at module scope. So every real file serve crashed with `NameError` — the request handler died and the connection returned nothing (`000`). Workspace-file image/video rendering in the chat was broken.

External image/video URLs, live app previews, and the composer image **upload** were unaffected (they do not hit `/api/files/raw`).

## Fix

Import `mimetypes` at module scope. Ships via ConfigMap (no image rebuild).

## How it was found

Live in-pod test after the v1.20.0 deploy: `/api/files/raw?path=<img>.png` returned `000` while its auth (401) and traversal (400) guards — which return *before* the `mimetypes` call — worked. Pod logs showed the `NameError` traceback at the `guess_type` line.

Delivered to imran-ws via `make ship-config` and re-verified the endpoint serves 200/206/415 correctly.