### PR TITLE
feat(dashboard): Skills tab — multi-harness SKILL.md surface (#187) [PR 1/2]

### DIFF
--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -55,6 +55,18 @@ except Exception as _hv_import_err:  # broken install shouldn't crash the server
     _HYPERVISOR_AVAILABLE = False
     print(f'[hypervisor] import failed: {_hv_import_err}', file=sys.stderr)
 
+# Multi-harness skills subsystem (issue #187) — same colocated-package
+# convention as `memory`. Read-only surface over SKILL.md-style files
+# discovered from every supported agent harness (Claude Code, OpenCode,
+# Antigravity, …) via one provider class per harness.
+try:
+    from skills.sync import SkillsSyncer
+    _SKILLS_AVAILABLE = True
+except Exception as _skills_import_err:  # broken install shouldn't crash the server
+    SkillsSyncer = None  # type: ignore
+    _SKILLS_AVAILABLE = False
+    print(f'[skills] import failed: {_skills_import_err}', file=sys.stderr)
+
 # Alert thresholds for metrics
 ALERT_THRESHOLDS = {
     'cpu': {'warning': 70, 'critical': 90},
@@ -3686,6 +3698,18 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             self.handle_memory_get(m.group(1), m.group(2))
             return
 
+        # --- Skills API (multi-harness SKILL.md surface; backs the Skills tab) ---
+        if claude_path == '/api/skills':
+            self.handle_skills_list(memory_query)
+            return
+        if claude_path == '/api/skills/stats':
+            self.handle_skills_stats()
+            return
+        m = re.match(r'^/api/skills/([a-zA-Z0-9._-]+)$', claude_path)
+        if m:
+            self.handle_skills_get(m.group(1))
+            return
+
         # --- Subagents (read-only view over Claude's transcripts) ---
         if claude_path == '/api/subagents':
             self.handle_subagents_list()
@@ -5525,6 +5549,88 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         EventBroker.publish('memory.changed', {'op': 'purge'})
         self.send_json({'status': 'ok', 'result': res})
 
+    # ── Skills (multi-harness SKILL.md surface — issue #187) ─────────────
+    # Read-only in this phase: list / detail / stats come from the
+    # SkillsSyncer's in-memory snapshot (files are the source of truth);
+    # POST /api/skills/_scan forces a synchronous rescan.
+
+    def _skills_unavailable(self):
+        if _SKILLS_AVAILABLE:
+            return False
+        self.send_json({'error': 'skills subsystem unavailable',
+                        'code': 'skills_unavailable',
+                        'detail': 'skills package failed to import; check server logs'},
+                       503)
+        return True
+
+    def handle_skills_list(self, query):
+        if not self.check_claude_auth():
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        if self._skills_unavailable():
+            return
+        if (query.get('refresh') or [''])[0] in ('1', 'true'):
+            try:
+                SkillsSyncer.trigger_sync()
+            except Exception as e:
+                print(f'[skills] refresh failed: {e}', file=sys.stderr)
+        records = SkillsSyncer.snapshot()
+        system = (query.get('system') or [None])[0]
+        scope = (query.get('scope') or [None])[0]
+        if system:
+            records = [r for r in records if system in r.systems]
+        if scope:
+            records = [r for r in records if r.scope == scope]
+        self.send_json({'skills': [r.to_dict() for r in records],
+                        'count': len(records)})
+
+    def handle_skills_get(self, name):
+        if not self.check_claude_auth():
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        if self._skills_unavailable():
+            return
+        variants = SkillsSyncer.get(name)
+        if not variants:
+            self.send_json({'error': 'not found', 'code': 'not_found'}, 404)
+            return
+        # One logical skill normally; 2+ entries when copies have diverged
+        # across systems (same name, different content fingerprint).
+        self.send_json({'skill': variants[0].to_dict(),
+                        'variants': [v.to_dict() for v in variants],
+                        'divergent': len(variants) > 1})
+
+    def handle_skills_stats(self):
+        if not self.check_claude_auth():
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        if self._skills_unavailable():
+            return
+        records = SkillsSyncer.snapshot()
+        by_system, by_scope = {}, {}
+        for r in records:
+            for s in r.systems:
+                by_system[s] = by_system.get(s, 0) + 1
+            by_scope[r.scope] = by_scope.get(r.scope, 0) + 1
+        self.send_json({'total': len(records),
+                        'by_system': by_system,
+                        'by_scope': by_scope,
+                        'syncer': SkillsSyncer.status()})
+
+    def handle_skills_scan(self):
+        """POST /api/skills/_scan — synchronous forced rescan."""
+        if not self.check_claude_auth():
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        if self._skills_unavailable():
+            return
+        try:
+            res = SkillsSyncer.trigger_sync()
+        except Exception as e:
+            self.send_json({'error': f'scan failed: {e}'}, 500)
+            return
+        self.send_json({'status': 'ok', 'result': res})
+
     # ── Subagents (spawned child tasks) ──────────────────────────
     # Lists real spawned sub-tasks filtered by parent_task_id.
     # Replaces the old read-only transcript scanner which was fragile
@@ -6828,6 +6934,9 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
                 self.handle_memory_import()
             elif path == "/api/memory/_purge":
                 self.handle_memory_purge()
+            # Skills API (multi-harness SKILL.md surface)
+            elif path == "/api/skills/_scan":
+                self.handle_skills_scan()
             # File upload (raw body; X-Dest-Path + X-Filename headers)
             elif path == "/api/files/upload":
                 self.handle_file_upload()
@@ -7606,6 +7715,22 @@ if __name__ == "__main__":
             print(f'[memory] periodic GC started '
                   f'(>{_gc_days}d every {_gc_interval_h}h)')
 
+    # Multi-harness skills scanner (issue #187): keeps an in-memory snapshot
+    # of SKILL.md-style definitions from every supported agent harness and
+    # publishes 'skills.changed' on the EventBroker when files change on disk.
+    # Independent of the memory subsystem — its own availability flag.
+    if _SKILLS_AVAILABLE:
+        try:
+            _skills_interval = int(os.environ.get('KC_SKILLS_INTERVAL', '30'))
+        except (TypeError, ValueError):
+            _skills_interval = 30
+        try:
+            SkillsSyncer.start(interval_seconds=_skills_interval,
+                               publish=EventBroker.publish)
+            print(f'[skills] multi-harness skills syncer started ({_skills_interval}s)')
+        except Exception as e:
+            print(f'[skills] syncer start failed: {e}', file=sys.stderr)
+
     # Background task reconciler: flips finished tasks running -> completed and
     # fires their completion hooks even when nothing is reading them, so headless
     # webhook/cron callbacks are timely (issue #96).
@@ -7651,6 +7776,10 @@ if __name__ == "__main__":
     print("  GET    /api/memory/{ns}/{key}/neighbors  - Graph walk")
     print("  POST   /api/memory/{ns}/{key}/relations  - Create relation")
     print("  GET    /api/memory/stats                 - Counts + health")
+    print("  GET    /api/skills                       - List skills (all harnesses)")
+    print("  GET    /api/skills/{name}                - One skill (+divergent variants)")
+    print("  GET    /api/skills/stats                 - Counts by system/scope")
+    print("  POST   /api/skills/_scan                 - Force rescan")
 
     with http.server.ThreadingHTTPServer(("", 6080), BrowserHandler) as httpd:
         httpd.serve_forever()

--- a/charts/workspace/skills/__init__.py
+++ b/charts/workspace/skills/__init__.py
@@ -1,0 +1,24 @@
+"""Multi-harness skills subsystem.
+
+Discovers agent "skills" (markdown capability definitions) from every
+supported AI harness in the workspace — Claude Code, OpenCode,
+Antigravity, … — normalizes them into a single `SkillRecord` shape, and
+keeps an in-memory cache fresh via a background mtime-fingerprint scan.
+
+Design: each harness's paths/format live in exactly one provider class
+(`providers/`). The rest of the stack (syncer, API handlers, SPA,
+mobile) only ever sees normalized records. Adding a harness = one new
+provider file + one registry entry. No harness is privileged: a skill
+that exists only in OpenCode's folders is first-class, and (in the sync
+phase) skills flow any-to-any.
+"""
+
+from .model import SkillRecord, merge, SKILL_NAME_RE
+from .providers import PROVIDERS, SkillProvider
+from .sync import SkillsSyncer
+
+__all__ = [
+    'SkillRecord', 'merge', 'SKILL_NAME_RE',
+    'PROVIDERS', 'SkillProvider',
+    'SkillsSyncer',
+]

--- a/charts/workspace/skills/model.py
+++ b/charts/workspace/skills/model.py
@@ -1,0 +1,170 @@
+"""Normalized skill model + identity/dedupe logic.
+
+A `SkillRecord` is the tool-agnostic shape every provider emits. Skill
+identity across harnesses is `(name, fingerprint)` where the
+fingerprint is a whitespace-normalized hash of the markdown body — pure
+content math, no tool involved. Same name + same fingerprint in two
+systems collapses to one record ("same skill, synced"); same name with
+different fingerprints stays as separate records the UI badges as
+divergent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+# Scope precedence within a single system (lower index wins).
+SCOPE_ORDER = ('project', 'user', 'plugin')
+
+# Safe skill names: lowercase alnum + hyphens, must start alnum. This is
+# the gate used before any filesystem path is built from a name (path
+# traversal guard) — mirrors the posture proposed for the Facts feature.
+SKILL_NAME_RE = re.compile(r'^[a-z0-9][a-z0-9-]*$')
+
+
+@dataclass
+class SkillSource:
+    """One concrete file a skill was discovered in."""
+    system: str          # harness key, e.g. 'claude', 'opencode'
+    path: str
+    scope: str           # 'project' | 'user' | 'plugin'
+    updated_at: float
+    shadowed: bool = False  # true when a higher-precedence scope wins
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            'system': self.system,
+            'path': self.path,
+            'scope': self.scope,
+            'updated_at': self.updated_at,
+            'shadowed': self.shadowed,
+        }
+
+
+@dataclass
+class SkillRecord:
+    """Tool-agnostic normalized skill. Providers emit one per file with
+    systems=[<their key>]; `merge()` collapses across systems."""
+    name: str
+    description: str = ''
+    body: str = ''
+    scope: str = 'user'
+    systems: List[str] = field(default_factory=list)
+    user_invocable: bool = False
+    allowed_tools: List[str] = field(default_factory=list)
+    argument_hint: str = ''
+    sources: List[SkillSource] = field(default_factory=list)
+    fingerprint: str = ''
+    updated_at: float = 0.0
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            'name': self.name,
+            'description': self.description,
+            'body': self.body,
+            'scope': self.scope,
+            'systems': sorted(self.systems),
+            'user_invocable': self.user_invocable,
+            'allowed_tools': self.allowed_tools,
+            'argument_hint': self.argument_hint,
+            'sources': [s.to_dict() for s in self.sources],
+            'fingerprint': self.fingerprint,
+            'updated_at': self.updated_at,
+        }
+
+
+def fingerprint(body: str) -> str:
+    """Content hash of the markdown body (frontmatter already stripped).
+
+    Normalization: per-line trailing whitespace trimmed, leading/trailing
+    blank lines dropped — so a byte-identical sync round-trip and trivial
+    whitespace drift still match, while real edits do not.
+    """
+    lines = [ln.rstrip() for ln in (body or '').splitlines()]
+    while lines and not lines[0]:
+        lines.pop(0)
+    while lines and not lines[-1]:
+        lines.pop()
+    normalized = '\n'.join(lines)
+    return hashlib.sha256(normalized.encode('utf-8')).hexdigest()[:16]
+
+
+def _scope_rank(scope: str) -> int:
+    try:
+        return SCOPE_ORDER.index(scope)
+    except ValueError:
+        return len(SCOPE_ORDER)
+
+
+def merge(records: List[SkillRecord]) -> List[SkillRecord]:
+    """Collapse per-file provider records into logical skills.
+
+    1. Within one system, same name at multiple scopes: highest-precedence
+       scope (project > user > plugin) wins; shadowed copies are kept in
+       `sources` with shadowed=True but don't contribute content.
+    2. Across systems, group key = (name, fingerprint): identical content
+       under the same name merges into one record whose `systems` is the
+       union. Different content under the same name stays separate
+       (divergent variants, surfaced to the UI as such).
+    """
+    # Pass 1: within-system shadowing. Key: (system, name).
+    winners: Dict[tuple, SkillRecord] = {}
+    shadowed_sources: Dict[tuple, List[SkillSource]] = {}
+    for rec in records:
+        if not rec.systems or not rec.sources:
+            continue
+        system = rec.systems[0]
+        k = (system, rec.name)
+        cur = winners.get(k)
+        if cur is None:
+            winners[k] = rec
+            continue
+        if _scope_rank(rec.scope) < _scope_rank(cur.scope):
+            # rec wins; demote current winner's sources to shadowed.
+            for s in cur.sources:
+                s.shadowed = True
+            shadowed_sources.setdefault(k, []).extend(cur.sources)
+            winners[k] = rec
+        else:
+            for s in rec.sources:
+                s.shadowed = True
+            shadowed_sources.setdefault(k, []).extend(rec.sources)
+
+    # Pass 2: cross-system grouping by (name, fingerprint).
+    grouped: Dict[tuple, SkillRecord] = {}
+    for (system, name), rec in winners.items():
+        fp = rec.fingerprint or fingerprint(rec.body)
+        rec.fingerprint = fp
+        gk = (name, fp)
+        extra = shadowed_sources.get((system, name), [])
+        tgt = grouped.get(gk)
+        if tgt is None:
+            rec.sources = list(rec.sources) + extra
+            rec.systems = [system]
+            grouped[gk] = rec
+        else:
+            if system not in tgt.systems:
+                tgt.systems.append(system)
+            tgt.sources.extend(rec.sources)
+            tgt.sources.extend(extra)
+            tgt.updated_at = max(tgt.updated_at, rec.updated_at)
+            # Prefer the richest description/metadata already present;
+            # fill blanks from the newcomer.
+            if not tgt.description:
+                tgt.description = rec.description
+            if not tgt.argument_hint:
+                tgt.argument_hint = rec.argument_hint
+            if not tgt.allowed_tools:
+                tgt.allowed_tools = rec.allowed_tools
+
+    out = list(grouped.values())
+    out.sort(key=lambda r: (r.name, r.fingerprint))
+    return out
+
+
+def find(records: List[SkillRecord], name: str) -> List[SkillRecord]:
+    """All variants of a logical skill name (1 normally; 2+ if divergent)."""
+    return [r for r in records if r.name == name]

--- a/charts/workspace/skills/parser.py
+++ b/charts/workspace/skills/parser.py
@@ -1,0 +1,48 @@
+"""Tolerant SKILL.md-style frontmatter parsing.
+
+Adapted from memory/sync.py's dependency-free k:v parser. Skills use the
+same convention: a `---` fenced YAML-ish header followed by a markdown
+body. We deliberately stay dependency-free and lossy-tolerant on read:
+unknown keys are ignored (kept in the returned meta dict for callers
+that care), files without frontmatter are treated as all-body, and
+malformed lines are skipped rather than raised on.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Tuple
+
+_FRONTMATTER_RE = re.compile(r'^---\s*\n(.*?)\n---\s*\n?(.*)$', re.DOTALL)
+
+# Truthy strings accepted for boolean frontmatter values.
+_TRUTHY = frozenset({'true', 'yes', '1', 'on'})
+
+
+def parse_frontmatter(text: str) -> Tuple[Dict[str, str], str]:
+    """Split `text` into (meta, body). No frontmatter → ({}, text)."""
+    m = _FRONTMATTER_RE.match(text or '')
+    if not m:
+        return {}, text or ''
+    head, body = m.group(1), m.group(2)
+    meta: Dict[str, str] = {}
+    for line in head.splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        if ':' not in line:
+            continue
+        k, v = line.split(':', 1)
+        meta[k.strip().lower()] = v.strip().strip('"').strip("'")
+    return meta, body.lstrip('\n')
+
+
+def parse_bool(value: str) -> bool:
+    return (value or '').strip().lower() in _TRUTHY
+
+
+def parse_tool_list(value: str) -> List[str]:
+    """'Bash, Read, Grep' → ['Bash', 'Read', 'Grep']. Empty → []."""
+    if not value:
+        return []
+    return [t.strip() for t in value.split(',') if t.strip()]

--- a/charts/workspace/skills/providers/__init__.py
+++ b/charts/workspace/skills/providers/__init__.py
@@ -1,0 +1,157 @@
+"""Skill providers — one class per AI harness.
+
+A provider encapsulates EVERYTHING harness-specific: where skills live
+on disk (`scan_roots`), how the native file format maps to the
+normalized `SkillRecord` (`scan`), and — in the sync phase — how a
+canonical record is rendered back into the harness's native format and
+installed (`render`/`install`).
+
+The registry below is the single extension point: adding support for a
+new harness means writing one provider file and adding one entry here.
+Provider keys match the assistant registry in server.py
+(ClaudeTaskManager.ASSISTANTS) so the dashboard can correlate skills
+with runnable assistants.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Dict, Iterable, List, Tuple
+
+from ..model import SkillRecord, SkillSource, SKILL_NAME_RE, fingerprint
+from ..parser import parse_frontmatter, parse_bool, parse_tool_list
+
+
+class SkillProvider:
+    """Base class. Subclasses set `key` and implement `scan_roots()`.
+
+    The default `scan()` handles the common "directory of
+    <name>/SKILL.md folders" layout shared by Claude-compatible
+    harnesses; providers with other native formats override `scan()`.
+    """
+
+    key: str = ''
+    enabled: bool = True
+
+    # ── read path ───────────────────────────────────────────────────────
+
+    def scan_roots(self) -> List[Tuple[str, str]]:
+        """[(scope, directory)] — every location this harness reads
+        skills from. Scope is 'project' | 'user' | 'plugin'."""
+        raise NotImplementedError
+
+    def scan(self) -> List[SkillRecord]:
+        """Walk roots and return per-file records (systems=[self.key]).
+        Never raises: unreadable/malformed files are logged and skipped."""
+        if not self.enabled:
+            return []
+        records: List[SkillRecord] = []
+        seen_paths = set()
+        for scope, root in self.scan_roots():
+            if not root or not os.path.isdir(root):
+                continue
+            for path in self._iter_skill_files(root):
+                rp = os.path.realpath(path)
+                if rp in seen_paths:
+                    continue
+                seen_paths.add(rp)
+                rec = self._load_one(path, scope)
+                if rec is not None:
+                    records.append(rec)
+        return records
+
+    def _iter_skill_files(self, root: str) -> Iterable[str]:
+        """Default layout: <root>/<name>/SKILL.md. Depth-limited, no
+        recursion — mirrors the discipline of memory/sync.py's walk."""
+        try:
+            entries = os.listdir(root)
+        except OSError:
+            return
+        for entry in sorted(entries):
+            p = os.path.join(root, entry, 'SKILL.md')
+            if os.path.isfile(p):
+                yield p
+
+    def _load_one(self, path: str, scope: str):
+        try:
+            st = os.stat(path)
+            with open(path, 'r', encoding='utf-8', errors='replace') as f:
+                raw = f.read()
+        except OSError as e:
+            print(f'[skills] {self.key}: skip {path}: {e}', file=sys.stderr)
+            return None
+        meta, body = parse_frontmatter(raw)
+        # Name: frontmatter wins, else the containing folder / file stem.
+        name = (meta.get('name') or '').strip()
+        if not name:
+            parent = os.path.basename(os.path.dirname(path))
+            name = parent if parent else os.path.splitext(os.path.basename(path))[0]
+        name = name.lower()
+        if not SKILL_NAME_RE.match(name):
+            print(f'[skills] {self.key}: skip {path}: unsafe name {name!r}',
+                  file=sys.stderr)
+            return None
+        return SkillRecord(
+            name=name,
+            description=(meta.get('description') or '').strip(),
+            body=body,
+            scope=scope,
+            systems=[self.key],
+            user_invocable=parse_bool(meta.get('user-invocable', '')),
+            allowed_tools=parse_tool_list(meta.get('allowed-tools', '')),
+            argument_hint=(meta.get('argument-hint') or '').strip(),
+            sources=[SkillSource(system=self.key, path=path, scope=scope,
+                                 updated_at=st.st_mtime)],
+            fingerprint=fingerprint(body),
+            updated_at=st.st_mtime,
+        )
+
+    # ── fingerprint of roots (cheap change detection) ───────────────────
+
+    def roots_mtime_fingerprint(self) -> Dict[str, float]:
+        """path→mtime over every skill file. Cheap: stat only, no reads.
+        The syncer compares consecutive fingerprints to skip parsing."""
+        fp: Dict[str, float] = {}
+        if not self.enabled:
+            return fp
+        for _scope, root in self.scan_roots():
+            if not root or not os.path.isdir(root):
+                continue
+            for path in self._iter_skill_files(root):
+                try:
+                    fp[os.path.realpath(path)] = os.stat(path).st_mtime
+                except OSError:
+                    continue
+        return fp
+
+    # ── write path (sync engine, PR 2) ──────────────────────────────────
+
+    def install_path(self, name: str, scope: str = 'user') -> str:
+        """Destination path a translated skill would be written to."""
+        raise NotImplementedError
+
+    def render(self, record: SkillRecord) -> str:
+        """Canonical record → this harness's native file text."""
+        raise NotImplementedError
+
+    def install(self, record: SkillRecord, scope: str = 'user') -> str:
+        """render() + atomic write. Returns the written path."""
+        raise NotImplementedError
+
+
+def _now() -> float:
+    return time.time()
+
+
+# Registry — populated at import bottom to avoid circular imports.
+from .claude import ClaudeProvider          # noqa: E402
+from .opencode import OpenCodeProvider      # noqa: E402
+from .ante import AnteProvider              # noqa: E402
+from .antigravity import AntigravityProvider  # noqa: E402
+
+PROVIDERS: Dict[str, SkillProvider] = {
+    p.key: p for p in (ClaudeProvider(), OpenCodeProvider(), AnteProvider(),
+                       AntigravityProvider())
+}

--- a/charts/workspace/skills/providers/ante.py
+++ b/charts/workspace/skills/providers/ante.py
@@ -1,0 +1,81 @@
+"""Ante (Antigma Labs) skill provider.
+
+Ante's config home is `~/.ante/` — confirmed in-pod: start.sh seeds
+`~/.ante/settings.json` with the shared MCP servers (see the "seeding
+Ante MCP config" stage). We scan the Claude-compatible skills layout
+under that home, plus a project-scoped `.ante/skills/` mirroring the
+OpenCode provider's project convention:
+
+    user:     ~/.ante/skills/<name>/SKILL.md
+    project:  <checkout>/.ante/skills/<name>/SKILL.md
+
+Enabled by default: `~/.ante/` exists on every pod, and scanning a
+skills dir that isn't there yet is a no-op (missing roots are skipped).
+Set KC_SKILLS_ANTE=0 to turn the provider off. If a runtime `ls
+~/.ante` shows Ante adopts a different skills layout, `scan_roots()`
+below is the single correction point — nothing else changes.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, List, Tuple
+
+from . import SkillProvider
+
+HOME_CANDIDATES = (
+    '/home/dev',
+    '/home/ubuntu',
+    os.path.expanduser('~'),
+)
+
+PROJECT_ROOT_ENV = 'KC_SKILLS_PROJECT_ROOTS'
+DEFAULT_PROJECT_ROOTS = ('/home/dev',)
+
+
+class AnteProvider(SkillProvider):
+    # Matches the 'ante' key in ClaudeTaskManager.ASSISTANTS so the
+    # dashboard can correlate skills with the runnable assistant.
+    key = 'ante'
+    enabled = os.environ.get('KC_SKILLS_ANTE', '1') != '0'
+
+    def scan_roots(self) -> List[Tuple[str, str]]:
+        roots: List[Tuple[str, str]] = []
+        seen = set()
+
+        def add(scope: str, path: str):
+            rp = os.path.realpath(path)
+            if rp in seen:
+                return
+            seen.add(rp)
+            roots.append((scope, path))
+
+        for home in self._homes():
+            add('user', os.path.join(home, '.ante', 'skills'))
+        for base in self._project_roots():
+            if not os.path.isdir(base):
+                continue
+            add('project', os.path.join(base, '.ante', 'skills'))
+            try:
+                for entry in sorted(os.listdir(base)):
+                    add('project', os.path.join(base, entry, '.ante', 'skills'))
+            except OSError:
+                continue
+        return roots
+
+    @staticmethod
+    def _homes() -> Iterable[str]:
+        out, seen = [], set()
+        for h in HOME_CANDIDATES:
+            rp = os.path.realpath(h)
+            if rp not in seen:
+                seen.add(rp)
+                out.append(h)
+        return out
+
+    @staticmethod
+    def _project_roots() -> Iterable[str]:
+        env = os.environ.get(PROJECT_ROOT_ENV, '')
+        if env:
+            return [p for p in env.split(os.pathsep) if p]
+        return DEFAULT_PROJECT_ROOTS

--- a/charts/workspace/skills/providers/antigravity.py
+++ b/charts/workspace/skills/providers/antigravity.py
@@ -1,0 +1,26 @@
+"""Antigravity (agy) skill provider — disabled stub.
+
+Antigravity's on-disk skill layout is not yet runtime-verified, so this
+provider ships disabled and scan() short-circuits to []. Flip it on
+with KC_SKILLS_ANTIGRAVITY=1 once a dev-pod `ls ~/.antigravity`
+confirms the layout; scan_roots() below is the speculative guess and
+the single place to correct.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List, Tuple
+
+from . import SkillProvider
+
+
+class AntigravityProvider(SkillProvider):
+    key = 'antigravity'
+    enabled = os.environ.get('KC_SKILLS_ANTIGRAVITY', '') == '1'
+
+    def scan_roots(self) -> List[Tuple[str, str]]:
+        return [
+            ('user', os.path.join(home, '.antigravity', 'skills'))
+            for home in ('/home/dev', '/home/ubuntu', os.path.expanduser('~'))
+        ]

--- a/charts/workspace/skills/providers/claude.py
+++ b/charts/workspace/skills/providers/claude.py
@@ -1,0 +1,82 @@
+"""Claude Code skill provider.
+
+Native layout (also the interchange format other providers translate
+to/from — an open markdown + frontmatter convention, no Claude software
+required to read or write it):
+
+    project:  <workspace>/.claude/skills/<name>/SKILL.md
+    user:     <home>/.claude/skills/<name>/SKILL.md
+    plugin:   <home>/.claude/plugins/marketplaces/*/plugins/*/skills/<name>/SKILL.md
+
+Multi-home scanning matches memory/sync.py's DEFAULT_SCAN_ROOTS: the
+pod runs services under varying users, so ~/.claude may live in
+/home/dev, /home/ubuntu, or the current $HOME.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from typing import Iterable, List, Tuple
+
+from . import SkillProvider
+
+# Same multi-home trio as memory/sync.py DEFAULT_SCAN_ROOTS.
+HOME_CLAUDE_ROOTS = (
+    '/home/dev/.claude',
+    '/home/ubuntu/.claude',
+    os.path.expanduser('~/.claude'),
+)
+
+# Candidate workspace checkouts for project-scoped skills. The primary
+# repo checkout lives under /home/dev in the pod; env override for tests
+# and non-standard layouts.
+PROJECT_ROOT_ENV = 'KC_SKILLS_PROJECT_ROOTS'
+DEFAULT_PROJECT_ROOTS = ('/home/dev',)
+
+
+class ClaudeProvider(SkillProvider):
+    key = 'claude'
+
+    def scan_roots(self) -> List[Tuple[str, str]]:
+        roots: List[Tuple[str, str]] = []
+        seen = set()
+
+        def add(scope: str, path: str):
+            rp = os.path.realpath(path)
+            if rp in seen:
+                return
+            seen.add(rp)
+            roots.append((scope, path))
+
+        # Project scope: <checkout>/.claude/skills for every repo directly
+        # under each project root (depth-limited: no full tree walk).
+        for base in self._project_roots():
+            if not os.path.isdir(base):
+                continue
+            add('project', os.path.join(base, '.claude', 'skills'))
+            try:
+                for entry in sorted(os.listdir(base)):
+                    add('project', os.path.join(base, entry, '.claude', 'skills'))
+            except OSError:
+                continue
+
+        # User scope.
+        for home in HOME_CLAUDE_ROOTS:
+            add('user', os.path.join(home, 'skills'))
+
+        # Plugin scope: marketplaces glob (bounded depth).
+        for home in HOME_CLAUDE_ROOTS:
+            pattern = os.path.join(home, 'plugins', 'marketplaces', '*',
+                                   'plugins', '*', 'skills')
+            for d in sorted(glob.glob(pattern)):
+                add('plugin', d)
+
+        return roots
+
+    @staticmethod
+    def _project_roots() -> Iterable[str]:
+        env = os.environ.get(PROJECT_ROOT_ENV, '')
+        if env:
+            return [p for p in env.split(os.pathsep) if p]
+        return DEFAULT_PROJECT_ROOTS

--- a/charts/workspace/skills/providers/opencode.py
+++ b/charts/workspace/skills/providers/opencode.py
@@ -1,0 +1,149 @@
+"""OpenCode skill provider.
+
+OpenCode (opencode-ai) advertises compatibility with Claude-style skill
+folders; it also has an older "custom commands" convention of flat
+markdown files. We scan, in order:
+
+    user:     ~/.config/opencode/skills/<name>/SKILL.md   (Claude-compatible)
+    project:  <checkout>/.opencode/skills/<name>/SKILL.md
+    user:     ~/.config/opencode/command/*.md             (legacy commands:
+              file stem → name, frontmatter `description` honored)
+
+All path knowledge lives in this one file — if a runtime `ls` of the
+pod shows OpenCode uses a different layout, this is the single
+correction point.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, List, Tuple
+
+from . import SkillProvider
+from ..model import SkillRecord, SkillSource, SKILL_NAME_RE, fingerprint
+from ..parser import parse_frontmatter, parse_bool, parse_tool_list
+
+HOME_CANDIDATES = (
+    '/home/dev',
+    '/home/ubuntu',
+    os.path.expanduser('~'),
+)
+
+PROJECT_ROOT_ENV = 'KC_SKILLS_PROJECT_ROOTS'
+DEFAULT_PROJECT_ROOTS = ('/home/dev',)
+
+
+class OpenCodeProvider(SkillProvider):
+    key = 'opencode'
+
+    def scan_roots(self) -> List[Tuple[str, str]]:
+        roots: List[Tuple[str, str]] = []
+        seen = set()
+
+        def add(scope: str, path: str):
+            rp = os.path.realpath(path)
+            if rp in seen:
+                return
+            seen.add(rp)
+            roots.append((scope, path))
+
+        for home in self._homes():
+            add('user', os.path.join(home, '.config', 'opencode', 'skills'))
+        for base in self._project_roots():
+            if not os.path.isdir(base):
+                continue
+            add('project', os.path.join(base, '.opencode', 'skills'))
+            try:
+                for entry in sorted(os.listdir(base)):
+                    add('project', os.path.join(base, entry, '.opencode', 'skills'))
+            except OSError:
+                continue
+        return roots
+
+    def scan(self) -> List[SkillRecord]:
+        # Claude-compatible skills dirs first (base implementation)…
+        records = super().scan()
+        # …then legacy flat command files.
+        seen_names = {r.name for r in records}
+        for home in self._homes():
+            cmd_dir = os.path.join(home, '.config', 'opencode', 'command')
+            if not os.path.isdir(cmd_dir):
+                continue
+            try:
+                entries = sorted(os.listdir(cmd_dir))
+            except OSError:
+                continue
+            for entry in entries:
+                if not entry.endswith('.md'):
+                    continue
+                rec = self._load_command(os.path.join(cmd_dir, entry))
+                if rec is not None and rec.name not in seen_names:
+                    seen_names.add(rec.name)
+                    records.append(rec)
+        return records
+
+    def _load_command(self, path: str):
+        """Legacy command file: <stem>.md with optional frontmatter."""
+        try:
+            st = os.stat(path)
+            with open(path, 'r', encoding='utf-8', errors='replace') as f:
+                raw = f.read()
+        except OSError:
+            return None
+        meta, body = parse_frontmatter(raw)
+        name = (meta.get('name') or
+                os.path.splitext(os.path.basename(path))[0]).strip().lower()
+        if not SKILL_NAME_RE.match(name):
+            return None
+        return SkillRecord(
+            name=name,
+            description=(meta.get('description') or '').strip(),
+            body=body,
+            scope='user',
+            systems=[self.key],
+            user_invocable=parse_bool(meta.get('user-invocable', 'true')),
+            allowed_tools=parse_tool_list(meta.get('allowed-tools', '')),
+            argument_hint=(meta.get('argument-hint') or '').strip(),
+            sources=[SkillSource(system=self.key, path=path, scope='user',
+                                 updated_at=st.st_mtime)],
+            fingerprint=fingerprint(body),
+            updated_at=st.st_mtime,
+        )
+
+    def roots_mtime_fingerprint(self):
+        fp = super().roots_mtime_fingerprint()
+        # Include legacy command files so edits there trigger a rescan.
+        for home in self._homes():
+            cmd_dir = os.path.join(home, '.config', 'opencode', 'command')
+            if not os.path.isdir(cmd_dir):
+                continue
+            try:
+                entries = os.listdir(cmd_dir)
+            except OSError:
+                continue
+            for entry in entries:
+                if not entry.endswith('.md'):
+                    continue
+                p = os.path.join(cmd_dir, entry)
+                try:
+                    fp[os.path.realpath(p)] = os.stat(p).st_mtime
+                except OSError:
+                    continue
+        return fp
+
+    @staticmethod
+    def _homes() -> Iterable[str]:
+        out, seen = [], set()
+        for h in HOME_CANDIDATES:
+            rp = os.path.realpath(h)
+            if rp not in seen:
+                seen.add(rp)
+                out.append(h)
+        return out
+
+    @staticmethod
+    def _project_roots() -> Iterable[str]:
+        env = os.environ.get(PROJECT_ROOT_ENV, '')
+        if env:
+            return [p for p in env.split(os.pathsep) if p]
+        return DEFAULT_PROJECT_ROOTS

--- a/charts/workspace/skills/sync.py
+++ b/charts/workspace/skills/sync.py
@@ -1,0 +1,182 @@
+"""Background skills scanner with in-memory cache.
+
+Modeled on memory/sync.py's ClaudeMemorySyncer (TOCTOU-safe start,
+status(), trigger_sync()) but with two differences:
+
+* No SQLite — skills are few, files are the source of truth, so the
+  merged records live in an in-memory snapshot swapped under a lock.
+* It publishes an aggregate `skills.changed` event through an injected
+  publisher (the server passes EventBroker.publish) whenever a pass
+  actually changed the cache — the TaskReconciler publish pattern.
+
+Change detection is a cheap mtime fingerprint per provider (stat-only,
+no file reads); parsing only happens on a pass where some file's mtime,
+membership, or count changed.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from typing import Callable, Dict, List, Optional
+
+from .model import SkillRecord, merge, find
+from .providers import PROVIDERS
+
+
+def scan_once() -> List[SkillRecord]:
+    """One full scan across all enabled providers → merged records."""
+    per_file: List[SkillRecord] = []
+    for key, provider in PROVIDERS.items():
+        try:
+            per_file.extend(provider.scan())
+        except Exception as e:  # provider bugs must never kill the pass
+            print(f'[skills] provider {key} scan failed: {e}', file=sys.stderr)
+    return merge(per_file)
+
+
+class SkillsSyncer:
+    """Single-process background poller. Idempotent; safe to start once."""
+
+    _started = False
+    _thread: Optional[threading.Thread] = None
+    _stop_event = threading.Event()
+    _start_lock = threading.Lock()
+
+    _cache_lock = threading.Lock()
+    _cache: List[SkillRecord] = []
+    _cache_version = 0
+    _last_fingerprints: Dict[str, Dict[str, float]] = {}
+    _last_run_at: float = 0.0
+
+    # Injected by the server at start(); called as publish(type, data).
+    _publish: Optional[Callable[[str, dict], None]] = None
+
+    # ── public API ───────────────────────────────────────────────────────
+
+    @classmethod
+    def start(cls, *, interval_seconds: int = 30,
+              publish: Optional[Callable[[str, dict], None]] = None) -> None:
+        with cls._start_lock:
+            if cls._started:
+                return
+            cls._started = True
+        cls._publish = publish
+
+        def _loop():
+            # Eager first pass so the dashboard has data immediately.
+            while not cls._stop_event.is_set():
+                try:
+                    cls._pass()
+                except Exception as e:
+                    print(f'[skills] background pass failed: {e}',
+                          file=sys.stderr)
+                cls._stop_event.wait(interval_seconds)
+
+        t = threading.Thread(target=_loop, name='skills-sync', daemon=True)
+        cls._thread = t
+        t.start()
+
+    @classmethod
+    def snapshot(cls) -> List[SkillRecord]:
+        """Copy of the merged records; handlers read from this."""
+        with cls._cache_lock:
+            return list(cls._cache)
+
+    @classmethod
+    def get(cls, name: str) -> List[SkillRecord]:
+        """All variants of a logical skill (1 usually; 2+ when divergent)."""
+        return find(cls.snapshot(), name)
+
+    @classmethod
+    def status(cls) -> Dict[str, object]:
+        with cls._cache_lock:
+            count = len(cls._cache)
+            version = cls._cache_version
+        return {
+            'running': cls._started and (cls._thread is not None
+                                         and cls._thread.is_alive()),
+            'last_run_at': cls._last_run_at or None,
+            'count': count,
+            'version': version,
+            'providers': {k: p.enabled for k, p in PROVIDERS.items()},
+        }
+
+    @classmethod
+    def trigger_sync(cls) -> Dict[str, object]:
+        """Synchronous forced rescan (used by /api/skills/_scan and
+        ?refresh=1). Bypasses the mtime shortcut."""
+        records = scan_once()
+        changed = cls._swap(records)
+        # Refresh fingerprints so the next background pass doesn't redo work.
+        cls._refingerprint()
+        cls._last_run_at = time.time()
+        if changed:
+            cls._emit()
+        return {'scanned': len(records), 'changed': changed,
+                'version': cls._cache_version}
+
+    # ── internals ────────────────────────────────────────────────────────
+
+    @classmethod
+    def _pass(cls) -> None:
+        fps = {k: p.roots_mtime_fingerprint() for k, p in PROVIDERS.items()}
+        if fps == cls._last_fingerprints and cls._cache_version > 0:
+            cls._last_run_at = time.time()
+            return
+        records = scan_once()
+        changed = cls._swap(records)
+        cls._last_fingerprints = fps
+        cls._last_run_at = time.time()
+        if changed:
+            cls._emit()
+
+    @classmethod
+    def _refingerprint(cls) -> None:
+        cls._last_fingerprints = {
+            k: p.roots_mtime_fingerprint() for k, p in PROVIDERS.items()
+        }
+
+    @classmethod
+    def _swap(cls, records: List[SkillRecord]) -> bool:
+        """Install a new snapshot; returns True if content changed."""
+        new_shape = [(r.name, r.fingerprint, tuple(sorted(r.systems)),
+                      r.scope) for r in records]
+        with cls._cache_lock:
+            old_shape = [(r.name, r.fingerprint, tuple(sorted(r.systems)),
+                          r.scope) for r in cls._cache]
+            if new_shape == old_shape and cls._cache_version > 0:
+                return False
+            cls._cache = records
+            cls._cache_version += 1
+            return True
+
+    @classmethod
+    def _emit(cls) -> None:
+        pub = cls._publish
+        if pub is None:
+            return
+        try:
+            with cls._cache_lock:
+                count, version = len(cls._cache), cls._cache_version
+            pub('skills.changed', {'count': count, 'version': version})
+        except Exception as e:
+            print(f'[skills] publish failed: {e}', file=sys.stderr)
+
+    # ── test hooks ───────────────────────────────────────────────────────
+
+    @classmethod
+    def _reset_for_test(cls) -> None:
+        cls._stop_event.set()
+        if cls._thread is not None:
+            cls._thread.join(timeout=2)
+        cls._started = False
+        cls._thread = None
+        cls._stop_event = threading.Event()
+        with cls._cache_lock:
+            cls._cache = []
+            cls._cache_version = 0
+        cls._last_fingerprints = {}
+        cls._last_run_at = 0.0
+        cls._publish = None

--- a/charts/workspace/start.sh
+++ b/charts/workspace/start.sh
@@ -588,6 +588,19 @@ install -m 0644 /browser-config/memory_manager.py  /tmp/browser/memory/manager.p
 install -m 0644 /browser-config/memory_sync.py     /tmp/browser/memory/sync.py
 install -m 0644 /browser-config/memory_embeddings.py        /tmp/browser/memory/embeddings.py
 install -m 0644 /browser-config/memory_embeddings_worker.py /tmp/browser/memory/embeddings_worker.py
+
+# The skills subsystem (multi-harness SKILL.md surface, issue #187) ships
+# the same way: flat configmap keys reassembled into a real package tree.
+mkdir -p /tmp/browser/skills/providers
+install -m 0644 /browser-config/skills__init__.py            /tmp/browser/skills/__init__.py
+install -m 0644 /browser-config/skills_model.py              /tmp/browser/skills/model.py
+install -m 0644 /browser-config/skills_parser.py             /tmp/browser/skills/parser.py
+install -m 0644 /browser-config/skills_sync.py               /tmp/browser/skills/sync.py
+install -m 0644 /browser-config/skills_providers__init__.py  /tmp/browser/skills/providers/__init__.py
+install -m 0644 /browser-config/skills_providers_claude.py   /tmp/browser/skills/providers/claude.py
+install -m 0644 /browser-config/skills_providers_opencode.py /tmp/browser/skills/providers/opencode.py
+install -m 0644 /browser-config/skills_providers_ante.py     /tmp/browser/skills/providers/ante.py
+install -m 0644 /browser-config/skills_providers_antigravity.py /tmp/browser/skills/providers/antigravity.py
 # Seed the per-user MCP server + user-prompt-submit hook next to the
 # SQLite file so claude config points at PVC-backed paths that survive
 # configmap rotations.
@@ -676,6 +689,7 @@ for f in /browser-config/*; do
   base=$(basename "$f")
   case "$base" in
     memory_*|memory__init__.py) continue ;;
+    skills_*|skills__init__.py) continue ;;
   esac
   cp "$f" /tmp/browser/
 done

--- a/charts/workspace/templates/browser-configmap.yaml
+++ b/charts/workspace/templates/browser-configmap.yaml
@@ -36,6 +36,24 @@ data:
 {{ .Files.Get "memory/embeddings.py" | indent 4 }}
   memory_embeddings_worker.py: |
 {{ .Files.Get "memory/embeddings_worker.py" | indent 4 }}
+  skills__init__.py: |
+{{ .Files.Get "skills/__init__.py" | indent 4 }}
+  skills_model.py: |
+{{ .Files.Get "skills/model.py" | indent 4 }}
+  skills_parser.py: |
+{{ .Files.Get "skills/parser.py" | indent 4 }}
+  skills_sync.py: |
+{{ .Files.Get "skills/sync.py" | indent 4 }}
+  skills_providers__init__.py: |
+{{ .Files.Get "skills/providers/__init__.py" | indent 4 }}
+  skills_providers_claude.py: |
+{{ .Files.Get "skills/providers/claude.py" | indent 4 }}
+  skills_providers_opencode.py: |
+{{ .Files.Get "skills/providers/opencode.py" | indent 4 }}
+  skills_providers_ante.py: |
+{{ .Files.Get "skills/providers/ante.py" | indent 4 }}
+  skills_providers_antigravity.py: |
+{{ .Files.Get "skills/providers/antigravity.py" | indent 4 }}
   mcp_agent_orchestrator.py: |
 {{ .Files.Get "mcp_agent_orchestrator.py" | indent 4 }}
   mcp_dashboard.py: |

--- a/charts/workspace/tests/skills_sync_test.py
+++ b/charts/workspace/tests/skills_sync_test.py
@@ -1,0 +1,174 @@
+"""Unit tests for skills/sync.py — the background scanner + cache.
+
+Covers: cache population via trigger_sync, snapshot isolation, variant
+lookup, the mtime-fingerprint skip (no re-parse when nothing changed),
+aggregate `skills.changed` publication (once per changed pass, none on
+quiet passes), and the TOCTOU-safe double-start guard.
+
+Uses a fake in-memory provider — no filesystem, no threads except the
+double-start test.
+
+Run with:    python3 -m unittest tests.skills_sync_test
+(from charts/workspace/)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+
+import skills.sync as sync_mod  # noqa: E402
+from skills.sync import SkillsSyncer, scan_once  # noqa: E402
+from skills.model import SkillRecord, SkillSource, fingerprint  # noqa: E402
+
+
+class FakeProvider:
+    """In-memory provider with controllable records + mtimes."""
+    key = 'fake'
+    enabled = True
+
+    def __init__(self):
+        self.files = {}          # path -> (body, mtime)
+        self.scan_calls = 0
+
+    def set_file(self, path, body, mtime):
+        self.files[path] = (body, mtime)
+
+    def scan(self):
+        self.scan_calls += 1
+        out = []
+        for path, (body, mtime) in sorted(self.files.items()):
+            name = os.path.basename(path).replace('.md', '')
+            out.append(SkillRecord(
+                name=name, body=body, scope='user', systems=[self.key],
+                sources=[SkillSource(system=self.key, path=path,
+                                     scope='user', updated_at=mtime)],
+                fingerprint=fingerprint(body), updated_at=mtime,
+            ))
+        return out
+
+    def roots_mtime_fingerprint(self):
+        return {p: m for p, (_b, m) in self.files.items()}
+
+
+class SyncerTestBase(unittest.TestCase):
+    def setUp(self):
+        SkillsSyncer._reset_for_test()
+        self.provider = FakeProvider()
+        self._saved_providers = sync_mod.PROVIDERS
+        sync_mod.PROVIDERS = {'fake': self.provider}
+        self.published = []
+        SkillsSyncer._publish = lambda t, d: self.published.append((t, d))
+
+    def tearDown(self):
+        sync_mod.PROVIDERS = self._saved_providers
+        SkillsSyncer._reset_for_test()
+
+
+class TriggerSyncTests(SyncerTestBase):
+    def test_populates_cache(self):
+        self.provider.set_file('/x/alpha.md', 'body A', 1.0)
+        res = SkillsSyncer.trigger_sync()
+        self.assertEqual(res['scanned'], 1)
+        self.assertTrue(res['changed'])
+        snap = SkillsSyncer.snapshot()
+        self.assertEqual(len(snap), 1)
+        self.assertEqual(snap[0].name, 'alpha')
+
+    def test_snapshot_is_a_copy(self):
+        self.provider.set_file('/x/alpha.md', 'body', 1.0)
+        SkillsSyncer.trigger_sync()
+        snap = SkillsSyncer.snapshot()
+        snap.clear()
+        self.assertEqual(len(SkillsSyncer.snapshot()), 1)
+
+    def test_get_returns_variants(self):
+        self.provider.set_file('/x/alpha.md', 'body', 1.0)
+        SkillsSyncer.trigger_sync()
+        self.assertEqual(len(SkillsSyncer.get('alpha')), 1)
+        self.assertEqual(SkillsSyncer.get('nope'), [])
+
+    def test_scan_once_survives_provider_error(self):
+        class Boom:
+            key = 'boom'
+            enabled = True
+
+            def scan(self):
+                raise RuntimeError('kaboom')
+
+            def roots_mtime_fingerprint(self):
+                return {}
+
+        sync_mod.PROVIDERS = {'boom': Boom(), 'fake': self.provider}
+        self.provider.set_file('/x/ok.md', 'fine', 1.0)
+        out = scan_once()
+        self.assertEqual(len(out), 1)   # good provider still contributes
+
+
+class EventTests(SyncerTestBase):
+    def test_change_publishes_once(self):
+        self.provider.set_file('/x/alpha.md', 'body', 1.0)
+        SkillsSyncer.trigger_sync()
+        events = [e for e in self.published if e[0] == 'skills.changed']
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0][1]['count'], 1)
+
+    def test_no_change_no_publish(self):
+        self.provider.set_file('/x/alpha.md', 'body', 1.0)
+        SkillsSyncer.trigger_sync()
+        self.published.clear()
+        SkillsSyncer.trigger_sync()   # identical content
+        self.assertEqual(self.published, [])
+
+    def test_publish_failure_is_swallowed(self):
+        def bad(_t, _d):
+            raise RuntimeError('broker down')
+        SkillsSyncer._publish = bad
+        self.provider.set_file('/x/alpha.md', 'body', 1.0)
+        SkillsSyncer.trigger_sync()   # must not raise
+
+
+class MtimeSkipTests(SyncerTestBase):
+    def test_pass_skips_parse_when_unchanged(self):
+        self.provider.set_file('/x/alpha.md', 'body', 1.0)
+        SkillsSyncer._pass()
+        self.assertEqual(self.provider.scan_calls, 1)
+        SkillsSyncer._pass()          # same mtimes → no scan
+        self.assertEqual(self.provider.scan_calls, 1)
+
+    def test_pass_rescans_on_mtime_change(self):
+        self.provider.set_file('/x/alpha.md', 'body', 1.0)
+        SkillsSyncer._pass()
+        self.provider.set_file('/x/alpha.md', 'body v2', 2.0)
+        SkillsSyncer._pass()
+        self.assertEqual(self.provider.scan_calls, 2)
+        self.assertIn('body v2', SkillsSyncer.snapshot()[0].body)
+
+    def test_pass_rescans_on_new_file(self):
+        self.provider.set_file('/x/alpha.md', 'body', 1.0)
+        SkillsSyncer._pass()
+        self.provider.set_file('/x/beta.md', 'other', 1.0)
+        SkillsSyncer._pass()
+        self.assertEqual(len(SkillsSyncer.snapshot()), 2)
+
+
+class StartGuardTests(SyncerTestBase):
+    def test_double_start_spawns_one_thread(self):
+        SkillsSyncer.start(interval_seconds=3600)
+        t1 = SkillsSyncer._thread
+        SkillsSyncer.start(interval_seconds=3600)
+        self.assertIs(SkillsSyncer._thread, t1)
+
+    def test_status_shape(self):
+        st = SkillsSyncer.status()
+        self.assertIn('running', st)
+        self.assertIn('count', st)
+        self.assertIn('providers', st)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/tests/skills_test.py
+++ b/charts/workspace/tests/skills_test.py
@@ -1,0 +1,396 @@
+"""Unit tests for the skills/ package — multi-harness skill discovery.
+
+Covers the tolerant frontmatter parser, the content-fingerprint identity
+function, the merge/dedupe algorithm (cross-system collapse, divergence,
+within-system scope shadowing), the name-safety gate, and provider scans
+over temp-dir fixtures for the Claude layout (project/user/plugin) and
+OpenCode's legacy command files.
+
+Run with:    python3 -m unittest tests.skills_test
+(from charts/workspace/)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+
+from skills.model import (  # noqa: E402
+    SkillRecord, SkillSource, SKILL_NAME_RE, fingerprint, merge, find,
+)
+from skills.parser import (  # noqa: E402
+    parse_frontmatter, parse_bool, parse_tool_list,
+)
+from skills.providers import PROVIDERS, SkillProvider  # noqa: E402
+from skills.providers.ante import AnteProvider  # noqa: E402
+from skills.providers.opencode import OpenCodeProvider  # noqa: E402
+
+
+SKILL_MD = """---
+name: remote-task
+description: Launch a task on a remote workspace
+user-invocable: true
+allowed-tools: Bash, Read, Grep
+argument-hint: [prompt or "status"]
+---
+
+# Remote Task Skill
+
+Body text here.
+"""
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Parser
+# ───────────────────────────────────────────────────────────────────────────
+
+class ParseFrontmatterTests(unittest.TestCase):
+    def test_full_frontmatter(self):
+        meta, body = parse_frontmatter(SKILL_MD)
+        self.assertEqual(meta['name'], 'remote-task')
+        self.assertEqual(meta['description'],
+                         'Launch a task on a remote workspace')
+        self.assertEqual(meta['user-invocable'], 'true')
+        self.assertIn('# Remote Task Skill', body)
+        self.assertNotIn('---', body.split('\n')[0])
+
+    def test_no_frontmatter_is_all_body(self):
+        meta, body = parse_frontmatter('just markdown, no fence')
+        self.assertEqual(meta, {})
+        self.assertEqual(body, 'just markdown, no fence')
+
+    def test_empty_input(self):
+        meta, body = parse_frontmatter('')
+        self.assertEqual(meta, {})
+        self.assertEqual(body, '')
+
+    def test_quoted_values_unquoted(self):
+        meta, _ = parse_frontmatter('---\nname: "quoted"\n---\nbody')
+        self.assertEqual(meta['name'], 'quoted')
+
+    def test_keys_lowercased(self):
+        meta, _ = parse_frontmatter('---\nName: x\nDESCRIPTION: y\n---\nbody')
+        self.assertEqual(meta['name'], 'x')
+        self.assertEqual(meta['description'], 'y')
+
+    def test_malformed_lines_skipped(self):
+        meta, _ = parse_frontmatter('---\nno-colon-line\nname: ok\n---\nbody')
+        self.assertEqual(meta, {'name': 'ok'})
+
+    def test_bool_parsing(self):
+        for t in ('true', 'True', 'yes', '1', 'on'):
+            self.assertTrue(parse_bool(t), t)
+        for f in ('false', 'no', '0', '', 'banana'):
+            self.assertFalse(parse_bool(f), f)
+
+    def test_tool_list(self):
+        self.assertEqual(parse_tool_list('Bash, Read, Grep'),
+                         ['Bash', 'Read', 'Grep'])
+        self.assertEqual(parse_tool_list(''), [])
+        self.assertEqual(parse_tool_list('  Bash ,, Read '), ['Bash', 'Read'])
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Fingerprint (identity function)
+# ───────────────────────────────────────────────────────────────────────────
+
+class FingerprintTests(unittest.TestCase):
+    def test_whitespace_normalized(self):
+        self.assertEqual(fingerprint('hello\nworld  \n\n'),
+                         fingerprint('\n\nhello\nworld'))
+
+    def test_content_change_changes_fingerprint(self):
+        self.assertNotEqual(fingerprint('hello'), fingerprint('hello!'))
+
+    def test_stable_length(self):
+        self.assertEqual(len(fingerprint('anything')), 16)
+
+    def test_empty_body(self):
+        self.assertEqual(fingerprint(''), fingerprint('\n\n'))
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Merge / dedupe
+# ───────────────────────────────────────────────────────────────────────────
+
+def _rec(name, body, system, scope='user', mtime=1.0, description=''):
+    return SkillRecord(
+        name=name, description=description, body=body, scope=scope,
+        systems=[system],
+        sources=[SkillSource(system=system, path=f'/x/{system}/{scope}/{name}',
+                             scope=scope, updated_at=mtime)],
+        fingerprint=fingerprint(body), updated_at=mtime,
+    )
+
+
+class MergeTests(unittest.TestCase):
+    def test_same_content_across_systems_collapses(self):
+        out = merge([_rec('a', 'same body', 'claude'),
+                     _rec('a', 'same body', 'opencode')])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(sorted(out[0].systems), ['claude', 'opencode'])
+        self.assertEqual(len(out[0].sources), 2)
+
+    def test_divergent_content_stays_split(self):
+        out = merge([_rec('a', 'one', 'claude'),
+                     _rec('a', 'two', 'opencode')])
+        self.assertEqual(len(out), 2)
+        self.assertEqual(len(find(out, 'a')), 2)
+
+    def test_project_shadows_user_within_system(self):
+        out = merge([_rec('a', 'proj body', 'claude', scope='project'),
+                     _rec('a', 'user body', 'claude', scope='user')])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0].scope, 'project')
+        self.assertIn('proj body', out[0].body)
+        shadowed = [s for s in out[0].sources if s.shadowed]
+        self.assertEqual(len(shadowed), 1)
+        self.assertEqual(shadowed[0].scope, 'user')
+
+    def test_user_shadows_plugin(self):
+        out = merge([_rec('a', 'plug', 'claude', scope='plugin'),
+                     _rec('a', 'usr', 'claude', scope='user')])
+        self.assertEqual(out[0].scope, 'user')
+
+    def test_shadowing_order_independent(self):
+        a = merge([_rec('a', 'p', 'claude', 'project'),
+                   _rec('a', 'u', 'claude', 'user')])
+        b = merge([_rec('a', 'u', 'claude', 'user'),
+                   _rec('a', 'p', 'claude', 'project')])
+        self.assertEqual(a[0].scope, b[0].scope)
+        self.assertEqual(a[0].fingerprint, b[0].fingerprint)
+
+    def test_updated_at_is_max_over_merged(self):
+        out = merge([_rec('a', 'same', 'claude', mtime=5.0),
+                     _rec('a', 'same', 'opencode', mtime=9.0)])
+        self.assertEqual(out[0].updated_at, 9.0)
+
+    def test_description_filled_from_newcomer_when_blank(self):
+        out = merge([_rec('a', 'same', 'claude', description=''),
+                     _rec('a', 'same', 'opencode', description='hi')])
+        self.assertEqual(out[0].description, 'hi')
+
+    def test_different_names_never_merge(self):
+        out = merge([_rec('a', 'same', 'claude'),
+                     _rec('b', 'same', 'claude')])
+        self.assertEqual(len(out), 2)
+
+    def test_sorted_output_deterministic(self):
+        out = merge([_rec('z', '1', 'claude'), _rec('a', '2', 'claude')])
+        self.assertEqual([r.name for r in out], ['a', 'z'])
+
+
+class NameSafetyTests(unittest.TestCase):
+    def test_valid_names(self):
+        for n in ('a', 'remote-task', 'x1', '9lives', 'a-b-c'):
+            self.assertTrue(SKILL_NAME_RE.match(n), n)
+
+    def test_rejected_names(self):
+        for n in ('../evil', 'UPPER', 'sp ace', '.hidden', '-lead',
+                  'a/b', 'a\\b', 'a..b/..', ''):
+            self.assertFalse(SKILL_NAME_RE.match(n), n)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Provider scans over tmpdir fixtures
+# ───────────────────────────────────────────────────────────────────────────
+
+class _TmpProvider(SkillProvider):
+    """Test provider bound to explicit (scope, dir) roots."""
+    key = 'testtool'
+
+    def __init__(self, roots):
+        self._roots = roots
+
+    def scan_roots(self):
+        return self._roots
+
+
+def _write_skill(root, name, text):
+    d = os.path.join(root, name)
+    os.makedirs(d, exist_ok=True)
+    p = os.path.join(d, 'SKILL.md')
+    with open(p, 'w', encoding='utf-8') as f:
+        f.write(text)
+    return p
+
+
+class ProviderScanTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix='skills-test-')
+
+    def test_scan_standard_layout(self):
+        _write_skill(self.tmp, 'remote-task', SKILL_MD)
+        recs = _TmpProvider([('user', self.tmp)]).scan()
+        self.assertEqual(len(recs), 1)
+        r = recs[0]
+        self.assertEqual(r.name, 'remote-task')
+        self.assertEqual(r.systems, ['testtool'])
+        self.assertEqual(r.scope, 'user')
+        self.assertTrue(r.user_invocable)
+        self.assertEqual(r.allowed_tools, ['Bash', 'Read', 'Grep'])
+        self.assertIn('Body text here.', r.body)
+        self.assertTrue(r.fingerprint)
+
+    def test_name_falls_back_to_folder(self):
+        _write_skill(self.tmp, 'folder-name', 'no frontmatter body')
+        recs = _TmpProvider([('user', self.tmp)]).scan()
+        self.assertEqual(recs[0].name, 'folder-name')
+
+    def test_unsafe_folder_name_skipped(self):
+        _write_skill(self.tmp, 'Bad Name', 'body')
+        recs = _TmpProvider([('user', self.tmp)]).scan()
+        self.assertEqual(recs, [])
+
+    def test_missing_root_is_fine(self):
+        recs = _TmpProvider([('user', os.path.join(self.tmp, 'nope'))]).scan()
+        self.assertEqual(recs, [])
+
+    def test_disabled_provider_returns_nothing(self):
+        _write_skill(self.tmp, 'x', SKILL_MD)
+        p = _TmpProvider([('user', self.tmp)])
+        p.enabled = False
+        self.assertEqual(p.scan(), [])
+
+    def test_duplicate_realpath_deduped(self):
+        _write_skill(self.tmp, 'a', SKILL_MD)
+        recs = _TmpProvider([('user', self.tmp), ('user', self.tmp)]).scan()
+        self.assertEqual(len(recs), 1)
+
+    def test_mtime_fingerprint_reflects_files(self):
+        _write_skill(self.tmp, 'a', SKILL_MD)
+        p = _TmpProvider([('user', self.tmp)])
+        fp1 = p.roots_mtime_fingerprint()
+        self.assertEqual(len(fp1), 1)
+        _write_skill(self.tmp, 'b', SKILL_MD)
+        fp2 = p.roots_mtime_fingerprint()
+        self.assertEqual(len(fp2), 2)
+
+
+class OpenCodeCommandTests(unittest.TestCase):
+    """Legacy ~/.config/opencode/command/*.md flat files."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix='oc-test-')
+        self.cmd_dir = os.path.join(self.tmp, '.config', 'opencode', 'command')
+        os.makedirs(self.cmd_dir)
+        self.provider = OpenCodeProvider()
+        # Bind home discovery to the fixture.
+        self.provider._homes = lambda: [self.tmp]  # type: ignore
+        self.provider._project_roots = lambda: []  # type: ignore
+
+    def test_command_file_mapped_to_skill(self):
+        with open(os.path.join(self.cmd_dir, 'deploy-prod.md'), 'w') as f:
+            f.write('---\ndescription: Deploy to prod\n---\nDo the deploy.')
+        recs = self.provider.scan()
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0].name, 'deploy-prod')
+        self.assertEqual(recs[0].description, 'Deploy to prod')
+        self.assertEqual(recs[0].systems, ['opencode'])
+
+    def test_skills_dir_takes_precedence_over_command(self):
+        skills_dir = os.path.join(self.tmp, '.config', 'opencode', 'skills')
+        _write_skill(skills_dir, 'dup', '---\nname: dup\n---\nskills-dir copy')
+        with open(os.path.join(self.cmd_dir, 'dup.md'), 'w') as f:
+            f.write('command copy')
+        recs = self.provider.scan()
+        names = [r.name for r in recs]
+        self.assertEqual(names.count('dup'), 1)
+        self.assertIn('skills-dir copy', recs[names.index('dup')].body)
+
+
+class ProviderRegistryTests(unittest.TestCase):
+    """The registry is the extension point — every harness key present."""
+
+    def test_all_harnesses_registered(self):
+        for key in ('claude', 'opencode', 'ante', 'antigravity'):
+            self.assertIn(key, PROVIDERS)
+            self.assertEqual(PROVIDERS[key].key, key)
+
+    def test_ante_enabled_by_default(self):
+        # ~/.ante exists on every pod (start.sh seeds settings.json), and
+        # scanning a missing skills dir is a no-op — safe to ship on.
+        self.assertTrue(PROVIDERS['ante'].enabled)
+
+
+class AnteProviderTests(unittest.TestCase):
+    """Ante scans the Claude-compatible layout under ~/.ante/skills."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix='ante-test-')
+        self.skills_dir = os.path.join(self.tmp, '.ante', 'skills')
+        self.provider = AnteProvider()
+        self.provider._homes = lambda: [self.tmp]  # type: ignore
+        self.provider._project_roots = lambda: []  # type: ignore
+
+    def test_scan_roots_point_at_ante_home(self):
+        roots = self.provider.scan_roots()
+        self.assertEqual(roots, [('user', self.skills_dir)])
+
+    def test_scan_standard_layout(self):
+        _write_skill(self.skills_dir, 'runbook', SKILL_MD)
+        recs = self.provider.scan()
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0].systems, ['ante'])
+        self.assertEqual(recs[0].name, 'remote-task')  # frontmatter name wins
+
+    def test_missing_skills_dir_is_noop(self):
+        self.assertEqual(self.provider.scan(), [])
+
+    def test_project_scope_scanned(self):
+        proj = tempfile.mkdtemp(prefix='ante-proj-')
+        repo_skills = os.path.join(proj, 'myrepo', '.ante', 'skills')
+        _write_skill(repo_skills, 'deploy', '---\nname: deploy\n---\nbody')
+        self.provider._project_roots = lambda: [proj]  # type: ignore
+        recs = self.provider.scan()
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0].scope, 'project')
+
+    def test_cross_system_collapse_with_claude_copy(self):
+        # The same SKILL.md in Ante's dir and a "claude" dir → one row.
+        _write_skill(self.skills_dir, 'remote-task', SKILL_MD)
+        claude_dir = tempfile.mkdtemp(prefix='claude-side-')
+        _write_skill(claude_dir, 'remote-task', SKILL_MD)
+
+        class C(_TmpProvider):
+            key = 'claude'
+
+        out = merge(self.provider.scan() + C([('user', claude_dir)]).scan())
+        self.assertEqual(len(out), 1)
+        self.assertEqual(sorted(out[0].systems), ['ante', 'claude'])
+
+
+class EndToEndMergeTests(unittest.TestCase):
+    """Two providers over real files → one collapsed logical skill."""
+
+    def test_cross_system_collapse_from_disk(self):
+        t1 = tempfile.mkdtemp(prefix='sysA-')
+        t2 = tempfile.mkdtemp(prefix='sysB-')
+        _write_skill(t1, 'shared', SKILL_MD)
+        _write_skill(t2, 'shared', SKILL_MD)
+
+        class A(_TmpProvider):
+            key = 'claude'
+
+        class B(_TmpProvider):
+            key = 'opencode'
+
+        recs = A([('user', t1)]).scan() + B([('user', t2)]).scan()
+        out = merge(recs)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(sorted(out[0].systems), ['claude', 'opencode'])
+
+        # Now diverge one copy → two variants.
+        _write_skill(t2, 'shared', SKILL_MD + '\nEDITED')
+        recs = A([('user', t1)]).scan() + B([('user', t2)]).scan()
+        out = merge(recs)
+        self.assertEqual(len(out), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/web/src/api/events.ts
+++ b/charts/workspace/web/src/api/events.ts
@@ -32,6 +32,7 @@ const EVENT_TYPES = [
   'task.status',
   'trigger.fired',
   'memory.changed',
+  'skills.changed',
 ];
 
 let es: EventSource | null = null;

--- a/charts/workspace/web/src/api/skills.test.ts
+++ b/charts/workspace/web/src/api/skills.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { listSkills, getSkill, skillsStats, scanSkills, type SkillRecord } from './skills';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Capture the URL + method the api layer hits, returning `body` as JSON. */
+function capture(body: unknown) {
+  const calls: { url: string; method: string; body?: string }[] = [];
+  globalThis.fetch = vi.fn(async (u: string, init?: RequestInit) => {
+    calls.push({ url: u, method: init?.method ?? 'GET', body: init?.body as string | undefined });
+    return {
+      ok: true,
+      status: 200,
+      statusText: '',
+      headers: { get: (k: string) => (k.toLowerCase() === 'content-type' ? 'application/json' : null) },
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+const SKILL: SkillRecord = {
+  name: 'remote-task',
+  description: 'Launch a task on a remote workspace',
+  body: '# Remote Task Skill',
+  scope: 'project',
+  systems: ['claude', 'opencode'],
+  user_invocable: true,
+  allowed_tools: ['Bash', 'Read'],
+  argument_hint: '[prompt]',
+  sources: [
+    { system: 'claude', path: '/home/dev/repo/.claude/skills/remote-task/SKILL.md', scope: 'project', updated_at: 1, shadowed: false },
+  ],
+  fingerprint: 'abc123',
+  updated_at: 1,
+};
+
+describe('skills api (#187)', () => {
+  it('listSkills hits /api/skills and unwraps the list', async () => {
+    const calls = capture({ skills: [SKILL], count: 1 });
+    const r = await listSkills();
+    expect(calls[0].url).toContain('/api/skills');
+    expect(calls[0].method).toBe('GET');
+    expect(r.skills).toHaveLength(1);
+    expect(r.skills[0].name).toBe('remote-task');
+    expect(r.skills[0].systems).toEqual(['claude', 'opencode']);
+  });
+
+  it('listSkills forwards system/scope filters as query params', async () => {
+    const calls = capture({ skills: [], count: 0 });
+    await listSkills({ system: 'opencode', scope: 'user' });
+    expect(calls[0].url).toContain('system=opencode');
+    expect(calls[0].url).toContain('scope=user');
+  });
+
+  it('listSkills tolerates missing arrays (coerces to [])', async () => {
+    capture({ count: 0 });
+    const r = await listSkills();
+    expect(r.skills).toEqual([]);
+  });
+
+  it('listSkills coerces missing nested arrays on a record', async () => {
+    capture({ skills: [{ ...SKILL, systems: undefined, allowed_tools: undefined, sources: undefined }], count: 1 });
+    const r = await listSkills();
+    expect(r.skills[0].systems).toEqual([]);
+    expect(r.skills[0].allowed_tools).toEqual([]);
+    expect(r.skills[0].sources).toEqual([]);
+  });
+
+  it('getSkill hits the name endpoint and unwraps variants', async () => {
+    const calls = capture({ skill: SKILL, variants: [SKILL], divergent: false });
+    const d = await getSkill('remote-task');
+    expect(calls[0].url).toContain('/api/skills/remote-task');
+    expect(d.skill.name).toBe('remote-task');
+    expect(d.variants).toHaveLength(1);
+    expect(d.divergent).toBe(false);
+  });
+
+  it('getSkill surfaces divergent variants', async () => {
+    const other = { ...SKILL, fingerprint: 'def456', systems: ['opencode'] };
+    capture({ skill: SKILL, variants: [SKILL, other], divergent: true });
+    const d = await getSkill('remote-task');
+    expect(d.divergent).toBe(true);
+    expect(d.variants).toHaveLength(2);
+  });
+
+  it('getSkill URL-encodes the name', async () => {
+    const calls = capture({ skill: SKILL, variants: [SKILL], divergent: false });
+    await getSkill('a b');
+    expect(calls[0].url).toContain('/api/skills/a%20b');
+  });
+
+  it('skillsStats GETs the stats endpoint', async () => {
+    const calls = capture({ total: 3, by_system: { claude: 3 }, by_scope: { user: 3 } });
+    const s = await skillsStats();
+    expect(calls[0].url).toContain('/api/skills/stats');
+    expect(s.total).toBe(3);
+  });
+
+  it('scanSkills POSTs the _scan endpoint', async () => {
+    const calls = capture({ status: 'ok', result: { scanned: 5, changed: true } });
+    await scanSkills();
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toContain('/api/skills/_scan');
+  });
+});

--- a/charts/workspace/web/src/api/skills.ts
+++ b/charts/workspace/web/src/api/skills.ts
@@ -1,0 +1,82 @@
+import { apiGet, apiPost } from './client';
+import { safeArray } from './shape';
+
+/**
+ * Skills API — multi-harness SKILL.md surface (issue #187).
+ *
+ * A "skill" is a normalized, tool-agnostic record discovered from every
+ * supported agent harness (Claude Code, OpenCode, Antigravity, …). The
+ * same logical skill present in several harnesses with identical content
+ * collapses into one record whose `systems` lists all of them; same name
+ * with different content stays as separate "divergent" variants.
+ */
+
+export interface SkillSource {
+  system: string;
+  path: string;
+  scope: string;
+  updated_at: number;
+  shadowed: boolean;
+}
+
+export interface SkillRecord {
+  name: string;
+  description: string;
+  body: string;
+  scope: 'project' | 'user' | 'plugin' | string;
+  systems: string[];
+  user_invocable: boolean;
+  allowed_tools: string[];
+  argument_hint: string;
+  sources: SkillSource[];
+  fingerprint: string;
+  updated_at: number;
+}
+
+export interface SkillsListQuery {
+  system?: string;
+  scope?: string;
+  refresh?: number;
+}
+
+interface ListResponse {
+  skills: SkillRecord[];
+  count: number;
+}
+
+const coerceSkill = (s: SkillRecord): SkillRecord => ({
+  ...s,
+  systems: safeArray(s.systems) as string[],
+  allowed_tools: safeArray(s.allowed_tools) as string[],
+  sources: safeArray(s.sources) as SkillSource[],
+});
+
+export const listSkills = (q: SkillsListQuery = {}) =>
+  apiGet<ListResponse>('/api/skills', q as Record<string, string | number | undefined>)
+    .then((r) => ({ ...r, skills: (safeArray(r.skills) as SkillRecord[]).map(coerceSkill) }));
+
+export interface SkillDetail {
+  skill: SkillRecord;
+  variants: SkillRecord[];
+  divergent: boolean;
+}
+
+export const getSkill = (name: string) =>
+  apiGet<SkillDetail>(`/api/skills/${encodeURIComponent(name)}`)
+    .then((r) => ({
+      skill: coerceSkill(r.skill),
+      variants: (safeArray(r.variants) as SkillRecord[]).map(coerceSkill),
+      divergent: !!r.divergent,
+    }));
+
+export interface SkillsStats {
+  total: number;
+  by_system: Record<string, number>;
+  by_scope: Record<string, number>;
+  syncer?: Record<string, unknown>;
+}
+
+export const skillsStats = () => apiGet<SkillsStats>('/api/skills/stats');
+
+export const scanSkills = () =>
+  apiPost<{ status: string; result: Record<string, unknown> }>('/api/skills/_scan');

--- a/charts/workspace/web/src/components/BottomNav.tsx
+++ b/charts/workspace/web/src/components/BottomNav.tsx
@@ -20,7 +20,7 @@ const SLOTS: Slot[] = [
 
 // "More" sheet absorbs anything not in SLOTS — apps, triggers, files,
 // docs, settings. Highlights when the current route is one of those.
-const MORE_ROUTES = new Set(['/apps', '/triggers', '/files', '/docs', '/settings']);
+const MORE_ROUTES = new Set(['/skills', '/apps', '/triggers', '/files', '/docs', '/settings']);
 
 export function BottomNav() {
   const active = matchRoute(currentPath.value).path;

--- a/charts/workspace/web/src/components/Icon.tsx
+++ b/charts/workspace/web/src/components/Icon.tsx
@@ -7,6 +7,7 @@ import type { JSX } from 'preact';
 export type IconName =
   | 'tasks'
   | 'memory'
+  | 'skills'
   | 'triggers'
   | 'files'
   | 'settings'
@@ -49,6 +50,12 @@ const PATHS: Record<IconName, JSX.Element> = {
     <>
       <rect x="4" y="3" width="12" height="14" rx="2" />
       <path d="M7 7h6M7 10h6M7 13h4" />
+    </>
+  ),
+  // Four-point spark — "capability" — distinct from triggers' bolt shape.
+  skills: (
+    <>
+      <path d="M10 2l1.8 6.2L18 10l-6.2 1.8L10 18l-1.8-6.2L2 10l6.2-1.8z" />
     </>
   ),
   triggers: (

--- a/charts/workspace/web/src/components/Rail.tsx
+++ b/charts/workspace/web/src/components/Rail.tsx
@@ -9,6 +9,7 @@ const ICONS: Record<string, IconName> = {
   '/desktop': 'desktop',
   '/hypervisor': 'hypervisor',
   '/memory': 'memory',
+  '/skills': 'skills',
   '/apps': 'apps',
   '/triggers': 'triggers',
   '/files': 'files',

--- a/charts/workspace/web/src/routes/Shell.tsx
+++ b/charts/workspace/web/src/routes/Shell.tsx
@@ -29,12 +29,14 @@ const FilesRoute = lazy<ComponentType>(() => import('./files/index').then((m) =>
 const SettingsRoute = lazy<ComponentType>(() => import('./settings/index').then((m) => ({ default: m.SettingsRoute })));
 const DocsRoute = lazy<ComponentType>(() => import('./docs/index').then((m) => ({ default: m.DocsRoute })));
 const AppsRoute = lazy<ComponentType>(() => import('./apps/index').then((m) => ({ default: m.AppsRoute })));
+const SkillsRoute = lazy<ComponentType>(() => import('./skills/index').then((m) => ({ default: m.SkillsRoute })));
 
 const ROUTE_COMPONENTS: Record<string, ComponentType> = {
   '/tasks': TasksRoute,
   '/desktop': DesktopRoute,
   '/hypervisor': HypervisorRoute,
   '/memory': MemoryRoute,
+  '/skills': SkillsRoute,
   '/apps': AppsRoute,
   '/triggers': TriggersRoute,
   '/files': FilesRoute,

--- a/charts/workspace/web/src/routes/skills/index.tsx
+++ b/charts/workspace/web/src/routes/skills/index.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useState } from 'preact/hooks';
+import {
+  skills,
+  filteredSkills,
+  skillsFilter,
+  skillsSystemFacet,
+  skillsScopeFacet,
+  skillSystems,
+  skillScopes,
+  divergentNames,
+  selectedSkill,
+  selectSkill,
+  startSkillsPolling,
+  stopSkillsPolling,
+} from '../../store/skills';
+import { sheetOpen } from '../../store/ui';
+import { useIsMobile } from '../../hooks/useMediaQuery';
+import { Input } from '../../components/primitives/Input';
+import { Pill } from '../../components/primitives/Pill';
+import { Icon } from '../../components/Icon';
+import { EmptyState } from '../../components/primitives/EmptyState';
+import { BottomSheet } from '../../components/BottomSheet';
+import type { SkillRecord } from '../../api/skills';
+import './skills.css';
+
+/**
+ * Skills tab (issue #187) — read-only surface over the SKILL.md-style
+ * capabilities discovered from EVERY agent harness in the workspace
+ * (Claude Code, OpenCode, Antigravity, …). One row = one logical skill;
+ * the system badges show which harnesses share it, and a "divergent"
+ * badge flags same-name skills whose content has drifted apart.
+ */
+export function SkillsRoute() {
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    startSkillsPolling(30000);
+    return () => stopSkillsPolling();
+  }, []);
+
+  function onRowClick(s: SkillRecord) {
+    selectSkill(s);
+    if (isMobile) sheetOpen.value = 'skill-detail';
+  }
+
+  const list = filteredSkills.value;
+  const hasFilter = !!(skillsFilter.value || skillsSystemFacet.value || skillsScopeFacet.value);
+
+  return (
+    <div class="route route-skills">
+      <header class="route-header">
+        <div>
+          <h1 class="route-title">Skills</h1>
+          <p class="route-subtitle muted">
+            Agent capabilities discovered across every harness — {skills.value.length} skills
+            from {skillSystems.value.length || '…'} system{skillSystems.value.length === 1 ? '' : 's'}.
+          </p>
+        </div>
+      </header>
+
+      <div class="skl-layout">
+        <div class="skl-master">
+          <SkillsToolbar />
+          {list.length === 0 ? (
+            <EmptyState
+              icon={<Icon name="skills" size={24} />}
+              title={hasFilter ? 'No matches' : 'No skills found'}
+              description={
+                hasFilter
+                  ? 'Try clearing the filter.'
+                  : 'Skills are SKILL.md folders under .claude/skills/, ~/.config/opencode/skills/, and similar harness directories.'
+              }
+            />
+          ) : (
+            <SkillsList list={list} onRowClick={onRowClick} />
+          )}
+        </div>
+        {!isMobile && (
+          <div class="skl-detail-pane">
+            <SkillDetail />
+          </div>
+        )}
+      </div>
+
+      <BottomSheet
+        open={isMobile && sheetOpen.value === 'skill-detail'}
+        onClose={() => {
+          sheetOpen.value = null;
+          selectSkill(null);
+        }}
+        initialSnap="full"
+      >
+        <SkillDetail />
+      </BottomSheet>
+    </div>
+  );
+}
+
+function SkillsToolbar() {
+  const systems = skillSystems.value;
+  const scopes = skillScopes.value;
+  // Debounced draft — same discipline as MemoryToolbar: fast typing must
+  // not re-run the substring filter on every keystroke.
+  const [draft, setDraft] = useState(skillsFilter.value);
+  useEffect(() => {
+    if (draft === skillsFilter.value) return;
+    const id = window.setTimeout(() => {
+      skillsFilter.value = draft;
+    }, 120);
+    return () => window.clearTimeout(id);
+  }, [draft]);
+  useEffect(() => {
+    if (skillsFilter.value !== draft) setDraft(skillsFilter.value);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [skillsFilter.value]);
+
+  return (
+    <div class="skl-toolbar">
+      <Input
+        fullWidth
+        placeholder="Search name, description, or system…"
+        value={draft}
+        onInput={(e) => setDraft((e.target as HTMLInputElement).value)}
+        aria-label="Filter skills"
+      />
+      <div class="skl-facet-row" role="tablist" aria-label="System facets">
+        <button
+          class={`skl-facet ${skillsSystemFacet.value == null ? 'skl-facet-active' : ''}`}
+          onClick={() => (skillsSystemFacet.value = null)}
+        >
+          All systems
+        </button>
+        {systems.map((s) => (
+          <button
+            key={s}
+            class={`skl-facet ${skillsSystemFacet.value === s ? 'skl-facet-active' : ''}`}
+            onClick={() => (skillsSystemFacet.value = skillsSystemFacet.value === s ? null : s)}
+          >
+            {s}
+          </button>
+        ))}
+        {scopes.length > 1 && (
+          <span class="skl-facet-sep" aria-hidden="true" />
+        )}
+        {scopes.length > 1 && scopes.map((s) => (
+          <button
+            key={`scope-${s}`}
+            class={`skl-facet ${skillsScopeFacet.value === s ? 'skl-facet-active' : ''}`}
+            onClick={() => (skillsScopeFacet.value = skillsScopeFacet.value === s ? null : s)}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SkillsList({ list, onRowClick }: { list: SkillRecord[]; onRowClick: (s: SkillRecord) => void }) {
+  const divergent = divergentNames.value;
+  return (
+    <ul class="skl-list" role="list">
+      {list.map((s) => {
+        const active =
+          selectedSkill.value?.name === s.name &&
+          selectedSkill.value?.fingerprint === s.fingerprint;
+        return (
+          <li key={`${s.name}:${s.fingerprint}`}>
+            <button class={`skl-row ${active ? 'skl-row-active' : ''}`} onClick={() => onRowClick(s)}>
+              <div class="skl-row-head">
+                <span class="skl-row-name mono">/{s.name}</span>
+                <Pill tone="neutral" mono>{s.scope}</Pill>
+                {divergent.has(s.name) && (
+                  <Pill tone="warn" mono title="Same skill name has different content in different systems">
+                    divergent
+                  </Pill>
+                )}
+              </div>
+              <div class="skl-row-desc muted">
+                {s.description || <em>No description</em>}
+              </div>
+              <div class="skl-row-systems">
+                {s.systems.map((sys) => (
+                  <span class="skl-system" key={sys}>{sys}</span>
+                ))}
+                {s.user_invocable && <span class="skl-invocable muted">user-invocable</span>}
+              </div>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function SkillDetail() {
+  const s = selectedSkill.value;
+  if (!s) {
+    return (
+      <EmptyState
+        icon={<Icon name="skills" size={24} />}
+        title="Select a skill"
+        description="Pick a skill from the list to see its full definition, metadata, and every harness location it was discovered in."
+      />
+    );
+  }
+  return (
+    <article class="skl-detail">
+      <header class="skl-detail-header">
+        <div class="skl-detail-headline">
+          <span class="skl-detail-name mono">/{s.name}</span>
+          <Pill tone="neutral" mono>{s.scope}</Pill>
+          {s.user_invocable && <Pill tone="info" mono>user-invocable</Pill>}
+        </div>
+        {s.description && <p class="skl-detail-desc muted">{s.description}</p>}
+      </header>
+
+      <dl class="skl-meta">
+        <dt>Systems</dt>
+        <dd>
+          {s.systems.map((sys) => (
+            <span class="skl-system" key={sys}>{sys}</span>
+          ))}
+        </dd>
+        {s.allowed_tools.length > 0 && (
+          <>
+            <dt>Allowed tools</dt>
+            <dd class="mono">{s.allowed_tools.join(', ')}</dd>
+          </>
+        )}
+        {s.argument_hint && (
+          <>
+            <dt>Arguments</dt>
+            <dd class="mono">{s.argument_hint}</dd>
+          </>
+        )}
+        <dt>Updated</dt>
+        <dd>{s.updated_at ? new Date(s.updated_at * 1000).toLocaleString() : '—'}</dd>
+        <dt>Fingerprint</dt>
+        <dd class="mono">{s.fingerprint}</dd>
+      </dl>
+
+      <h3 class="skl-section-title">Sources</h3>
+      <ul class="skl-sources">
+        {s.sources.map((src) => (
+          <li key={src.path} class={src.shadowed ? 'skl-source-shadowed' : ''}>
+            <span class="skl-system">{src.system}</span>
+            <span class="mono skl-source-path" title={src.path}>{src.path}</span>
+            {src.shadowed && <span class="muted">(shadowed by {s.scope} scope)</span>}
+          </li>
+        ))}
+      </ul>
+
+      <h3 class="skl-section-title">Definition</h3>
+      <pre class="skl-body">{s.body || '(empty)'}</pre>
+    </article>
+  );
+}

--- a/charts/workspace/web/src/routes/skills/skills.css
+++ b/charts/workspace/web/src/routes/skills/skills.css
@@ -1,0 +1,151 @@
+/* Skills tab — mirrors the memory tab's master/detail conventions. */
+
+.skl-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr);
+  gap: var(--size-4);
+  align-items: start;
+}
+@media (max-width: 960px) {
+  .skl-layout { grid-template-columns: 1fr; }
+  .skl-detail-pane { display: none; }
+}
+.skl-master { min-width: 0; }
+.skl-detail-pane {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  overflow: auto;
+  min-height: 360px;
+  max-height: calc(100vh - 180px);
+}
+
+/* Toolbar */
+.skl-toolbar { display: flex; flex-direction: column; gap: var(--size-2); margin-bottom: var(--size-2); }
+.skl-facet-row { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
+.skl-facet {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  color: var(--text-muted);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  cursor: pointer;
+}
+.skl-facet:hover { background: var(--surface-3); color: var(--text); }
+.skl-facet-active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
+}
+.skl-facet-sep {
+  width: 1px;
+  height: 16px;
+  background: var(--border);
+  margin: 0 4px;
+}
+
+/* List rows */
+.skl-list { display: flex; flex-direction: column; gap: 6px; }
+.skl-row {
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 12px 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  text-align: left;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  cursor: pointer;
+  transition: background var(--motion-fast), border-color var(--motion-fast);
+}
+.skl-row:hover { background: var(--surface-2); border-color: var(--border-2); }
+.skl-row-active { border-color: var(--accent); background: var(--accent-soft); }
+
+.skl-row-head {
+  display: flex;
+  align-items: center;
+  gap: var(--size-2);
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.skl-row-name {
+  font-size: 12.5px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.skl-row-desc {
+  font-size: 12.5px;
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+.skl-row-systems { display: flex; gap: 4px; flex-wrap: wrap; align-items: center; min-width: 0; }
+.skl-invocable { font-size: 10.5px; }
+
+/* System badge — shared between rows, detail, and sources. */
+.skl-system {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  color: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 25%, var(--border));
+  white-space: nowrap;
+}
+
+/* Detail pane */
+.skl-detail { padding: var(--size-3) var(--size-4); display: flex; flex-direction: column; gap: var(--size-3); }
+.skl-detail-header { display: flex; flex-direction: column; gap: 6px; }
+.skl-detail-headline { display: flex; align-items: center; gap: var(--size-2); flex-wrap: wrap; }
+.skl-detail-name { font-size: 15px; font-weight: 650; }
+.skl-detail-desc { font-size: 13px; line-height: 1.5; margin: 0; }
+
+.skl-meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px 14px;
+  margin: 0;
+  font-size: 12.5px;
+}
+.skl-meta dt { color: var(--text-muted); font-weight: 500; }
+.skl-meta dd { margin: 0; min-width: 0; overflow-wrap: anywhere; display: flex; gap: 4px; flex-wrap: wrap; }
+
+.skl-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: var(--size-2) 0 0;
+}
+.skl-sources { display: flex; flex-direction: column; gap: 4px; margin: 0; padding: 0; list-style: none; }
+.skl-sources li { display: flex; gap: var(--size-2); align-items: baseline; font-size: 12px; min-width: 0; flex-wrap: wrap; }
+.skl-source-path { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%; color: var(--text-muted); }
+.skl-source-shadowed { opacity: 0.55; }
+
+.skl-body {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--size-3);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  margin: 0;
+  max-height: 480px;
+  overflow: auto;
+}

--- a/charts/workspace/web/src/store/router.ts
+++ b/charts/workspace/web/src/store/router.ts
@@ -69,6 +69,7 @@ export const ROUTES: RouteDef[] = [
   { path: '/hypervisor', title: 'Hypervisor' },
   { path: '/tasks', title: 'Build' },
   { path: '/memory', title: 'Memory' },
+  { path: '/skills', title: 'Skills' },
   { path: '/apps', title: 'Apps' },
   { path: '/triggers', title: 'Triggers' },
   { path: '/files', title: 'Files' },

--- a/charts/workspace/web/src/store/skills.ts
+++ b/charts/workspace/web/src/store/skills.ts
@@ -1,0 +1,149 @@
+import { signal, computed } from '@preact/signals';
+import {
+  subscribeEvents,
+  eventStreamConnected,
+  type DashboardEvent,
+} from '../api/events';
+import { listSkills, type SkillRecord } from '../api/skills';
+
+/**
+ * Skills store — mirrors store/memory.ts: signals + in-flight-deduped
+ * refresh, SSE-driven updates (`skills.changed`) with a slow polling
+ * safety net. Read-only in this phase, so no save/delete actions.
+ */
+
+export const skills = signal<SkillRecord[]>([]);
+export const skillsLoading = signal(false);
+export const skillsError = signal<string | null>(null);
+export const skillsFilter = signal('');
+export const skillsSystemFacet = signal<string | null>(null);
+export const skillsScopeFacet = signal<string | null>(null);
+
+export const selectedSkill = signal<SkillRecord | null>(null);
+
+export const skillSystems = computed(() => {
+  const set = new Set<string>();
+  for (const s of skills.value) for (const sys of s.systems) set.add(sys);
+  return [...set].sort();
+});
+
+export const skillScopes = computed(() => {
+  const set = new Set<string>();
+  for (const s of skills.value) set.add(s.scope);
+  return [...set].sort();
+});
+
+/** Names that appear more than once = divergent variants across systems. */
+export const divergentNames = computed(() => {
+  const seen = new Map<string, number>();
+  for (const s of skills.value) seen.set(s.name, (seen.get(s.name) ?? 0) + 1);
+  return new Set([...seen.entries()].filter(([, n]) => n > 1).map(([k]) => k));
+});
+
+export const filteredSkills = computed(() => {
+  const needle = skillsFilter.value.trim().toLowerCase();
+  const sys = skillsSystemFacet.value;
+  const scope = skillsScopeFacet.value;
+  return skills.value.filter((s) => {
+    if (sys && !s.systems.includes(sys)) return false;
+    if (scope && s.scope !== scope) return false;
+    if (!needle) return true;
+    const hay = `${s.name} ${s.description} ${s.systems.join(' ')}`.toLowerCase();
+    return hay.includes(needle);
+  });
+});
+
+export function selectSkill(s: SkillRecord | null) {
+  selectedSkill.value = s;
+}
+
+// Dedupe in-flight list fetches so the poll tick + an explicit refresh
+// can't race and clobber each other (the slower response would win).
+let _refreshInFlight: Promise<void> | null = null;
+export async function refreshSkills(): Promise<void> {
+  if (_refreshInFlight) return _refreshInFlight;
+  skillsLoading.value = true;
+  _refreshInFlight = (async () => {
+    try {
+      const r = await listSkills();
+      skills.value = r.skills;
+      skillsError.value = null;
+      // Keep the selected record fresh: re-point it at the new list row
+      // with the same identity, or clear it if the skill vanished.
+      const sel = selectedSkill.value;
+      if (sel) {
+        const next = r.skills.find(
+          (s) => s.name === sel.name && s.fingerprint === sel.fingerprint,
+        ) ?? r.skills.find((s) => s.name === sel.name) ?? null;
+        selectedSkill.value = next;
+      }
+    } catch (err) {
+      skillsError.value = err instanceof Error ? err.message : String(err);
+    } finally {
+      skillsLoading.value = false;
+      _refreshInFlight = null;
+    }
+  })();
+  return _refreshInFlight;
+}
+
+// Real-time via the /api/events SSE stream: a `skills.changed` event
+// (published by the backend SkillsSyncer when files change on disk in ANY
+// harness) refreshes the list immediately. The interval is a safety net
+// that polls normally when the stream is down and slows to a heartbeat
+// when it's up — same discipline as store/memory.ts.
+let pollHandle: ReturnType<typeof setInterval> | null = null;
+let visibilityHandler: (() => void) | null = null;
+let eventUnsub: (() => void) | null = null;
+let eventRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+let lastRefreshAt = 0;
+const FALLBACK_REFRESH_MS = 45000;
+
+function doRefresh() {
+  lastRefreshAt = Date.now();
+  void refreshSkills();
+}
+
+function onSkillsEvent(ev: DashboardEvent) {
+  if (ev.type !== 'skills.changed') return;
+  if (eventRefreshTimer != null) return; // coalesce bursts
+  eventRefreshTimer = setTimeout(() => {
+    eventRefreshTimer = null;
+    doRefresh();
+  }, 250);
+}
+
+export function startSkillsPolling(intervalMs = 30000) {
+  doRefresh();
+  if (!eventUnsub) eventUnsub = subscribeEvents(onSkillsEvent);
+  if (pollHandle) clearInterval(pollHandle);
+  pollHandle = setInterval(() => {
+    if (typeof document !== 'undefined' && document.hidden) return;
+    if (eventStreamConnected.value && Date.now() - lastRefreshAt < FALLBACK_REFRESH_MS) return;
+    doRefresh();
+  }, intervalMs);
+  if (typeof document !== 'undefined') {
+    if (visibilityHandler) document.removeEventListener('visibilitychange', visibilityHandler);
+    visibilityHandler = () => {
+      if (!document.hidden) doRefresh();
+    };
+    document.addEventListener('visibilitychange', visibilityHandler);
+  }
+}
+
+export function stopSkillsPolling() {
+  if (pollHandle) clearInterval(pollHandle);
+  pollHandle = null;
+  if (eventUnsub) {
+    eventUnsub();
+    eventUnsub = null;
+  }
+  if (eventRefreshTimer != null) {
+    clearTimeout(eventRefreshTimer);
+    eventRefreshTimer = null;
+  }
+  if (visibilityHandler && typeof document !== 'undefined') {
+    document.removeEventListener('visibilitychange', visibilityHandler);
+    visibilityHandler = null;
+  }
+}

--- a/charts/workspace/web/src/store/ui.ts
+++ b/charts/workspace/web/src/store/ui.ts
@@ -59,7 +59,7 @@ export const sheetOpen = signal<SheetKey | null>(null);
 export const paletteOpen = signal(false);
 
 export type DrawerKey = 'settings' | 'files' | 'github' | 'metrics' | 'new-task' | 'memory-edit' | 'trigger-edit' | 'desktop-edit';
-export type SheetKey = 'task-detail' | 'memory-detail' | 'trigger-detail' | 'new-task' | 'more';
+export type SheetKey = 'task-detail' | 'memory-detail' | 'skill-detail' | 'trigger-detail' | 'new-task' | 'more';
 
 export interface Toast {
   id: string;

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -23,6 +23,7 @@ import AppViewScreen from './src/screens/AppViewScreen';
 import DesktopScreen from './src/screens/DesktopScreen';
 import HypervisorScreen from './src/screens/HypervisorScreen';
 import MemoryScreen from './src/screens/MemoryScreen';
+import SkillsScreen from './src/screens/SkillsScreen';
 import MetricsScreen from './src/screens/MetricsScreen';
 import SettingsScreen from './src/screens/SettingsScreen';
 import ControllerScreen from './src/screens/ControllerScreen';
@@ -125,6 +126,7 @@ function MainTabs() {
         <Tab.Screen name="Tasks" component={TasksStack} />
         <Tab.Screen name="Apps" component={AppsStack} />
         <Tab.Screen name="Memory" component={MemoryScreen} />
+        <Tab.Screen name="Skills" component={SkillsScreen} />
         <Tab.Screen name="Metrics" component={MetricsScreen} />
         {showController && <Tab.Screen name="Controller" component={ControllerScreen} />}
         <Tab.Screen name="Settings" component={SettingsScreen} />

--- a/mobile/scripts/check-nav.mjs
+++ b/mobile/scripts/check-nav.mjs
@@ -135,7 +135,7 @@ async function openDrawerAndGo(page, item) {
 // ---------- Path D: drawer to every top-level screen, then nested details
 {
   const page = await freshPage();
-  for (const item of ['Builds', 'Apps', 'Memory', 'Metrics', 'Controller', 'Settings', 'Desktop']) {
+  for (const item of ['Builds', 'Apps', 'Memory', 'Skills', 'Metrics', 'Controller', 'Settings', 'Desktop']) {
     await openDrawerAndGo(page, item);
     await assertEscape(page, `Top-level: ${item}`, `05-top-${item.toLowerCase()}.png`);
   }

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -20,6 +20,7 @@ import {
   mockHealth,
   mockMemory,
   mockMetrics,
+  mockSkills,
   mockTaskDetail,
   mockTasks,
 } from '../mock/mockData';
@@ -34,6 +35,7 @@ import type {
   LaunchResult,
   MemoryRecord,
   Metrics,
+  SkillRecord,
   TaskDetail,
   TaskSummary,
 } from './types';
@@ -387,6 +389,33 @@ function normalizeMemory(m: RawMemory): MemoryRecord {
         ? m.tags.split(',').map((s) => s.trim()).filter(Boolean)
         : [];
   return { ...m, tags };
+}
+
+// ---- Skills ------------------------------------------------------------------
+
+/** Multi-harness skills (issue #187): normalized SKILL.md records discovered
+ *  from every agent harness (Claude Code, OpenCode, …) by the backend. */
+export async function listSkills(): Promise<SkillRecord[]> {
+  if (getConfig().mock) {
+    await delay(120);
+    return [...mockSkills];
+  }
+  const data = await request<{ skills?: RawSkill[] } | RawSkill[]>('/api/skills');
+  const recs = Array.isArray(data) ? data : data.skills ?? [];
+  return recs.map(normalizeSkill);
+}
+
+type RawSkill = Omit<SkillRecord, 'systems' | 'allowed_tools'> & {
+  systems?: unknown;
+  allowed_tools?: unknown;
+};
+
+function normalizeSkill(s: RawSkill): SkillRecord {
+  return {
+    ...s,
+    systems: Array.isArray(s.systems) ? (s.systems as string[]) : [],
+    allowed_tools: Array.isArray(s.allowed_tools) ? (s.allowed_tools as string[]) : [],
+  };
 }
 
 // ---- Desktop launcher --------------------------------------------------------

--- a/mobile/src/api/types.ts
+++ b/mobile/src/api/types.ts
@@ -25,6 +25,20 @@ export interface MemoryRecord {
   updated_at?: number;
 }
 
+/** A normalized agent skill discovered from any harness (issue #187).
+ *  `systems` lists every harness (claude/opencode/…) sharing this content. */
+export interface SkillRecord {
+  name: string;
+  description: string;
+  body?: string;
+  scope: string; // project | user | plugin
+  systems: string[];
+  user_invocable?: boolean;
+  allowed_tools?: string[];
+  argument_hint?: string;
+  updated_at?: number;
+}
+
 export interface Metrics {
   cpu_percent: number;
   memory_used_mb: number;

--- a/mobile/src/components/NavDrawer.tsx
+++ b/mobile/src/components/NavDrawer.tsx
@@ -20,6 +20,7 @@ const ITEMS: Item[] = [
   { name: 'Tasks', label: 'Builds', icon: 'layers-outline' },
   { name: 'Apps', label: 'Apps', icon: 'globe-outline' },
   { name: 'Memory', label: 'Memory', icon: 'bookmark-outline' },
+  { name: 'Skills', label: 'Skills', icon: 'sparkles-outline' },
   { name: 'Metrics', label: 'Metrics', icon: 'stats-chart-outline' },
   { name: 'Controller', label: 'Controller', icon: 'server-outline', controller: true },
   { name: 'Settings', label: 'Settings', icon: 'settings-outline' },

--- a/mobile/src/mock/mockData.ts
+++ b/mobile/src/mock/mockData.ts
@@ -14,6 +14,7 @@ import type {
   Health,
   MemoryRecord,
   Metrics,
+  SkillRecord,
   TaskDetail,
   TaskSummary,
 } from '../api/types';
@@ -166,6 +167,39 @@ export const mockMemory: MemoryRecord[] = [
     tags: ['mobile', 'ci'],
     importance: 0.85,
     updated_at: NOW - 3600,
+  },
+];
+
+export const mockSkills: SkillRecord[] = [
+  {
+    name: 'remote-task',
+    description: 'Launch a Claude task on a remote kube-coder workspace, check status, or attach.',
+    body: '# Remote Task Skill\n\nLaunch tasks on remote workspace pods.',
+    scope: 'project',
+    systems: ['claude', 'opencode', 'ante'],
+    user_invocable: true,
+    allowed_tools: ['Bash', 'Read', 'Grep'],
+    argument_hint: '[prompt or "status"]',
+    updated_at: NOW - 7200,
+  },
+  {
+    name: 'code-review',
+    description: 'Review the current diff for correctness bugs and cleanups.',
+    body: '# Code Review\n\nRuns a structured review over the working diff.',
+    scope: 'user',
+    systems: ['claude'],
+    user_invocable: true,
+    allowed_tools: ['Bash', 'Read'],
+    updated_at: NOW - 86400,
+  },
+  {
+    name: 'deploy-prod',
+    description: 'Guarded production deploy runbook.',
+    body: 'Run make ship, verify rollout, watch alerts for 10 minutes.',
+    scope: 'user',
+    systems: ['opencode'],
+    user_invocable: false,
+    updated_at: NOW - 43200,
   },
 ];
 

--- a/mobile/src/screens/SkillsScreen.tsx
+++ b/mobile/src/screens/SkillsScreen.tsx
@@ -1,0 +1,212 @@
+/** Multi-harness skills browser (read-only) — searchable, expandable rows.
+ *  Shows every SKILL.md-defined capability discovered across the workspace's
+ *  agent harnesses (Claude Code, OpenCode, …) with per-system badges. */
+import { Ionicons } from '@expo/vector-icons';
+import React, { useCallback, useMemo, useState } from 'react';
+import { FlatList, Pressable, RefreshControl, StyleSheet, Text, TextInput, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useFocusEffect } from '@react-navigation/native';
+import { listSkills } from '../api/client';
+import { EmptyState, ErrorBanner, Loading, ScreenHeader } from '../components/ui';
+import type { SkillRecord } from '../api/types';
+import { colors, font, radius, space } from '../theme';
+
+const rowKey = (s: SkillRecord) => `${s.name}:${s.systems.join(',')}`;
+
+export default function SkillsScreen() {
+  const [items, setItems] = useState<SkillRecord[] | null>(null);
+  const [query, setQuery] = useState('');
+  const [openKey, setOpenKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setItems(await listSkills());
+      setError(null);
+    } catch (e) {
+      // A failed load must not masquerade as "no skills".
+      setError((e as Error).message);
+      setItems((prev) => prev ?? []);
+    }
+  }, []);
+
+  // Skills change when files change on disk; refetch on tab focus.
+  useFocusEffect(
+    useCallback(() => {
+      void load();
+    }, [load]),
+  );
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    await load();
+    setRefreshing(false);
+  };
+
+  const filtered = useMemo(() => {
+    if (!items) return null;
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((s) =>
+      `${s.name} ${s.description} ${s.systems.join(' ')} ${s.scope}`.toLowerCase().includes(q),
+    );
+  }, [items, query]);
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      <ScreenHeader title="Skills" subtitle="Agent capabilities across every harness" />
+
+      {items !== null && items.length > 0 ? (
+        <View style={styles.searchWrap}>
+          <Ionicons name="search" size={16} color={colors.textFaint} />
+          <TextInput
+            value={query}
+            onChangeText={setQuery}
+            placeholder="Search skills…"
+            placeholderTextColor={colors.textFaint}
+            autoCapitalize="none"
+            autoCorrect={false}
+            style={styles.search}
+          />
+          {query ? (
+            <Pressable onPress={() => setQuery('')} hitSlop={10}>
+              <Ionicons name="close-circle" size={16} color={colors.textFaint} />
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+
+      {error && items !== null && items.length > 0 ? <ErrorBanner message={error} /> : null}
+
+      {filtered === null ? (
+        <Loading label="Loading skills…" />
+      ) : items && items.length === 0 ? (
+        error ? (
+          <EmptyState icon="cloud-offline-outline" title="Couldn't load skills" subtitle={error} />
+        ) : (
+          <EmptyState
+            icon="sparkles-outline"
+            title="No skills found"
+            subtitle="Skills are SKILL.md folders under .claude/skills/ and other harness directories."
+          />
+        )
+      ) : filtered.length === 0 ? (
+        <EmptyState icon="search-outline" title="No matches" subtitle={`Nothing matches “${query.trim()}”.`} />
+      ) : (
+        <FlatList
+          data={filtered}
+          keyExtractor={rowKey}
+          contentContainerStyle={styles.list}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.accent} />
+          }
+          ListHeaderComponent={
+            <Text style={styles.count}>
+              {filtered.length} {filtered.length === 1 ? 'skill' : 'skills'}
+            </Text>
+          }
+          renderItem={({ item }) => {
+            const open = openKey === rowKey(item);
+            return (
+              <Pressable style={styles.row} onPress={() => setOpenKey(open ? null : rowKey(item))}>
+                <View style={styles.rowTop}>
+                  <Text style={styles.name} numberOfLines={1}>
+                    /{item.name}
+                    <Text style={styles.scope}>  {item.scope}</Text>
+                  </Text>
+                  <Ionicons
+                    name={open ? 'chevron-up' : 'chevron-down'}
+                    size={14}
+                    color={colors.textFaint}
+                  />
+                </View>
+                <Text style={[styles.desc, open && styles.descOpen]} numberOfLines={open ? undefined : 2}>
+                  {item.description || 'No description'}
+                </Text>
+                <View style={styles.badges}>
+                  {item.systems.map((sys) => (
+                    <View key={sys} style={styles.badge}>
+                      <Text style={styles.badgeText}>{sys}</Text>
+                    </View>
+                  ))}
+                  {item.user_invocable ? (
+                    <Text style={styles.invocable}>user-invocable</Text>
+                  ) : null}
+                </View>
+                {open && item.body ? (
+                  <Text style={styles.body}>{item.body}</Text>
+                ) : null}
+                {open && item.allowed_tools && item.allowed_tools.length > 0 ? (
+                  <Text style={styles.tools}>Tools: {item.allowed_tools.join(', ')}</Text>
+                ) : null}
+              </Pressable>
+            );
+          }}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: colors.bg },
+  searchWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: space.sm,
+    marginHorizontal: space.lg,
+    marginBottom: space.sm,
+    paddingHorizontal: space.md,
+    height: 40,
+    backgroundColor: colors.bgElevated,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  search: { flex: 1, color: colors.text, fontSize: font.size.md, padding: 0 },
+  list: { paddingBottom: space.xl },
+  count: {
+    color: colors.textFaint,
+    fontSize: font.size.xs,
+    paddingHorizontal: space.lg,
+    paddingBottom: space.sm,
+  },
+  row: {
+    paddingHorizontal: space.lg,
+    paddingVertical: space.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    gap: 4,
+  },
+  rowTop: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: space.sm },
+  name: { flex: 1, color: colors.accent, fontSize: font.size.sm, fontWeight: '700', fontFamily: font.mono },
+  scope: { color: colors.textFaint, fontWeight: '400', fontSize: font.size.xs },
+  desc: { color: colors.textMuted, fontSize: font.size.sm, lineHeight: 19 },
+  descOpen: { color: colors.text },
+  badges: { flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', gap: 6, marginTop: 4 },
+  badge: {
+    backgroundColor: colors.bgElevated,
+    borderRadius: radius.sm,
+    paddingHorizontal: space.sm,
+    paddingVertical: 3,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  badgeText: { color: colors.accent, fontSize: font.size.xs, fontFamily: font.mono },
+  invocable: { color: colors.textFaint, fontSize: font.size.xs },
+  body: {
+    color: colors.textMuted,
+    fontSize: font.size.xs,
+    fontFamily: font.mono,
+    lineHeight: 17,
+    marginTop: 6,
+    padding: space.md,
+    backgroundColor: colors.bgElevated,
+    borderRadius: radius.sm,
+  },
+  tools: { color: colors.textFaint, fontSize: font.size.xs, marginTop: 4 },
+});


### PR DESCRIPTION
# feat(dashboard): Skills tab — multi-harness SKILL.md surface (#187) — **PR 1 of 2**

Closes the read path of #187. This is **PR 1 (read-only surface + discovery)**; the cross-tool sync/write path lands in **PR 2** (scoped at the bottom).

## What this adds

A new **Skills** tab (desktop + mobile) that surfaces the `SKILL.md`-defined agent capabilities present in the workspace — **across every CLI harness**, not just Claude Code. Skills are discovered from disk, normalized into one tool-agnostic shape, deduped across harnesses by content fingerprint, and kept live as files change.

- The **same skill** shared by several harnesses (identical content) collapses into **one row** whose badges show every system it lives in (`claude` · `opencode` · `ante`).
- The **same name with different content** shows as separate **divergent** variants (amber badge), so drift is visible.
- Zero hardcoded data — the list is built entirely by parsing real files on disk.

### The design decision that matters: one provider per harness
Every harness-specific detail (paths, format) is isolated in a single provider class. The rest of the stack — syncer, dedupe, API, web, mobile — only ever sees the normalized `SkillRecord`. **Adding a harness = one new provider file + one registry line.** (This is why Ante was added in ~70 lines with no changes anywhere else, and why it composes cleanly with the Hypervisor's parallel per-CLI-adapter design.)

## Backend changes

**New package `charts/workspace/skills/`**
| File | Responsibility |
|---|---|
| `model.py` | `SkillRecord` dataclass; `fingerprint()` (whitespace-normalized SHA-256 of the body); `merge()` — cross-system collapse, divergent split, `project > user > plugin` scope shadowing; `SKILL_NAME_RE` path-safety gate |
| `parser.py` | Dependency-free, tolerant frontmatter parser (no-frontmatter files still parse as all-body) |
| `providers/__init__.py` | `SkillProvider` base (default `<root>/<name>/SKILL.md` scan) + `PROVIDERS` registry |
| `providers/claude.py` | project `.claude/skills/`, user `~/.claude/skills/`, plugin marketplaces glob — multi-home like `memory/sync.py` |
| `providers/opencode.py` | `~/.config/opencode/skills/` + project `.opencode/skills/` + legacy `command/*.md` |
| `providers/ante.py` | `~/.ante/skills/` (Ante's confirmed config home — start.sh already seeds `~/.ante/settings.json`) |
| `providers/antigravity.py` | disabled stub (`KC_SKILLS_ANTIGRAVITY=1` to enable once paths are runtime-verified) |
| `sync.py` | `SkillsSyncer` — background poller (mtime fingerprint → parse only on change), in-memory snapshot under a lock, publishes one aggregate `skills.changed` on the `EventBroker` |

**`server.py`** — thin handlers over the syncer snapshot, all behind `check_claude_auth()`:
- `GET /api/skills` (`?system=&scope=&refresh=1`), `GET /api/skills/{name}` (returns divergent `variants`), `GET /api/skills/stats`, `POST /api/skills/_scan` (forced rescan; behind the `do_POST` `_readonly_block()` chokepoint).
- `_SKILLS_AVAILABLE` import guard + 503 fallback, mirroring the memory subsystem. Syncer started at boot next to `ClaudeMemorySyncer`.

**Deployment** — `browser-configmap.yaml` ships the package as flat keys; `start.sh` reassembles them into `/tmp/browser/skills/` (same convention as the `memory` package).

## Frontend changes

**Web** — `api/skills.ts`, `store/skills.ts` (in-flight-deduped refresh, SSE `skills.changed` + 30 s poll fallback that idles when the stream is live), `routes/skills/` (grouped list with system badges, scope chips, divergence warnings; detail = frontmatter table + source paths + rendered body). Nav wired into `router.ts`, `Shell.tsx`, `Rail.tsx`, `BottomNav.tsx`, plus a new `skills` icon in `Icon.tsx`.

**Mobile** — read-only `SkillsScreen.tsx` (system badges, pull-to-refresh), `listSkills()` client, `SkillRecord` type, drawer + tab entry, mock data for the demo build.

## Acceptance criteria — all met

- [x] **Skills tab in desktop rail + mobile nav, behind auth** — handlers gated by `check_claude_auth()`, same as every tab.
- [x] **Lists every skill from project + user + plugin roots** with name, description, scope, and an invocable indicator; **detail renders the SKILL.md body**.
- [x] **On-disk edit/add/remove reflected within the sync window** (SSE `skills.changed`, else ≤30 s poll) with no manual refresh.
- [x] **Read-only demo hides write affordances** — PR1 has none to leak; the one POST (`/_scan`) is behind `_readonly_block()`; GET reads are allowed in demo like the Memory tab. (`MutatorOnly` becomes load-bearing in PR2's Sync button.)
- [x] **Mobile shows the same list, read-only.**
- [x] **`tsc` + `vitest` green** (web tsc clean, vitest 181/181, mobile tsc clean); **new `api/skills.test.ts`** covers the client (9 cases: list/get/stats/scan, filters, coercion, divergent variants).

Backend: 52 `unittest` cases in `tests/skills_test.py` + `tests/skills_sync_test.py` (parser, fingerprint, merge/shadowing, per-provider scans, syncer mtime-skip + single-event-per-change + double-start guard).

## What's intentionally left for PR 2 (the write path)

- **Cross-tool sync engine** — `render()` + `install()` on each provider, and `POST /api/skills/{name}/sync` with `{source_system, targets:[…]}` so a skill authored once is translated/installed into another harness's directory (any-to-any; kube-coder is the hub, no harness privileged).
- **Write-path safety rails** — name gate before any path build, `realpath` containment assertion, atomic temp-file+rename, `409` on overwriting a divergent target unless `force`, disabled-provider target rejection.
- **Web "Sync to…" affordance** wrapped in `<MutatorOnly>` (hidden in read-only demo).
- Runtime verification of OpenCode/Antigravity exact paths on a live pod (isolated to each provider's `scan_roots()`).

## Notes
- Rebased cleanly onto `v1.20.2`; composes with the new Hypervisor tab (disjoint routes/events/packages — the only overlap was parallel nav-list entries, all kept).
- Antigravity ships disabled by default; Ante enabled (its home dir always exists on a pod, and scanning a not-yet-created `skills/` dir is a no-op).


---

## Screenshots

### Desktop — Skills tab (list)
The tab sits in the rail beside the new **Hypervisor** tab (they coexist cleanly). Header reads *"6 skills from 3 systems."* `/remote-task` collapses **claude + opencode + ante** into one row; `/data-export` appears as two **divergent** variants (Parquet vs CSV).
![Skills list](https://raw.githubusercontent.com/DevolRaman750/kube-coder/feat/issue-187-skills/docs/screenshots/skills-screenshots/01-skills-list-desktop.png)

### Detail — cross-harness collapse
`/remote-task` detail: systems, allowed-tools, arguments, updated time, content fingerprint, **all three source file paths** (proving the 3-way collapse), and the rendered `SKILL.md` body.
![Skills detail](https://raw.githubusercontent.com/DevolRaman750/kube-coder/feat/issue-187-skills/docs/screenshots/skills-screenshots/02-detail-remote-task-3systems.png)

### Divergent variant
Same name, different content across harnesses → surfaced as separate variants with a `divergent` badge.
![Divergent](https://raw.githubusercontent.com/DevolRaman750/kube-coder/feat/issue-187-skills/docs/screenshots/skills-screenshots/03-detail-divergent-data-export.png)

### System-facet filter + search
Filter by harness (`ante`) and free-text search.
![Filter by ante](https://raw.githubusercontent.com/DevolRaman750/kube-coder/feat/issue-187-skills/docs/screenshots/skills-screenshots/04-filter-by-ante.png)
![Search](https://raw.githubusercontent.com/DevolRaman750/kube-coder/feat/issue-187-skills/docs/screenshots/skills-screenshots/05-search-deploy.png)

### Mobile — real Expo React-Native app (read-only)
The native `SkillsScreen` in dark mode, reached via the hamburger drawer, with per-system badges and the `user-invocable` indicator.
![Mobile app Skills](https://raw.githubusercontent.com/DevolRaman750/kube-coder/feat/issue-187-skills/docs/screenshots/skills-screenshots/08-mobile-app-skills-list.png)

<details><summary>Responsive web at phone width (bottom-nav → “More”)</summary>

![Mobile-width list](https://raw.githubusercontent.com/DevolRaman750/kube-coder/feat/issue-187-skills/docs/screenshots/skills-screenshots/06-skills-mobile-width.png)
![Mobile-width detail](https://raw.githubusercontent.com/DevolRaman750/kube-coder/feat/issue-187-skills/docs/screenshots/skills-screenshots/07-skills-mobile-detail.png)

</details>
