### PR TITLE
feat(workspace): self-service provider API keys (OpenRouter/DeepSeek/Anthropic)

### DIFF
--- a/charts/workspace/hypervisor_session.py
+++ b/charts/workspace/hypervisor_session.py
@@ -68,6 +68,27 @@ from typing import Any, Callable, Dict, List, Optional
 WORKSPACE_HOME = '/home/dev'
 HYPERVISOR_DIR = os.path.join(WORKSPACE_HOME, '.claude-tasks', 'hypervisor')
 
+# User-set provider keys (managed by server.py's ProviderKeysManager) are stored
+# as one JSON on the PVC and overlaid onto every CLI subprocess's env at spawn,
+# so a key set in Settings takes effect on the next turn with no restart. This
+# module can't import server.py (server imports us), so we read the same file
+# directly — keep _PROVIDER_KEY_VARS in sync with ProviderKeysManager.ALLOWED.
+_PROVIDER_KEYS_FILE = os.path.join(WORKSPACE_HOME, '.claude-tasks', 'provider-keys.json')
+_PROVIDER_KEY_VARS = ('OPENROUTER_API_KEY', 'DEEPSEEK_API_KEY', 'ANTHROPIC_API_KEY')
+
+
+def _provider_key_overlay() -> Dict[str, str]:
+    """{VAR: value} for the provider keys the user has set, or {} if none."""
+    try:
+        with open(_PROVIDER_KEYS_FILE) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {k: data[k] for k in _PROVIDER_KEY_VARS
+            if isinstance(data.get(k), str) and data[k].strip()}
+
 # Strip ANSI/VT escape sequences from fallback CLI output so a non-structured
 # assistant still reads as clean prose, never raw terminal control codes.
 _ANSI_RE = re.compile(r'\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b[()][A-Za-z0-9]|[\x00-\x08\x0b\x0c\x0e-\x1f]')
@@ -535,6 +556,10 @@ class HypervisorSession:
             # Force HOME=/home/dev on every spawned CLI so it finds its config /
             # credentials regardless of the server process's own $HOME.
             env = dict(spec.get('env') or os.environ)
