### PR TITLE
fix(hypervisor): don't yank the chat back to bottom while scrolling up

### DIFF
--- a/charts/workspace/web/src/routes/hypervisor/Chat.tsx
+++ b/charts/workspace/web/src/routes/hypervisor/Chat.tsx
@@ -163,6 +163,10 @@ export function Chat() {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const taRef = useRef<HTMLTextAreaElement | null>(null);
   const fileRef = useRef<HTMLInputElement | null>(null);
+  // Whether the view is pinned to the bottom. We only auto-scroll on new events
+  // while pinned — so scrolling up to read history isn't yanked back down by the
+  // 2s poll. Starts true; the scroll handler flips it as the user scrolls.
+  const pinnedRef = useRef(true);
 
   function addFiles(files: File[]) {
     const imgs = files.filter(isImageFile);
@@ -205,11 +209,25 @@ export function Chat() {
 
   useEffect(() => {
     const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (el && pinnedRef.current) el.scrollTop = el.scrollHeight;
   }, [turns]);
+
+  // Track pin state: pinned when within ~80px of the bottom. Scrolling up
+  // unpins (so polls stop yanking down); scrolling back to the bottom re-pins.
+  function onTranscriptScroll() {
+    const el = scrollRef.current;
+    if (!el) return;
+    pinnedRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }
+
+  // A freshly opened thread starts pinned to the bottom.
+  useEffect(() => {
+    pinnedRef.current = true;
+  }, [active]);
 
   function submit(text?: string) {
     if (blocked) return;
+    pinnedRef.current = true; // sending your own message re-pins to the bottom
     const value = (text ?? draft).trim();
     // Append each uploaded image's absolute path on its own line — Claude Code
     // reads the image by path (same as the Build tab composer).
@@ -250,7 +268,7 @@ export function Chat() {
     <div class="hv-chat">
       {active && <WorkspaceContext />}
 
-      <div class="hv-transcript" ref={scrollRef}>
+      <div class="hv-transcript" ref={scrollRef} onScroll={onTranscriptScroll}>
         {empty ? (
           <div class="hv-welcome-host">
             <EmptyState


### PR DESCRIPTION
## Problem

On the web Hypervisor page, scrolling up to read earlier conversation immediately snaps you back to the bottom — you cannot view past messages.

## Cause

The auto-scroll effect (`el.scrollTop = el.scrollHeight`) runs on every `turns` change, and `turns` recompute on **every 2s poll** (the events array is re-fetched each tick). So even after you scroll up, the next poll yanks you to the bottom.

## Fix

Standard chat behavior: only auto-scroll when the view is **pinned** near the bottom (within ~80px). An `onScroll` handler tracks pin state — scrolling up unpins (polls stop pulling you down), scrolling back to the bottom re-pins. Sending a message and switching threads re-pin so those still land at the bottom.

## Verification

Web `tsc` + `build` clean. Scope is `Chat.tsx` only.

_Note: the mobile screen has the same `scrollToEnd`-on-events pattern and could take the equivalent fix in a follow-up — flagged, not included here since the report was web-specific._