### PR TITLE
feat(hypervisor): add Codex (OpenAI) as a first-class assistant

### DIFF
--- a/charts/workspace/hypervisor_session.py
+++ b/charts/workspace/hypervisor_session.py
@@ -485,10 +485,88 @@ class OpencodeAdapter(_StructuredCliAdapter):
         return []
 
 
+class CodexAdapter(_StructuredCliAdapter):
+    """`codex exec --json` (headless); multi-turn via `codex exec resume <id>`.
+
+    Codex (OpenAI) emits JSONL, captured empirically:
+      {"type":"thread.started","thread_id":"<uuid>"}   → session id (for resume)
+      {"type":"turn.started"} / {"type":"item.started",...}   → in-progress noise
+      {"type":"item.completed","item":{"id":..,"type":"<t>",..}}   → the payload
+      {"type":"turn.completed"|"turn.failed",...}      → turn outcome
+    Transient top-level {"type":"error","message":"Reconnecting..."} lines are
+    connection-retry notices, NOT turn outcomes — only `turn.failed` is terminal,
+    so we deliberately drop the top-level error chatter.
+
+    Auth is ChatGPT OAuth (`codex login` once in the pod; creds under $CODEX_HOME
+    which start.sh persists on the PVC) — no API key. The pod is externally
+    sandboxed (k8s), so we pass --dangerously-bypass-approvals-and-sandbox (its
+    documented use is exactly an externally-sandboxed environment).
+
+    NOTE: item rendering is intentionally minimal (agent message + error) pending
+    an in-pod capture of the full item.type vocabulary (reasoning / command /
+    file-change items) — same empirical-refinement path ante/opencode took.
+    """
+
+    kind = 'codex'
+    # Shared exec options for both the first turn and a resume.
+    def _opts(self, ctx):
+        opts = ['--json', '--skip-git-repo-check',
+                '--dangerously-bypass-approvals-and-sandbox',
+                '-C', ctx.get('workdir') or WORKSPACE_HOME]
+        model = os.environ.get('KC_CODEX_MODEL', '')
+        if model:
+            opts += ['--model', model]
+        return opts
+
+    def build(self, ctx, text, first):
+        self._reset_turn(ctx)
+        sid = ctx.get('codex_session_id')
+        if sid:
+            argv = ['codex', 'exec', 'resume', *self._opts(ctx), sid, text]
+        else:
+            prompt = (ctx['preamble'] + '\n\n' + text) \
+                if (first and ctx.get('preamble')) else text
+            argv = ['codex', 'exec', *self._opts(ctx), prompt]
+        return {'argv': argv, 'cwd': ctx.get('workdir') or WORKSPACE_HOME}
+
+    def _parse_obj(self, ctx, o):
+        t = str(o.get('type') or '')
+        if t == 'thread.started':
+            tid = o.get('thread_id')
+            if isinstance(tid, str):
+                ctx['codex_session_id'] = tid
+            return []
+        if t == 'turn.failed':
+            err = o.get('error') if isinstance(o.get('error'), dict) else {}
+            ctx['_emitted'] = True
+            return [{'role': 'system', 'type': 'error',
+                     'text': err.get('message') or _stringify(o.get('error'))
+                             or 'codex turn failed'}]
+        if t == 'item.completed':
+            item = o.get('item') if isinstance(o.get('item'), dict) else {}
+            it = str(item.get('type') or '')
+            if 'error' in it:
+                ctx['_emitted'] = True
+                return [{'role': 'system', 'type': 'error',
+                         'text': _lift_text(item) or item.get('message')
+                                 or 'codex error'}]
+            # The agent's chat message (agent_message / assistant_message /
+            # message / text). Internal-step items (reasoning, command_execution,
+            # file_change, …) carry no such marker and are skipped for now.
+            if any(s in it for s in ('message', 'text', 'agent', 'assistant')):
+                txt = _lift_text(item)
+                if txt:
+                    ctx['_emitted'] = True
+                    return [{'role': 'assistant', 'type': 'message', 'text': txt}]
+            return []
+        return []  # turn.started / item.started / turn.completed / retry chatter
+
+
 _ADAPTERS: Dict[str, Adapter] = {
     'claude': ClaudeAdapter(),
     'ante': AnteAdapter(),
     'opencode': OpencodeAdapter(),
+    'codex': CodexAdapter(),
     'fallback': FallbackAdapter(),
 }
 
@@ -498,6 +576,8 @@ def _adapter_for(assistant: str) -> Adapter:
         return _ADAPTERS['claude']
     if assistant == 'ante':
         return _ADAPTERS['ante']
+    if assistant == 'codex':
+        return _ADAPTERS['codex']
     if assistant.startswith('opencode'):
         return _ADAPTERS['opencode']
     return _ADAPTERS['fallback']

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -617,6 +617,13 @@ class ClaudeTaskManager:
             'id': 'antigravity',
             'label': 'Antigravity',
         },
