### PR TITLE
fix(mobile): clean up Hypervisor header + iOS keyboard behavior

### DIFF
--- a/mobile/src/components/ui.tsx
+++ b/mobile/src/components/ui.tsx
@@ -162,7 +162,9 @@ export function ScreenHeader({
           </LinearGradient>
         ) : null}
         <View style={{ flexShrink: 1 }}>
-          <Text style={styles.headerTitle}>{title}</Text>
+          <Text style={styles.headerTitle} numberOfLines={1}>
+            {title}
+          </Text>
           {subtitle ? (
             <Text style={styles.headerSubtitle} numberOfLines={1}>
               {subtitle}

--- a/mobile/src/screens/HypervisorScreen.tsx
+++ b/mobile/src/screens/HypervisorScreen.tsx
@@ -40,6 +40,7 @@ import { buildTurns, type HvBlock } from '../util/hvTranscript';
 import { EmptyState, ErrorBanner, ScreenHeader } from '../components/ui';
 import { confirmAction } from '../util/confirm';
 import { relativeTime } from '../util/format';
+import { useKeyboardVisible } from '../util/useKeyboard';
 import { colors, font, radius, space } from '../theme';
 
 const SUGGESTIONS = [
@@ -59,6 +60,11 @@ interface Attachment {
 
 export default function HypervisorScreen() {
   const insets = useSafeAreaInsets();
+  const keyboardVisible = useKeyboardVisible();
+  // Measured header height → the KeyboardAvoidingView's offset (the composer
+  // must rise by exactly the space above it, or it over/under-shoots the
+  // keyboard). Defaults to a sane guess until the first layout pass.
+  const [headerH, setHeaderH] = useState(56);
   const [config, setConfig] = useState<HypervisorConfig | null>(null);
   const [threads, setThreads] = useState<HypervisorThread[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -258,6 +264,7 @@ export default function HypervisorScreen() {
 
   return (
     <SafeAreaView style={styles.root} edges={['top']}>
+      <View onLayout={(e) => setHeaderH(e.nativeEvent.layout.height)}>
       <ScreenHeader
         title={activeThread ? activeThread.title || 'Chat' : 'Hypervisor'}
         subtitle={activeThread ? `via ${activeThread.assistant || agentName}` : 'Talk to your workspace'}
@@ -282,6 +289,7 @@ export default function HypervisorScreen() {
           </View>
         }
       />
+      </View>
 
       <ChatsSheet
         visible={chatsOpen}
@@ -296,7 +304,7 @@ export default function HypervisorScreen() {
       <KeyboardAvoidingView
         style={styles.flex}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        keyboardVerticalOffset={insets.top + 44}
+        keyboardVerticalOffset={insets.top + headerH}
       >
         <ScrollView ref={scrollRef} style={styles.flex} contentContainerStyle={styles.transcript}>
           {empty ? (
@@ -369,7 +377,14 @@ export default function HypervisorScreen() {
           </ScrollView>
         )}
 
-        <View style={[styles.composer, { paddingBottom: Math.max(insets.bottom, space.sm) }]}>
+        <View
+          style={[
+            styles.composer,
+            // Keyboard up → it already covers the home indicator, so drop the
+            // safe-area inset that would otherwise leave a gap under the input.
+            { paddingBottom: keyboardVisible ? space.sm : Math.max(insets.bottom, space.sm) },
+          ]}
+        >
           <Pressable
             onPress={() => void pickImage()}
             disabled={blocked}

--- a/mobile/src/screens/NewTaskScreen.tsx
+++ b/mobile/src/screens/NewTaskScreen.tsx
@@ -1,5 +1,6 @@
 /** Create a new Claude task. */
 import { useNavigation } from '@react-navigation/native';
+import { useHeaderHeight } from '@react-navigation/elements';
 import React, { useState } from 'react';
 import {
   KeyboardAvoidingView,
@@ -21,6 +22,7 @@ const ASSISTANTS = ['claude', 'ante', 'opencode-openrouter'];
 
 export default function NewTaskScreen() {
   const nav = useNavigation<TasksNav>();
+  const headerHeight = useHeaderHeight();
   const [prompt, setPrompt] = useState('');
   const [workdir, setWorkdir] = useState('/home/dev');
   const [assistant, setAssistant] = useState('claude');
@@ -45,8 +47,16 @@ export default function NewTaskScreen() {
 
   return (
     <SafeAreaView style={styles.safe} edges={['bottom']}>
-      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined} style={{ flex: 1 }}>
-        <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={headerHeight}
+        style={{ flex: 1 }}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="interactive"
+        >
           <Label>Prompt</Label>
           <TextInput
             value={prompt}
@@ -102,7 +112,7 @@ export default function NewTaskScreen() {
 
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: colors.bg },
-  scroll: { padding: space.lg },
+  scroll: { padding: space.lg, paddingBottom: space.xxl },
   prompt: {
     backgroundColor: colors.bgElevated,
     borderWidth: 1,

--- a/mobile/src/screens/TaskDetailScreen.tsx
+++ b/mobile/src/screens/TaskDetailScreen.tsx
@@ -1,6 +1,7 @@
 /** Task detail: the live ttyd session (or archived output) + follow-up composer. */
 import { Ionicons } from '@expo/vector-icons';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
+import { useHeaderHeight } from '@react-navigation/elements';
 import { LinearGradient } from 'expo-linear-gradient';
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import {
@@ -91,6 +92,7 @@ function finishedNote(status: string): { icon: keyof typeof Ionicons.glyphMap; t
 export default function TaskDetailScreen() {
   const route = useRoute<RouteProp<TasksStackParams, 'TaskDetail'>>();
   const nav = useNavigation();
+  const headerHeight = useHeaderHeight();
   const { id } = route.params;
   const [task, setTask] = useState<TaskDetail | null>(null);
   const [output, setOutput] = useState('');
@@ -373,7 +375,7 @@ export default function TaskDetailScreen() {
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={{ flex: 1 }}
-        keyboardVerticalOffset={90}
+        keyboardVerticalOffset={headerHeight}
         onLayout={(e) => {
           splitAreaH.current = e.nativeEvent.layout.height;
         }}

--- a/mobile/src/util/useKeyboard.ts
+++ b/mobile/src/util/useKeyboard.ts
@@ -1,0 +1,29 @@
+/** Keyboard visibility. */
+import { useEffect, useState } from 'react';
+import { Keyboard, Platform } from 'react-native';
+
+/**
+ * True while the software keyboard is on screen.
+ *
+ * Composers pad their bottom with the safe-area inset so they clear the home
+ * indicator when the keyboard is down. Once the keyboard is up it already
+ * covers that area, so keeping the inset leaves a dead gap between the input and
+ * the keys (the classic iOS "input floats above the keyboard" bug). Screens use
+ * this to collapse that padding while the keyboard is showing. iOS fires the
+ * `Will` events ahead of the animation so the padding changes in step with the
+ * keyboard rather than a frame late.
+ */
+export function useKeyboardVisible(): boolean {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const showEvt = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvt = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+    const show = Keyboard.addListener(showEvt, () => setVisible(true));
+    const hide = Keyboard.addListener(hideEvt, () => setVisible(false));
+    return () => {
+      show.remove();
+      hide.remove();
+    };
+  }, []);
+  return visible;
+}


### PR DESCRIPTION
## Why

The Hypervisor flow had a few rough edges on mobile, most visibly on iOS:

- The initial question is used as the screen title, so a **long question wrapped to many rows** and ate the top of the view.
- On iOS the composer **floated in a dead gap above the keyboard**.
- Some forms (New task) let the **keyboard cover the submit button**.

## Changes

- **`ScreenHeader`** — truncate the title to one line (`numberOfLines={1}`) so a long Hypervisor thread title no longer fills the header. Static titles are unaffected.
- **`useKeyboardVisible()`** (new `src/util/useKeyboard.ts`) — drives the Hypervisor composer to drop its safe-area bottom inset while the keyboard is up (the keyboard already covers the home indicator), removing the floating gap. Uses `keyboardWillShow/Hide` on iOS so it moves in step with the keyboard.
- **Hypervisor `KeyboardAvoidingView` offset** — measure the real header height via `onLayout` instead of a hardcoded `44` that was wrong whenever the header had a subtitle.
- **`NewTaskScreen`** — give the `KeyboardAvoidingView` the real header height (`useHeaderHeight`), plus interactive dismiss and bottom scroll padding, so the **Start task** button is no longer covered by the keyboard.
- **`TaskDetailScreen`** — replace the hardcoded `keyboardVerticalOffset={90}` with `useHeaderHeight()` so the follow-up composer aligns across device sizes.

Other input surfaces (`Onboarding`, `ControllerConnectModal`, `DesktopEditorSheet`) were already correct (bottom-anchored sheets whose KAV lifts the whole sheet, or scrollable content) and are left unchanged.

## Testing

- `tsc --noEmit` clean.
- `expo export --platform web` builds clean (confirms the new `@react-navigation/elements` import + hooks resolve).
- ⚠️ Keyboard timing should be spot-checked on a physical iOS device/simulator — the offset/`headerH` is the knob if the composer sits a hair off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)