+            # Overlay any user-set provider keys (store wins over pod env). For
+            # Claude this only re-adds ANTHROPIC_API_KEY if the user explicitly
+            # set one — the adapter's default env drops it so oauth is used.
+            env.update(_provider_key_overlay())
             env['HOME'] = WORKSPACE_HOME
             proc = subprocess.Popen(
                 spec['argv'],

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -882,11 +882,18 @@ class ClaudeTaskManager:
 
         cli_cmd = ClaudeTaskManager.assistant_command(assistant, auto_approve=auto_approve)
         shell_cmd = f'cd {_shell_quote(workdir)} && {cli_cmd}'
+        # Overlay any user-set provider keys onto the new session's env, so a key
+        # set in Settings (no redeploy) reaches the CLI subprocess. Store wins
+        # over the pod env; when unset the pod/helm default carries through.
+        provider_env = []
+        for k, v in ProviderKeysManager.env_overlay().items():
+            provider_env += ['-e', f'{k}={v}']
         tmux_cmd = [
             'tmux', 'new-session', '-d',
             '-s', session_name,
             '-x', '220', '-y', '50',
             '-e', f'KC_TASK_ID={task_id}',
+            *provider_env,
             'bash', '-lc', shell_cmd,
         ]
 
@@ -2233,6 +2240,84 @@ class WebhookManager:
             return json.dumps(cur, default=str)
         except (TypeError, ValueError):
             return ''
+
+
+class ProviderKeysManager:
+    """User-settable provider API keys, persisted on the PVC and injected into
+    every CLI subprocess's env at spawn — so a user can set their own OpenRouter
+    / DeepSeek / Anthropic key from the workspace Settings UI (no redeploy), the
+    way Claude's oauth login is self-service. The helm value / pod env stays the
+    default; a stored key overrides it only when set. Model: WebhookManager
+    (one JSON on the PVC, atomic 0600 write, masked public view).
+    """
+
+    KEYS_FILE = '/home/dev/.claude-tasks/provider-keys.json'
+    # ONLY these env var names may ever be set/injected — never arbitrary env.
+    # Keep in sync with hypervisor_session._PROVIDER_KEY_VARS.
+    ALLOWED = ('OPENROUTER_API_KEY', 'DEEPSEEK_API_KEY', 'ANTHROPIC_API_KEY')
+
+    @classmethod
+    def _read(cls):
+        try:
+            with open(cls.KEYS_FILE) as f:
+                data = json.load(f)
+            return data if isinstance(data, dict) else {}
+        except (OSError, json.JSONDecodeError):
+            return {}
+
+    @classmethod
+    def _write(cls, data):
+        os.makedirs(os.path.dirname(cls.KEYS_FILE), mode=0o700, exist_ok=True)
+        tmp = cls.KEYS_FILE + '.tmp'
+        with open(tmp, 'w') as f:
+            json.dump(data, f, indent=2)
+        os.chmod(tmp, 0o600)
+        os.rename(tmp, cls.KEYS_FILE)
+
+    @classmethod
+    def set(cls, provider, key):
+        if provider not in cls.ALLOWED:
+            return False, 'unknown provider'
+        key = (key or '').strip()
+        if not key:
+            return False, 'key is required'
+        data = cls._read()
+        data[provider] = key
+        cls._write(data)
+        return True, None
+
+    @classmethod
+    def delete(cls, provider):
+        if provider not in cls.ALLOWED:
+            return False
+        data = cls._read()
+        if provider in data:
+            del data[provider]
+            cls._write(data)
+            return True
+        return False
+
+    @classmethod
+    def public_view(cls):
+        """Masked view for the UI — reports set/unset + a last-4 hint, NEVER the
+        key itself (same idea as WebhookManager stripping hmac_secret)."""
+        data = cls._read()
+        out = {}
+        for p in cls.ALLOWED:
+            v = data.get(p)
+            out[p] = {
+                'set': bool(v),
+                'hint': (f'…{v[-4:]}' if isinstance(v, str) and len(v) >= 4 else ''),
+            }
+        return out
+
+    @classmethod
+    def env_overlay(cls):
+        """{VAR: value} for the keys the user has set — applied over the pod env
+        at every CLI spawn (Build tab tmux + Hypervisor subprocess)."""
+        data = cls._read()
+        return {p: data[p] for p in cls.ALLOWED
+                if isinstance(data.get(p), str) and data[p].strip()}
 
 
 class CronManager:
@@ -3619,6 +3704,11 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             self.handle_claude_get_task()
             return
 
+        # --- Provider keys (dashboard Settings) ---
+        if claude_path == '/api/provider-keys':
+            self.handle_provider_keys_list()
+            return
+
         # --- Webhook CRUD (dashboard) ---
         if claude_path == '/api/webhooks':
             self.handle_webhook_list()
@@ -3994,6 +4084,10 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             m = re.match(r'^/api/hypervisor/threads/([A-Za-z0-9_-]+)$', path)
             if m:
                 self.handle_hypervisor_delete_thread(m.group(1))
+                return
+            m = re.match(r'^/api/provider-keys/([A-Z_]+)$', path)
+            if m:
+                self.handle_provider_keys_delete(m.group(1))
                 return
             m = re.match(r'^/api/webhooks/([a-zA-Z0-9_-]+)$', path)
             if m:
@@ -4918,6 +5012,38 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         if not ok:
             self.send_json({'error': 'Webhook not found'}, 404)
             return
+        self.send_json({'ok': True})
+
+    def handle_provider_keys_list(self):
+        # Secrets endpoint — must not be reachable in the unauth public demo
+        # (same posture as send_git_config), so allow_none_mode=False.
+        if not self.check_claude_auth(allow_none_mode=False):
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        # Masked view only — never returns the key itself.
+        self.send_json({'providers': ProviderKeysManager.public_view()})
+
+    def handle_provider_keys_set(self):
+        if not self.check_claude_auth(allow_none_mode=False):
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        try:
+            data = self.read_json_body()
+        except (json.JSONDecodeError, ValueError):
+            self.send_json({'error': 'Invalid JSON body'}, 400)
+            return
+        provider = (data.get('provider') or '').strip()
+        ok, err = ProviderKeysManager.set(provider, data.get('key'))
+        if not ok:
+            self.send_json({'error': err}, 400)
+            return
+        self.send_json({'ok': True, 'provider': provider})
+
+    def handle_provider_keys_delete(self, provider):
+        if not self.check_claude_auth(allow_none_mode=False):
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        ProviderKeysManager.delete(provider)
         self.send_json({'ok': True})
 
     def handle_webhook_receive(self):
@@ -6806,6 +6932,9 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             # Hypervisor chat threads
             elif path == "/api/hypervisor/threads":
                 self.handle_hypervisor_create_thread()
+            # Provider keys (dashboard Settings)
+            elif path == "/api/provider-keys":
+                self.handle_provider_keys_set()
             # Webhook CRUD (dashboard)
             elif path == "/api/webhooks":
                 self.handle_webhook_create()

--- a/charts/workspace/tests/hypervisor_session_test.py
+++ b/charts/workspace/tests/hypervisor_session_test.py
@@ -106,6 +106,30 @@ class FallbackAdapterTest(unittest.TestCase):
         self.assertEqual(out[0]['type'], 'error')
 
 
+class ProviderKeyOverlayTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._orig = hs._PROVIDER_KEYS_FILE
+        hs._PROVIDER_KEYS_FILE = os.path.join(self.tmp, 'provider-keys.json')
+
+    def tearDown(self):
+        hs._PROVIDER_KEYS_FILE = self._orig
+
+    def test_missing_file_is_empty_overlay(self):
+        self.assertEqual(hs._provider_key_overlay(), {})
+
+    def test_only_allowed_nonempty_keys_surface(self):
+        with open(hs._PROVIDER_KEYS_FILE, 'w') as f:
+            json.dump({'OPENROUTER_API_KEY': 'k1', 'DEEPSEEK_API_KEY': '  ',
+                       'EVIL': 'nope'}, f)
+        self.assertEqual(hs._provider_key_overlay(), {'OPENROUTER_API_KEY': 'k1'})
+
+    def test_garbage_file_is_empty_overlay(self):
+        with open(hs._PROVIDER_KEYS_FILE, 'w') as f:
+            f.write('not json')
+        self.assertEqual(hs._provider_key_overlay(), {})
+
+
 class SessionEventsTest(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()

--- a/charts/workspace/tests/server_test.py
+++ b/charts/workspace/tests/server_test.py
@@ -669,6 +669,67 @@ def _fake_kubectl_ok(*args, **kwargs):
     return mock.Mock(returncode=0, stdout='', stderr='')
 
 
+class ProviderKeysManagerTests(unittest.TestCase):
+    """Tests for ProviderKeysManager: set/delete, masked public_view (never
+    leaks the key), env_overlay only exposes allowed vars, atomic 0600 write."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='kctest-pk-')
+        self._orig_file = server.ProviderKeysManager.KEYS_FILE
+        server.ProviderKeysManager.KEYS_FILE = os.path.join(self.tmpdir, 'provider-keys.json')
+
+    def tearDown(self):
+        server.ProviderKeysManager.KEYS_FILE = self._orig_file
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_read_empty_when_absent(self):
+        self.assertEqual(server.ProviderKeysManager._read(), {})
+
+    def test_set_and_env_overlay_roundtrip(self):
+        ok, err = server.ProviderKeysManager.set('OPENROUTER_API_KEY', 'sk-or-secret123')
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        self.assertEqual(server.ProviderKeysManager.env_overlay(),
+                         {'OPENROUTER_API_KEY': 'sk-or-secret123'})
+
+    def test_set_rejects_unknown_provider(self):
+        ok, err = server.ProviderKeysManager.set('AWS_SECRET_KEY', 'x')
+        self.assertFalse(ok)
+        self.assertIn('unknown provider', err or '')
+        # Nothing written for a rejected provider.
+        self.assertEqual(server.ProviderKeysManager._read(), {})
+
+    def test_set_rejects_empty_key(self):
+        ok, err = server.ProviderKeysManager.set('DEEPSEEK_API_KEY', '   ')
+        self.assertFalse(ok)
+        self.assertIn('required', err or '')
+
+    def test_public_view_masks_and_never_leaks_key(self):
+        server.ProviderKeysManager.set('OPENROUTER_API_KEY', 'sk-or-abcd1234ecc18')
+        view = server.ProviderKeysManager.public_view()
+        self.assertTrue(view['OPENROUTER_API_KEY']['set'])
+        self.assertEqual(view['OPENROUTER_API_KEY']['hint'], '…cc18')
+        self.assertFalse(view['DEEPSEEK_API_KEY']['set'])
+        # The raw key must not appear anywhere in the serialized view.
+        self.assertNotIn('abcd1234', json.dumps(view))
+
+    def test_delete_removes_key(self):
+        server.ProviderKeysManager.set('ANTHROPIC_API_KEY', 'sk-ant-xyz')
+        self.assertTrue(server.ProviderKeysManager.delete('ANTHROPIC_API_KEY'))
+        self.assertEqual(server.ProviderKeysManager.env_overlay(), {})
+
+    def test_written_file_is_0600(self):
+        server.ProviderKeysManager.set('OPENROUTER_API_KEY', 'sk-or-x')
+        mode = os.stat(server.ProviderKeysManager.KEYS_FILE).st_mode & 0o777
+        self.assertEqual(mode, 0o600)
+
+    def test_env_overlay_only_allowed_vars(self):
+        # A stray non-allowed key in the file is never surfaced.
+        server.ProviderKeysManager._write({'OPENROUTER_API_KEY': 'k', 'EVIL': 'v'})
+        self.assertEqual(server.ProviderKeysManager.env_overlay(), {'OPENROUTER_API_KEY': 'k'})
+
+
 class CronManagerTests(unittest.TestCase):
     """Tests for CronManager: config CRUD, schedule validation, fire_token
     minting, kubectl apply manifest construction (without actually calling out

--- a/charts/workspace/web/src/api/providerKeys.ts
+++ b/charts/workspace/web/src/api/providerKeys.ts
@@ -1,0 +1,21 @@
+import { apiGet, apiPost, apiDelete } from './client';
+
+// The provider env-var names the workspace lets a user set for themselves.
+// Must match server.py ProviderKeysManager.ALLOWED.
+export type ProviderVar = 'OPENROUTER_API_KEY' | 'DEEPSEEK_API_KEY' | 'ANTHROPIC_API_KEY';
+
+export interface ProviderKeyStatus {
+  set: boolean;
+  hint: string; // last-4 like "…cc18"; never the full key
+}
+
+export type ProviderKeysView = Record<ProviderVar, ProviderKeyStatus>;
+
+export const listProviderKeys = () =>
+  apiGet<{ providers: ProviderKeysView }>('/api/provider-keys');
+
+export const setProviderKey = (provider: ProviderVar, key: string) =>
+  apiPost<{ ok: true; provider: ProviderVar }>('/api/provider-keys', { provider, key });
+
+export const deleteProviderKey = (provider: ProviderVar) =>
+  apiDelete<{ ok: true }>(`/api/provider-keys/${provider}`);

--- a/charts/workspace/web/src/routes/settings/ProviderKeysSection.tsx
+++ b/charts/workspace/web/src/routes/settings/ProviderKeysSection.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'preact/hooks';
+import {
+  listProviderKeys,
+  setProviderKey,
+  deleteProviderKey,
+  type ProviderVar,
+  type ProviderKeysView,
+} from '../../api/providerKeys';
+import { Button } from '../../components/primitives/Button';
+import { Input } from '../../components/primitives/Input';
+import { Pill } from '../../components/primitives/Pill';
+import { Icon } from '../../components/Icon';
+import { pushToast } from '../../store/ui';
+
+const PROVIDERS: { var: ProviderVar; label: string; hint: string }[] = [
+  { var: 'OPENROUTER_API_KEY', label: 'OpenRouter', hint: 'Powers OpenCode + OpenRouter-backed models.' },
+  { var: 'DEEPSEEK_API_KEY', label: 'DeepSeek', hint: 'DeepSeek API key.' },
+  { var: 'ANTHROPIC_API_KEY', label: 'Anthropic', hint: 'Overrides the Claude subscription/oauth default when set.' },
+];
+
+export function ProviderKeysSection() {
+  const [view, setView] = useState<ProviderKeysView | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<string | null>(null);
+
+  async function refresh() {
+    try {
+      const r = await listProviderKeys();
+      setView(r.providers);
+    } catch {
+      // server unavailable — leave view null
+    }
+  }
+  useEffect(() => { void refresh(); }, []);
+
+  async function onSave(p: ProviderVar) {
+    const key = (drafts[p] ?? '').trim();
+    if (!key) return;
+    setBusy(p);
+    try {
+      await setProviderKey(p, key);
+      pushToast('Key saved', { kind: 'success' });
+      setDrafts((d) => ({ ...d, [p]: '' }));
+      await refresh();
+    } catch (err) {
+      pushToast(err instanceof Error ? err.message : 'Save failed', { kind: 'danger' });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function onClear(p: ProviderVar) {
+    setBusy(p);
+    try {
+      await deleteProviderKey(p);
+      pushToast('Key cleared', { kind: 'info' });
+      await refresh();
+    } catch (err) {
+      pushToast(err instanceof Error ? err.message : 'Clear failed', { kind: 'danger' });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <section class="settings-section">
+      <h2 class="settings-section-title">Provider API keys</h2>
+      <p class="settings-row-hint muted">
+        Set your own model-provider keys for this workspace. Stored securely on your workspace disk
+        and used the next time an assistant runs — no redeploy. Leave blank to use the workspace default.
+      </p>
+
+      {PROVIDERS.map((prov) => {
+        const status = view?.[prov.var];
+        return (
+          <div class="settings-row" key={prov.var}>
+            <div class="settings-row-label">
+              {prov.label}
+              {' '}
+              <Pill tone={status?.set ? 'success' : 'warn'} mono>
+                {status?.set ? `set · ${status.hint}` : 'not set'}
+              </Pill>
+              <div class="settings-radio-hint muted">{prov.hint}</div>
+            </div>
+            <div class="settings-row-control" style={{ gap: 'var(--size-2)' }}>
+              <Input
+                fullWidth
+                type="password"
+                value={drafts[prov.var] ?? ''}
+                placeholder={status?.set ? 'Replace key…' : 'Paste key…'}
+                onInput={(e) => setDrafts((d) => ({ ...d, [prov.var]: (e.target as HTMLInputElement).value }))}
+              />
+              <Button
+                variant="primary"
+                type="button"
+                disabled={busy === prov.var || !(drafts[prov.var] ?? '').trim()}
+                onClick={() => onSave(prov.var)}
+              >
+                <Icon name="check" size={14} /> Save
+              </Button>
+              {status?.set && (
+                <Button
+                  variant="secondary"
+                  type="button"
+                  disabled={busy === prov.var}
+                  onClick={() => onClear(prov.var)}
+                >
+                  Clear
+                </Button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </section>
+  );
+}

--- a/charts/workspace/web/src/routes/settings/index.tsx
+++ b/charts/workspace/web/src/routes/settings/index.tsx
@@ -2,6 +2,7 @@ import { theme, density, type Theme, type Density, pushToast } from '../../store
 import { Button } from '../../components/primitives/Button';
 import { Icon } from '../../components/Icon';
 import { GitSection } from './GitSection';
+import { ProviderKeysSection } from './ProviderKeysSection';
 import { BrowserSection } from './BrowserSection';
 import { MetricsSection } from './MetricsSection';
 import { UpdatesSection } from './UpdatesSection';
@@ -77,6 +78,8 @@ export function SettingsRoute() {
       <UpdatesSection />
 
       <GitSection />
+
+      <ProviderKeysSection />
 
       <BrowserSection />
 

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -637,3 +637,38 @@ export function authHeaders(): Record<string, string> {
   const { token } = getConfig();
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
+
+// ---- Provider keys ---------------------------------------------------------
+// User-settable model-provider keys for this workspace. Must match server.py
+// ProviderKeysManager.ALLOWED. GET returns a masked view (never the key).
+
+export type ProviderVar = 'OPENROUTER_API_KEY' | 'DEEPSEEK_API_KEY' | 'ANTHROPIC_API_KEY';
+
+export interface ProviderKeyStatus {
+  set: boolean;
+  hint: string;
+}
+
+export type ProviderKeysView = Record<ProviderVar, ProviderKeyStatus>;
+
+const EMPTY_PROVIDER_VIEW: ProviderKeysView = {
+  OPENROUTER_API_KEY: { set: false, hint: '' },
+  DEEPSEEK_API_KEY: { set: false, hint: '' },
+  ANTHROPIC_API_KEY: { set: false, hint: '' },
+};
+
+export async function listProviderKeys(): Promise<ProviderKeysView> {
+  if (getConfig().mock) return EMPTY_PROVIDER_VIEW;
+  const r = await request<{ providers: ProviderKeysView }>('/api/provider-keys');
+  return r.providers;
+}
+
+export async function setProviderKey(provider: ProviderVar, key: string): Promise<void> {
+  if (getConfig().mock) return;
+  await request('/api/provider-keys', { method: 'POST', body: { provider, key } });
+}
+
+export async function deleteProviderKey(provider: ProviderVar): Promise<void> {
+  if (getConfig().mock) return;
+  await request(`/api/provider-keys/${provider}`, { method: 'DELETE' });
+}

--- a/mobile/src/components/ProviderKeysCard.tsx
+++ b/mobile/src/components/ProviderKeysCard.tsx
@@ -1,0 +1,207 @@
+/** Settings card for user-settable model-provider API keys. Each provider shows
+ *  its masked status (set · …cc18 / not set) and opens a small modal to paste a
+ *  new key or clear it. Keys are stored on the workspace disk and used the next
+ *  time an assistant runs — no redeploy. Mirrors ControllerConnectModal. */
+import { Ionicons } from '@expo/vector-icons';
+import React, { useEffect, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {
+  listProviderKeys,
+  setProviderKey,
+  deleteProviderKey,
+  type ProviderVar,
+  type ProviderKeysView,
+} from '../api/client';
+import { colors, font, radius, space } from '../theme';
+import { Button, Card, Label } from './ui';
+
+const PROVIDERS: { var: ProviderVar; label: string; hint: string }[] = [
+  { var: 'OPENROUTER_API_KEY', label: 'OpenRouter', hint: 'OpenCode + OpenRouter-backed models' },
+  { var: 'DEEPSEEK_API_KEY', label: 'DeepSeek', hint: 'DeepSeek API' },
+  { var: 'ANTHROPIC_API_KEY', label: 'Anthropic', hint: 'Overrides the Claude oauth default' },
+];
+
+export function ProviderKeysCard({ readOnly }: { readOnly?: boolean }) {
+  const [view, setView] = useState<ProviderKeysView | null>(null);
+  const [editing, setEditing] = useState<ProviderVar | null>(null);
+
+  async function refresh() {
+    try {
+      setView(await listProviderKeys());
+    } catch {
+      // server unavailable — leave null
+    }
+  }
+  useEffect(() => { void refresh(); }, []);
+
+  const active = PROVIDERS.find((p) => p.var === editing) ?? null;
+
+  return (
+    <Card style={{ gap: space.md, marginTop: space.lg }}>
+      <Label>Provider API keys</Label>
+      <Text style={styles.help}>
+        Set your own model-provider keys for this workspace. Used the next time an assistant runs — no
+        redeploy. Leave unset to use the workspace default.
+      </Text>
+      {PROVIDERS.map((p) => {
+        const st = view?.[p.var];
+        return (
+          <View key={p.var} style={styles.row}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.provName}>{p.label}</Text>
+              <Text style={[styles.provState, { color: st?.set ? colors.success : colors.textFaint }]}>
+                {st?.set ? `set · ${st.hint}` : 'not set'}
+              </Text>
+            </View>
+            {!readOnly ? (
+              <Pressable onPress={() => setEditing(p.var)} hitSlop={8} accessibilityLabel={`Edit ${p.label} key`}>
+                <Ionicons name="create-outline" size={20} color={colors.textMuted} />
+              </Pressable>
+            ) : null}
+          </View>
+        );
+      })}
+
+      <ProviderKeyModal
+        provider={active}
+        isSet={active ? !!view?.[active.var]?.set : false}
+        onClose={() => setEditing(null)}
+        onDone={async () => { setEditing(null); await refresh(); }}
+      />
+    </Card>
+  );
+}
+
+function ProviderKeyModal({
+  provider,
+  isSet,
+  onClose,
+  onDone,
+}: {
+  provider: { var: ProviderVar; label: string; hint: string } | null;
+  isSet: boolean;
+  onClose: () => void;
+  onDone: () => void;
+}) {
+  const [key, setKey] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset the draft whenever the target provider changes.
+  useEffect(() => { setKey(''); setError(null); }, [provider?.var]);
+
+  async function save() {
+    if (!provider) return;
+    if (!key.trim()) {
+      setError('Paste a key');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await setProviderKey(provider.var, key.trim());
+      onDone();
+    } catch (e) {
+      setError(`Couldn't save: ${(e as Error).message}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function clear() {
+    if (!provider) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await deleteProviderKey(provider.var);
+      onDone();
+    } catch (e) {
+      setError(`Couldn't clear: ${(e as Error).message}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal visible={!!provider} animationType="slide" transparent onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+          <View style={styles.sheet}>
+            <View style={styles.head}>
+              <Text style={styles.title}>{provider?.label} key</Text>
+              <Pressable onPress={onClose} hitSlop={8} accessibilityLabel="Close">
+                <Ionicons name="close" size={22} color={colors.textMuted} />
+              </Pressable>
+            </View>
+            <Text style={styles.help}>{provider?.hint}</Text>
+
+            <Label style={{ marginTop: space.md }}>API key</Label>
+            <TextInput
+              value={key}
+              onChangeText={setKey}
+              placeholder={isSet ? 'Replace current key…' : 'Paste key…'}
+              placeholderTextColor={colors.textFaint}
+              autoCapitalize="none"
+              autoCorrect={false}
+              secureTextEntry
+              style={styles.input}
+            />
+
+            {error ? <Text style={styles.error}>{error}</Text> : null}
+
+            <Button title="Save key" onPress={save} loading={busy} style={{ marginTop: space.lg }} />
+            {isSet ? (
+              <Button
+                title="Clear key"
+                variant="secondary"
+                icon="trash-outline"
+                onPress={clear}
+                disabled={busy}
+                style={{ marginTop: space.sm }}
+              />
+            ) : null}
+          </View>
+        </KeyboardAvoidingView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  help: { color: colors.textMuted, fontSize: font.size.sm, lineHeight: 19 },
+  row: { flexDirection: 'row', alignItems: 'center', gap: space.md },
+  provName: { color: colors.text, fontSize: font.size.md },
+  provState: { fontSize: font.size.xs, fontWeight: '700', marginTop: 2, letterSpacing: 0.3 },
+  backdrop: { flex: 1, backgroundColor: '#000a', justifyContent: 'flex-end' },
+  sheet: {
+    backgroundColor: colors.bgElevated,
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    padding: space.xl,
+    paddingBottom: space.xxl,
+    gap: 2,
+  },
+  head: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  title: { color: colors.text, fontSize: font.size.lg, fontWeight: '800' },
+  input: {
+    marginTop: space.xs,
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingHorizontal: space.md,
+    paddingVertical: space.md,
+    color: colors.text,
+    fontSize: font.size.md,
+  },
+  error: { color: colors.danger, fontSize: font.size.sm, marginTop: space.md },
+});

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -4,6 +4,7 @@ import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Card, Label, ScreenHeader } from '../components/ui';
 import { ControllerConnectModal } from '../components/ControllerConnectModal';
+import { ProviderKeysCard } from '../components/ProviderKeysCard';
 import { clearConnection, clearControllerConnection, hasController, isDemoHost } from '../store/config';
 import { useConfig } from '../store/useConfig';
 import { colors, font, space } from '../theme';
@@ -73,6 +74,8 @@ export default function SettingsScreen() {
             style={{ marginTop: space.sm }}
           />
         ) : null}
+
+        {!cfg.mock ? <ProviderKeysCard readOnly={isDemo} /> : null}
 
         {/* Admin controller — a second, optional connection. */}
         <Card style={{ gap: space.md, marginTop: space.lg }}>


### PR DESCRIPTION
## What

Let a user set their **own** model-provider API keys (OpenRouter / DeepSeek / Anthropic) from the workspace **Settings** UI — the way Claude's oauth login is already self-service. No gitops edit, no redeploy.

**Why:** today `OPENROUTER_API_KEY` / `DEEPSEEK_API_KEY` come only from a helm value baked into the pod env at start, so changing a key means editing the gitops secret and rolling the pod — and an exhausted key silently blocks the Hypervisor's Ante / OpenRouter drivers. This makes provider keys behave like Claude auth: set once, in-workspace, persisted on the PVC, effective on the next turn.

## How

**Backend (`server.py`)**
- `ProviderKeysManager` — one JSON on the PVC (`0600` atomic write, modeled on `WebhookManager`); strict `ALLOWED` allowlist (`OPENROUTER_API_KEY`, `DEEPSEEK_API_KEY`, `ANTHROPIC_API_KEY`) so only known provider vars can ever be set/injected. `public_view()` masks to set/unset + a **last-4 hint** and never returns the key; `env_overlay()` yields `{VAR: value}` for set keys.
- `/api/provider-keys` `GET` (masked) / `POST {provider,key}` / `DELETE /<PROVIDER>`, all gated `check_claude_auth(allow_none_mode=False)` so secrets are unreachable in the unauth public demo; writes are already blocked in readonly by the do_POST/do_DELETE chokepoint.
- Overlay the store onto the CLI subprocess env at **both** spawn sites — the Build-tab `tmux` session and the Hypervisor turn subprocess — so a newly set key takes effect on the next turn/task. **Store wins over the pod env; when unset the helm default carries through**, so admin-provisioned defaults keep working (no forced migration).

`hypervisor_session.py` can't import `server.py` (server imports it), so it reads the same PVC file via a small local `_provider_key_overlay()` (var list kept in sync with `ProviderKeysManager.ALLOWED`). For Claude this only re-adds `ANTHROPIC_API_KEY` when the user explicitly set one — the adapter still drops the pod key by default so the subscription/oauth path is used.

**Web** — `ProviderKeysSection` in Settings (masked status + password field + **Save** / **Clear** per provider, modeled on `GitSection`).

**Mobile** — a *Provider keys* card with a per-provider modal (modeled on `ControllerConnectModal`), read-only in the public demo.

## Security

All endpoints require auth (`allow_none_mode=False`); store is `0600` on the per-tenant PVC; GET returns only `set` + a last-4 hint, never the key; the `ALLOWED` allowlist means arbitrary env can't be injected.

## Tests

`ProviderKeysManager` set/delete, masked `public_view` never leaks the key, `env_overlay` only surfaces allowed vars, `0600` write; the hypervisor overlay reader handles missing/garbage files and filters to allowed non-empty keys. Full suite green (641 python), web builds, web + mobile `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