+        # Codex — OpenAI's `codex` CLI, pre-installed in the image. ChatGPT
+        # OAuth login (no API key: `codex login` once in the pod), so it's
+        # listed whenever its binary is resolvable — same signal as Antigravity.
+        'codex': {
+            'id': 'codex',
+            'label': 'Codex',
+        },
         # LibreFang — open-source agent OS (https://librefang.ai). Tasks talk
         # to its registry-bundled "coder" agent via `librefang chat`; the CLI
         # picks up whatever provider key is in the environment
@@ -653,6 +660,15 @@ class ClaudeTaskManager:
             out.append(dict(
                 ClaudeTaskManager.ASSISTANTS['antigravity'],
                 model=os.environ.get('KC_ANTIGRAVITY_MODEL', ''),
+            ))
+        # Codex — listed only when its CLI is resolvable (older images predate
+        # it). Auth is ChatGPT OAuth (`codex login` once in the pod), so binary
+        # presence is the right signal — same as Antigravity. Optional model via
+        # KC_CODEX_MODEL (codex picks its own default otherwise).
+        if shutil.which('codex'):
+            out.append(dict(
+                ClaudeTaskManager.ASSISTANTS['codex'],
+                model=os.environ.get('KC_CODEX_MODEL', ''),
             ))
         # LibreFang — listed only when its CLI is actually resolvable (older
         # images predate it, and /usr/local/bin/librefang is a symlink to a
@@ -709,6 +725,16 @@ class ClaudeTaskManager:
             skip = '--dangerously-skip-permissions ' if auto_approve else ''
             model_flag = f'--model {_shell_quote(model)}' if model else ''
             return f'agy {skip}{model_flag}'.strip()
+        if assistant == 'codex':
+            # Interactive Codex TUI for the dashboard pane. Optional model via
+            # KC_CODEX_MODEL (codex picks its own default otherwise); quoted so a
+            # hostile env var can't break out of the `bash -lc` shell_cmd built
+            # downstream in create_task(). The pod is externally sandboxed (k8s),
+            # so auto_approve uses the bypass flag documented for exactly that.
+            model = os.environ.get('KC_CODEX_MODEL', '')
+            skip = '--dangerously-bypass-approvals-and-sandbox ' if auto_approve else ''
+            model_flag = f'--model {_shell_quote(model)}' if model else ''
+            return f'codex {skip}{model_flag}'.strip()
         if assistant == 'librefang':
             # Interactive chat REPL with the registry's "coder" agent (synced
             # into ~/.librefang by `librefang init`). KC_LIBREFANG_AGENT

--- a/charts/workspace/start.sh
+++ b/charts/workspace/start.sh
@@ -389,6 +389,37 @@ for HOME_DIR in /home/ubuntu; do
   ln -sfn "$TARGET" "$LINK" 2>/dev/null || true
 done
 
+# Persist Codex's OAuth credentials + sessions across pod restarts. Codex stores
+# everything (auth.json from `codex login`, config.toml, saved sessions) under
+# $CODEX_HOME (default ~/.codex), which on the ephemeral home is wiped every
+# restart — losing the login. Point ~/.codex at the PVC (same pattern as
+# ~/.claude above) so the ChatGPT login survives and `codex exec` (the
+# Hypervisor driver) can resume sessions.
+CODEX_TARGET=/home/dev/.codex
+mkdir -p "$CODEX_TARGET"
+chmod 700 "$CODEX_TARGET"
+if [ -L "$CODEX_TARGET" ]; then
+  CD=$(readlink "$CODEX_TARGET")
+  if [ "$CD" = "$CODEX_TARGET" ] || [ "$CD" = ".codex" ]; then
+    rm -f "$CODEX_TARGET"; mkdir -p "$CODEX_TARGET"; chmod 700 "$CODEX_TARGET"
+  fi
+fi
+for HOME_DIR in /home/ubuntu; do
+  [ -d "$HOME_DIR" ] || continue
+  LINK="$HOME_DIR/.codex"
+  [ "$LINK" = "$CODEX_TARGET" ] && continue
+  if [ -L "$LINK" ] && [ "$(readlink "$LINK")" = "$CODEX_TARGET" ]; then
+    continue
+  fi
+  if [ -d "$LINK" ] && [ ! -L "$LINK" ]; then
+    cp -an "$LINK"/. "$CODEX_TARGET"/ 2>/dev/null || true
+    rm -rf "$LINK"
+  elif [ -e "$LINK" ] || [ -L "$LINK" ]; then
+    rm -f "$LINK"
+  fi
+  ln -sfn "$CODEX_TARGET" "$LINK" 2>/dev/null || true
+done
+
 # Persist Ante's config across pod restarts and keep its binary on the PVC.
 # Ante stores everything (settings, sessions, versions.json) under ~/.ante,
 # which on the ephemeral /home/ubuntu home was wiped every restart. We point

