### PR TITLE
fix(controller): self-serve update runs a real chart reconcile, not just an image patch

### DIFF
--- a/charts/workspace-controller/controller.py
+++ b/charts/workspace-controller/controller.py
@@ -742,6 +742,26 @@ def set_workspace_image(user, target_version=None, persist=True):
         except (ProvisionError, GithubError) as exc:
             persist_error = str(exc)
             sys.stderr.write(f'[controller] gitops image update {user}->{new_tag} failed: {exc}\n')
+    # Config reconcile — the crux of a real "update". The live image patch above
+    # rolls the pod, but the pod runs server.py (and every other script) from the
+    # Helm-rendered ConfigMaps, which a bare `kubectl patch` NEVER refreshes. So
+    # backend code — new Hypervisor routes, the assistants list, … — would stay
+    # frozen at whatever chart version last did a `helm upgrade`, while the SPA
+    # baked into the image advances. That mismatch is the "workspace updated but
+    # Hypervisor 404s / no assistants" bug. Launch the same provisioning Job used
+    # for create: it runs `make deploy` (helm upgrade from CHART_REF against the
+    # user's gitops config, now carrying new_tag), refreshing every ConfigMap and
+    # rolling the pod via the deployment's checksum/* annotations. Run it even
+    # when the image is already current — a stale ConfigMap can (and does)
+    # coexist with an up-to-date image tag.
+    reconcile = None
+    if provisioning_enabled():
+        try:
+            create_provision_job(user)
+            reconcile = 'launched'
+        except (KubectlError, ProvisionError) as exc:
+            reconcile = 'failed'
+            sys.stderr.write(f'[controller] update {user}: config reconcile Job failed: {exc}\n')
     return {
         'user': user,
         'fromVersion': current_ver,
@@ -751,6 +771,10 @@ def set_workspace_image(user, target_version=None, persist=True):
         'rolled': not already,
         'persisted': persisted,
         'persistError': persist_error,
+        # 'launched' => a helm-upgrade Job is refreshing the ConfigMaps (the pod
+        # will roll again once it completes); None => provisioning not configured,
+        # so this update was image-tag only (legacy behavior).
+        'reconcile': reconcile,
     }
 
 

--- a/charts/workspace-controller/tests/controller_test.py
+++ b/charts/workspace-controller/tests/controller_test.py
@@ -682,6 +682,47 @@ class SetWorkspaceImageTest(unittest.TestCase):
         self.assertEqual(seen, {'slug': 'octo', 'tag': 'devlaptop-v1.4.0'})
         self.assertTrue(result['persisted'])
 
+    def _enable_provisioning(self):
+        """Turn on the wiring provisioning_enabled() checks + stub the Job launch
+        so no real kubectl is spawned. Returns the dict the stub records into."""
+        controller.GITOPS_REPO = 'github.com/o/r.git'
+        controller.GITOPS_TOKEN = 'tok'
+        self.addCleanup(setattr, controller, 'WORKSPACE_DOMAIN', controller.WORKSPACE_DOMAIN)
+        controller.WORKSPACE_DOMAIN = 'dev.example.com'
+        self.addCleanup(setattr, controller, 'gitops_update_image_tag',
+                        controller.gitops_update_image_tag)
+        controller.gitops_update_image_tag = lambda slug, tag: True
+        launched = {}
+        self.addCleanup(setattr, controller, 'create_provision_job',
+                        controller.create_provision_job)
+        controller.create_provision_job = lambda slug: launched.update(slug=slug) or 'job/x'
+        return launched
+
+    def test_config_reconcile_job_launched_on_update(self):
+        # A real update refreshes the ConfigMaps (server.py) via a helm-upgrade
+        # Job, not just the image tag.
+        controller._kubectl_run = lambda args, namespace=None: None
+        launched = self._enable_provisioning()
+        result = controller.set_workspace_image('octo')
+        self.assertEqual(launched, {'slug': 'octo'})
+        self.assertEqual(result['reconcile'], 'launched')
+
+    def test_config_reconcile_runs_even_when_already_on_target(self):
+        # The umi bug: image already latest but the ConfigMap (server.py) stale —
+        # "update" must still reconcile config, even with no image roll.
+        controller._kubectl_run = lambda args, namespace=None: None
+        launched = self._enable_provisioning()
+        result = controller.set_workspace_image('octo', 'v1.3.0')  # already on v1.3.0
+        self.assertFalse(result['rolled'])            # no image patch
+        self.assertEqual(launched, {'slug': 'octo'})  # but config still reconciled
+        self.assertEqual(result['reconcile'], 'launched')
+
+    def test_no_reconcile_job_when_provisioning_disabled(self):
+        # No GitOps/domain wiring → legacy image-tag-only update, no Job.
+        controller._kubectl_run = lambda args, namespace=None: None
+        result = controller.set_workspace_image('octo')  # GITOPS off (setUp default)
+        self.assertIsNone(result['reconcile'])
+
 
 class RestrictedListenerTest(unittest.TestCase):
     """The self-serve listener must 404 every admin/header-trusting route so a


### PR DESCRIPTION
## What

The self-serve **update** button now delivers **backend code**, not just a new image tag.

## Why

`set_workspace_image` only did a `kubectl patch` of the container image (+ a gitops `values.yaml` commit). But the pod runs `server.py` — and every script — from the **Helm-rendered ConfigMaps**, which a bare patch never refreshes. So backend code (new Hypervisor routes, the assistants list, …) stayed frozen at whatever chart version last ran `helm upgrade`, while the SPA baked into the new image advanced. That mismatch is the **"workspace updated but Hypervisor 404s / no assistants selectable"** bug (MJ's umi workspace, and in fact the whole fleet — every workspace except imran, who gets frequent operator `ship-config` runs).

## How

After the live patch + gitops tag commit, `set_workspace_image` launches the **same provisioning Job used for create**. It runs `make deploy` (helm upgrade from `CHART_REF` against the user's gitops config, now carrying the new tag), which refreshes every ConfigMap and rolls the pod via the deployment's existing `checksum/*` annotations.

- Runs **even when the image is already current** — a stale ConfigMap can coexist with an up-to-date image tag (exactly umi's case).
- **Gated on `provisioning_enabled()`** — with no GitOps/domain wiring it degrades to the legacy image-tag-only patch.
- Result gains a `reconcile` field (`'launched'` | `'failed'` | `None`) so callers can tell a config reconcile is in flight (the pod rolls again when the Job completes).

## Tests

reconcile Job launched on update; runs even when already on the target version; stays `None` when provisioning is disabled. **Full controller suite green (76).**

## Ships via

`make ship-controller-config` (controller pod), **separate from the workspace release image**. No workspace-chart change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