--- a/charts/workspace/tests/hypervisor_session_test.py
+++ b/charts/workspace/tests/hypervisor_session_test.py
@@ -153,7 +153,7 @@ class SessionEventsTest(unittest.TestCase):
         self.assertEqual(len(s.read_events(since_seq=1)), 1)
 
     def test_assistant_adapter_routing(self):
-        cases = {'claude': 'claude', 'ante': 'ante',
+        cases = {'claude': 'claude', 'ante': 'ante', 'codex': 'codex',
                  'opencode-openrouter': 'opencode', 'opencode-deepseek': 'opencode',
                  'librefang': 'fallback', 'kc-harness': 'fallback'}
         for assistant, kind in cases.items():
@@ -229,6 +229,78 @@ class OpencodeAdapterTest(unittest.TestCase):
         self.assertIn('openrouter/anthropic/claude-sonnet-4', spec['argv'])
         ctx['opencode_session_id'] = 'ses_x'
         self.assertIn('-s', self.a.build(ctx, 'again', first=False)['argv'])
+
+
+class CodexAdapterTest(unittest.TestCase):
+    def setUp(self):
+        self.a = hs.CodexAdapter()
+
+    def test_thread_started_captures_session_id(self):
+        ctx = {}
+        self.a._reset_turn(ctx)
+        out = self.a.parse(ctx, json.dumps(
+            {'type': 'thread.started', 'thread_id': 'tid-123'}))
+        self.assertEqual(out, [])
+        self.assertEqual(ctx['codex_session_id'], 'tid-123')
+
+    def test_item_completed_agent_message_becomes_text(self):
+        ctx = {}
+        self.a._reset_turn(ctx)
+        out = self.a.parse(ctx, json.dumps(
+            {'type': 'item.completed',
+             'item': {'id': 'item_1', 'type': 'agent_message', 'text': 'PONG'}}))
+        self.assertEqual(out, [{'role': 'assistant', 'type': 'message', 'text': 'PONG'}])
+
+    def test_item_completed_error_surfaces(self):
+        ctx = {}
+        self.a._reset_turn(ctx)
+        out = self.a.parse(ctx, json.dumps(
+            {'type': 'item.completed',
+             'item': {'id': 'item_0', 'type': 'error', 'message': 'boom'}}))
+        self.assertEqual(out, [{'role': 'system', 'type': 'error', 'text': 'boom'}])
+
+    def test_turn_failed_is_terminal_error(self):
+        ctx = {}
+        self.a._reset_turn(ctx)
+        out = self.a.parse(ctx, json.dumps(
+            {'type': 'turn.failed', 'error': {'message': '401 Unauthorized'}}))
+        self.assertEqual(out, [{'role': 'system', 'type': 'error', 'text': '401 Unauthorized'}])
+
+    def test_transient_error_and_step_events_are_noise(self):
+        ctx = {}
+        self.a._reset_turn(ctx)
+        # top-level reconnect chatter is NOT a turn outcome — dropped.
+        self.assertEqual(self.a.parse(ctx, json.dumps(
+            {'type': 'error', 'message': 'Reconnecting... 2/5'}), ), [])
+        for noise in ('turn.started', 'turn.completed'):
+            self.assertEqual(self.a.parse(ctx, json.dumps({'type': noise})), [])
+        self.assertEqual(self.a.parse(ctx, json.dumps(
+            {'type': 'item.started', 'item': {'type': 'reasoning'}})), [])
+        # reasoning item.completed carries no message marker → skipped.
+        self.assertEqual(self.a.parse(ctx, json.dumps(
+            {'type': 'item.completed', 'item': {'type': 'reasoning', 'text': 'hmm'}})), [])
+
+    def test_build_first_turn_and_resume(self):
+        ctx = {'workdir': '/home/dev', 'preamble': 'ROLE'}
+        spec = self.a.build(ctx, 'hi', first=True)
+        self.assertEqual(spec['argv'][:3], ['codex', 'exec', '--json'])
+        self.assertIn('--dangerously-bypass-approvals-and-sandbox', spec['argv'])
+        self.assertIn('--skip-git-repo-check', spec['argv'])
+        self.assertEqual(spec['argv'][-1], 'ROLE\n\nhi')  # preamble prepended, turn 1
+        # resume uses the captured session id via the `exec resume <id>` form.
+        ctx['codex_session_id'] = 'tid-9'
+        spec2 = self.a.build(ctx, 'again', first=False)
+        self.assertEqual(spec2['argv'][:3], ['codex', 'exec', 'resume'])
+        self.assertIn('tid-9', spec2['argv'])
+        self.assertEqual(spec2['argv'][-1], 'again')
+
+    def test_raw_fallback_when_no_structured_events(self):
+        ctx = {}
+        self.a.build(ctx, 'hi', first=True)
+        self.a.parse(ctx, 'plain non-json line')
+        out = self.a.finalize(ctx, 0)
+        self.assertEqual(out, [{'role': 'assistant', 'type': 'message',
+                                'text': 'plain non-json line'}])
 
 
 class StopTest(unittest.TestCase):

--- a/devlaptop/Dockerfile
+++ b/devlaptop/Dockerfile
@@ -90,6 +90,15 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 ARG OPENCODE_VERSION=1.17.4
 RUN npm install -g opencode-ai@${OPENCODE_VERSION}
 
+# Codex CLI — OpenAI's terminal-native coding agent. Surfaces in the dashboard
+# as the `codex` assistant and drives the Hypervisor via `codex exec --json`.
+# Auth is ChatGPT OAuth (no API key) — the user runs `codex login` once in the
+# pod; credentials + sessions live under $CODEX_HOME (~/.codex), which start.sh
+# persists on the PVC (same pattern as ~/.claude). npm-global install, so no
+# PVC-binary symlink is needed (unlike agy/ante). https://github.com/openai/codex
+ARG CODEX_VERSION=0.144.3
+RUN npm install -g @openai/codex@${CODEX_VERSION}
+
 # Antigravity CLI (agy) — Google's terminal-native coding agent. Selected
 # per-task in the dashboard (the `antigravity` assistant) and spawnable via the
 # agent-orchestrator. Auth is OAuth Google Sign-In (no API key) — the user runs

--- a/mobile/src/screens/NewTaskScreen.tsx
+++ b/mobile/src/screens/NewTaskScreen.tsx
@@ -18,7 +18,7 @@ import { Button, Label } from '../components/ui';
 import type { TasksNav } from '../navigation';
 import { colors, font, radius, space } from '../theme';
 
-const ASSISTANTS = ['claude', 'ante', 'opencode-openrouter'];
+const ASSISTANTS = ['claude', 'ante', 'codex', 'opencode-openrouter'];
 
 export default function NewTaskScreen() {
   const nav = useNavigation<TasksNav>();


### PR DESCRIPTION
## What

Adds OpenAI's **Codex** (`codex` CLI) as a selectable assistant, driven the same way Claude is: a structured Hypervisor adapter over the CLI's machine-readable stream, plus the interactive TUI on the Build tab. Auth is **ChatGPT OAuth** (no API key) — the user runs `codex login` once in the pod, exactly like the `agy`/`claude` login.

## How

- **Dockerfile** — install `@openai/codex` (npm-global, pinned `CODEX_VERSION`).
- **start.sh** — persist `$CODEX_HOME` (`~/.codex`: `auth.json` + saved sessions) on the PVC, mirroring the `~/.claude` block, so the ChatGPT login and resumable sessions survive pod restarts.
- **server.py** — register the `codex` assistant; list it whenever the binary is resolvable (OAuth → binary presence is the signal, same as Antigravity); Build-tab command is the interactive `codex` TUI, with `--dangerously-bypass-approvals-and-sandbox` under auto-approve (its documented use is an externally-sandboxed env — which the k8s pod is). Optional model via `KC_CODEX_MODEL`.
- **hypervisor_session.py** — `CodexAdapter` over `codex exec --json`, multi-turn via `codex exec resume <thread_id>`. **Event schema captured empirically from the real CLI** (v0.144.3):
  - `thread.started` → session id (for resume)
  - `item.completed` → agent message / error
  - `turn.failed` → terminal error
  - transient top-level `{"type":"error","message":"Reconnecting…"}` chatter is **dropped** — only `turn.failed` is a real outcome.
- **mobile** — add `codex` to the New Task assistant list for parity. (Web Hypervisor + Build pickers are dynamic off `available_assistants()`, so Codex appears there automatically.)

## Tests

`CodexAdapterTest` — thread-id capture, agent-message text, error + `turn.failed` surfacing, reconnect/step noise dropped, first-turn preamble + `exec resume` build, raw fallback — plus `codex` added to the adapter-routing case. **707 python tests green, mobile `tsc` + `helm template` clean.**

## Not yet validated end-to-end (needs image + login)

Codex is only in the image after this ships (image rebuild) and only works after a one-time in-pod `codex login`. Two follow-ups, to be done in-pod once the image is out (same empirical path ante/opencode took):
1. Confirm `codex exec resume` accepts the streaming flags (`--json`, `-C`, bypass) — if not, adjust the resume argv.
2. Capture the full `item.type` vocabulary (reasoning / command_execution / file_change) and render tool calls; the current cut deliberately surfaces only agent-message + error and skips internal-step items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
