### PR TITLE
feat: make Codex a true peer of Claude everywhere + mobile assistant parity

### DIFF
--- a/charts/workspace/claude-md.txt
+++ b/charts/workspace/claude-md.txt
@@ -238,8 +238,8 @@ won't leak into every prompt.
 This workspace ships an `agent-orchestrator` MCP server that lets you
 spawn, monitor, and collect results from sub-agent sessions. Use it to
 decompose large problems into parallel subtasks. The same tools are
-registered for **Claude, Ante, and OpenCode**, so any of these harnesses
-can spawn any other and lineage is tracked across them.
+registered for **Claude, Ante, OpenCode, and Codex**, so any of these
+harnesses can spawn any other and lineage is tracked across them.
 
 By default agents spawn in **headless** mode: the sub-agent runs the
 prompt to completion and exits, so `get_agent_status` flips to
@@ -267,6 +267,10 @@ so orchestration can't fork-bomb the pod or run away on API spend.
 
 - `ante` — Ante CLI (pre-installed; defaults to OpenRouter when its key is set)
 - `claude` — Claude Code (requires Anthropic API key or OAuth)
+- `codex` — Codex (OpenAI, pre-installed). ChatGPT OAuth — run `codex login`
+  ONCE in a terminal to sign in (creds persist on the PVC under `~/.codex`);
+  after that it works as a Hypervisor driver, a Build-tab REPL, and a
+  `spawn_agent(assistant="codex")` sub-agent, same as Claude. No API key.
 - `librefang` — LibreFang agent OS (pre-installed; talks to its registry
   `coder` agent and reuses whatever provider key is in the environment)
 - `opencode-openrouter` — OpenCode via OpenRouter

--- a/charts/workspace/mcp_agent_orchestrator.py
+++ b/charts/workspace/mcp_agent_orchestrator.py
@@ -239,7 +239,14 @@ def _append_sub_task_id(parent_task_id: str, child_task_id: str) -> None:
 # Assistants with a non-interactive one-shot "print" mode that exits when
 # the task is done. Anything not listed has no reliable headless interface
 # (kc-harness) and is always run interactively (prompt pasted into the REPL).
-_HEADLESS_CAPABLE = {'claude', 'ante', 'antigravity', 'librefang', 'opencode-openrouter', 'opencode-deepseek'}
+_HEADLESS_CAPABLE = {'claude', 'ante', 'codex', 'antigravity', 'librefang', 'opencode-openrouter', 'opencode-deepseek'}
+
+
+def _codex_model_flag() -> str:
+    """Optional `-m <model>` for codex; empty when KC_CODEX_MODEL is unset (codex
+    picks its own default). Mirrors server.py's assistant_command."""
+    m = os.environ.get('KC_CODEX_MODEL', '')
+    return f'-m {_shell_quote(m)} ' if m else ''
 
 
 def _opencode_model(assistant: str) -> str:
@@ -299,6 +306,10 @@ def _assistant_command(assistant: str, prompt: str = '', headless: bool = True) 
             return f'agy --model {_shell_quote(m)}' if m else 'agy'
         if assistant == 'kc-harness':
             return 'python3 /tmp/browser/harness.py'
+        if assistant == 'codex':
+            # Interactive Codex TUI. The pod is externally sandboxed (k8s), so
+            # bypass approvals/sandbox for the unattended sub-agent.
+            return f'codex --dangerously-bypass-approvals-and-sandbox {_codex_model_flag()}'.rstrip()
         if assistant == 'librefang':
             # Interactive REPL also needs the daemon — see _assistant_command's
             # headless branch and _librefang_daemon_bootstrap().
@@ -311,6 +322,14 @@ def _assistant_command(assistant: str, prompt: str = '', headless: bool = True) 
         return f'claude --dangerously-skip-permissions -p {q}'
     if assistant == 'ante':
         return f'ante --yolo -p {q}'
+    if assistant == 'codex':
+        # `codex exec <prompt>` is the one-shot non-interactive mode (exits when
+        # done). Bypass approvals/sandbox (pod is externally sandboxed) and skip
+        # the git-repo check so it runs in any workdir. No --json here: the
+        # orchestrator captures the tmux pane as text, and exec prints its final
+        # message to stdout.
+        return (f'codex exec --dangerously-bypass-approvals-and-sandbox '
+                f'--skip-git-repo-check {_codex_model_flag()}{q}')
     if assistant == 'antigravity':
         # `agy -p` is the CLI's one-shot print mode (prompt on the command line,
         # exits when done). --dangerously-skip-permissions auto-approves tool
@@ -356,6 +375,7 @@ def _wait_pane_ready(session_name: str, min_delay: float = 1.5,
 _ASSISTANTS_LIST = [
     {'id': 'claude', 'label': 'Claude Code'},
     {'id': 'ante', 'label': 'Ante CLI'},
+    {'id': 'codex', 'label': 'Codex'},
     {'id': 'antigravity', 'label': 'Antigravity'},
     {'id': 'librefang', 'label': 'LibreFang'},
     {'id': 'opencode-openrouter', 'label': 'OpenRouter'},

--- a/charts/workspace/start.sh
+++ b/charts/workspace/start.sh
@@ -753,6 +753,28 @@ os.replace(tmp, path)
 print('[seed_ante_config] wrote', path)
 PY
 
+# Seed Codex's MCP servers so a selected/spawned Codex agent gets the SAME
+# stdio MCP surface as Claude/Ante — agent-orchestrator (spawn + track
+# sub-agents), shared persistent memory, and the dashboard tools (metrics/
+# tasks/UI actions in the Hypervisor). Codex reads MCP servers from
+# $CODEX_HOME/config.toml; `codex mcp add` merges each block in idempotently
+# (overwrites the named server, preserves everything else incl. auth.json), so
+# a re-run on an established PVC is safe. Best-effort + gated on the binary so
+# older images / a failed add never stall boot. Independent of `codex login`
+# (MCP config isn't auth). CODEX_HOME is pinned to the PVC path the persistence
+# block above manages, so it lands regardless of this script's own $HOME.
+if command -v codex >/dev/null 2>&1; then
+  log_stage "seeding Codex MCP config (~/.codex/config.toml)"
+  for _mcp in \
+    "agent-orchestrator /tmp/browser/mcp_agent_orchestrator.py" \
+    "memory /home/dev/.claude-memory/mcp_memory.py" \
+    "dashboard /tmp/browser/mcp_dashboard.py"; do
+    set -- $_mcp   # $1=server name, $2=script path
+    CODEX_HOME=/home/dev/.codex codex mcp add "$1" -- python3 "$2" >/dev/null 2>&1 \
+      || log_stage "WARNING: codex mcp add $1 failed (Codex MCP $1 not registered)"
+  done
+fi
+
 log_stage "starting browser/Claude API server on :6080"
 mkdir -p /tmp/browser
 # Copy Python sources (these need a pod restart to take effect).

--- a/charts/workspace/tests/mcp_agent_orchestrator_test.py
+++ b/charts/workspace/tests/mcp_agent_orchestrator_test.py
@@ -47,6 +47,21 @@ class AssistantCommandTests(unittest.TestCase):
         self.assertIn('--yolo', cmd)
         self.assertIn("'write tests'", cmd)
 
+    def test_headless_codex_uses_exec_with_bypass(self):
+        cmd = orch._assistant_command('codex', 'write tests', headless=True)
+        self.assertIn('codex exec', cmd)
+        self.assertIn('--dangerously-bypass-approvals-and-sandbox', cmd)
+        self.assertIn('--skip-git-repo-check', cmd)
+        self.assertIn("'write tests'", cmd)
+
+    def test_interactive_codex_is_tui_with_bypass(self):
+        cmd = orch._assistant_command('codex', 'ignored', headless=False)
+        self.assertEqual(cmd, 'codex --dangerously-bypass-approvals-and-sandbox')
+
+    def test_codex_is_headless_capable_and_listed(self):
+        self.assertIn('codex', orch._HEADLESS_CAPABLE)
+        self.assertIn('codex', {a['id'] for a in orch._ASSISTANTS_LIST})
+
     def test_headless_antigravity_has_print_and_skip_permissions(self):
         cmd = orch._assistant_command('antigravity', 'write tests', headless=True)
         self.assertIn('agy', cmd)

--- a/charts/workspace/web/src/routes/desktop/DesktopEditor.tsx
+++ b/charts/workspace/web/src/routes/desktop/DesktopEditor.tsx
@@ -151,7 +151,7 @@ export function DesktopEditor({
                 fullWidth
                 value={taskAssistant}
                 onInput={(e) => setTaskAssistant((e.target as HTMLInputElement).value)}
-                placeholder="claude  (or opencode-openrouter / kc-harness)"
+                placeholder="claude  (or ante / codex / opencode-openrouter)"
               />
             </label>
           </div>

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -701,3 +701,27 @@ export async function deleteProviderKey(provider: ProviderVar): Promise<void> {
   if (getConfig().mock) return;
   await request(`/api/provider-keys/${provider}`, { method: 'DELETE' });
 }
+
+// ---- Assistants ------------------------------------------------------------
+// The set of AI harnesses the workspace has enabled (claude/ante/codex/opencode
+// /…), gated backend-side on binary + key presence. Drives the New Task picker
+// so it always reflects what's actually usable (incl. Codex when logged in).
+
+export interface Assistant {
+  id: string;
+  label?: string;
+  default?: boolean;
+  model?: string;
+}
+
+export async function listAssistants(): Promise<Assistant[]> {
+  if (getConfig().mock) {
+    return [
+      { id: 'claude', label: 'Claude Code', default: true },
+      { id: 'ante', label: 'Ante CLI' },
+      { id: 'codex', label: 'Codex' },
+    ];
+  }
+  const r = await request<{ assistants?: Assistant[] }>('/api/claude/assistants');
+  return r.assistants ?? [];
+}

--- a/mobile/src/screens/HypervisorScreen.tsx
+++ b/mobile/src/screens/HypervisorScreen.tsx
@@ -91,6 +91,8 @@ export default function HypervisorScreen() {
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [chatsOpen, setChatsOpen] = useState(false);
+  // Assistant chosen for the NEXT new chat (existing threads keep their own).
+  const [selectedAssistant, setSelectedAssistant] = useState<string | undefined>(undefined);
   const scrollRef = useRef<ScrollView | null>(null);
   const optimisticSeq = useRef(-1);
   // Whether the view is pinned to the bottom. We only auto-scroll on new events
@@ -108,7 +110,11 @@ export default function HypervisorScreen() {
 
   useEffect(() => {
     void getHypervisorConfig()
-      .then(setConfig)
+      .then((c) => {
+        setConfig(c);
+        // Seed the new-chat assistant picker with the workspace default.
+        setSelectedAssistant((prev) => prev ?? c.defaultAssistant);
+      })
       .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load config'));
     void refreshThreads();
   }, [refreshThreads]);
@@ -269,7 +275,7 @@ export default function HypervisorScreen() {
     ]);
     try {
       if (!activeId) {
-        const thread = await createThread(finalText, config?.defaultAssistant, CHAT_WORKDIR);
+        const thread = await createThread(finalText, selectedAssistant || config?.defaultAssistant, CHAT_WORKDIR);
         await refreshThreads();
         openThread(thread.id);
       } else {
@@ -443,6 +449,33 @@ export default function HypervisorScreen() {
                 </Pressable>
               </View>
             ))}
+          </ScrollView>
+        )}
+
+        {/* New-chat assistant picker — parity with the web Hypervisor agent
+            select. Only shown when starting a NEW chat (no active thread) and
+            more than one assistant is available; existing threads keep the
+            assistant they were created with. */}
+        {!activeThread && (config?.assistants?.length ?? 0) > 1 && (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.asstRow}
+            contentContainerStyle={styles.asstRowContent}
+            keyboardShouldPersistTaps="handled"
+          >
+            {config!.assistants.map((a) => {
+              const on = (selectedAssistant || config?.defaultAssistant) === a.id;
+              return (
+                <Pressable
+                  key={a.id}
+                  onPress={() => setSelectedAssistant(a.id)}
+                  style={[styles.asstChip, on && styles.asstChipOn]}
+                >
+                  <Text style={[styles.asstChipText, on && styles.asstChipTextOn]}>{a.label || a.id}</Text>
+                </Pressable>
+              );
+            })}
           </ScrollView>
         )}
 
@@ -871,6 +904,28 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
     borderTopColor: colors.border,
   },
+  asstRow: {
+    maxHeight: 44,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    backgroundColor: colors.bgElevated,
+  },
+  asstRowContent: {
+    alignItems: 'center',
+    gap: space.sm,
+    paddingHorizontal: space.md,
+    paddingVertical: space.sm,
+  },
+  asstChip: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.pill,
+    paddingHorizontal: space.md,
+    paddingVertical: 6,
+  },
+  asstChipOn: { backgroundColor: colors.accent + '22', borderColor: colors.accent },
+  asstChipText: { color: colors.textMuted, fontSize: font.size.sm, fontWeight: '500' },
+  asstChipTextOn: { color: colors.accent, fontWeight: '700' },
   composer: {
     flexDirection: 'row',
     alignItems: 'flex-end',

--- a/mobile/src/screens/NewTaskScreen.tsx
+++ b/mobile/src/screens/NewTaskScreen.tsx
@@ -1,7 +1,7 @@
 /** Create a new Claude task. */
 import { useNavigation } from '@react-navigation/native';
 import { useHeaderHeight } from '@react-navigation/elements';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -13,21 +13,40 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { createTask } from '../api/client';
+import { createTask, listAssistants, type Assistant } from '../api/client';
 import { Button, Label } from '../components/ui';
 import type { TasksNav } from '../navigation';
 import { colors, font, radius, space } from '../theme';
 
-const ASSISTANTS = ['claude', 'ante', 'codex', 'opencode-openrouter'];
+// Shown until the backend list loads (or if it fails) so the picker is never
+// empty. The live list from /api/claude/assistants replaces this and reflects
+// exactly what the workspace has enabled (incl. Codex once logged in).
+const FALLBACK_ASSISTANTS: Assistant[] = [
+  { id: 'claude', label: 'Claude Code', default: true },
+  { id: 'ante', label: 'Ante CLI' },
+  { id: 'codex', label: 'Codex' },
+];
 
 export default function NewTaskScreen() {
   const nav = useNavigation<TasksNav>();
   const headerHeight = useHeaderHeight();
   const [prompt, setPrompt] = useState('');
   const [workdir, setWorkdir] = useState('/home/dev');
+  const [assistants, setAssistants] = useState<Assistant[]>(FALLBACK_ASSISTANTS);
   const [assistant, setAssistant] = useState('claude');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void listAssistants()
+      .then((list) => {
+        if (list.length === 0) return;
+        setAssistants(list);
+        // Default the selection to the backend's default (or first) assistant.
+        setAssistant(list.find((a) => a.default)?.id ?? list[0].id);
+      })
+      .catch(() => {/* keep the fallback list */});
+  }, []);
 
   async function submit() {
     if (!prompt.trim()) return;
@@ -79,13 +98,13 @@ export default function NewTaskScreen() {
 
           <Label style={{ marginTop: space.xl }}>Assistant</Label>
           <View style={styles.chips}>
-            {ASSISTANTS.map((a) => (
+            {assistants.map((a) => (
               <Pressable
-                key={a}
-                onPress={() => setAssistant(a)}
-                style={[styles.chip, assistant === a && styles.chipActive]}
+                key={a.id}
+                onPress={() => setAssistant(a.id)}
+                style={[styles.chip, assistant === a.id && styles.chipActive]}
               >
-                <Text style={[styles.chipText, assistant === a && styles.chipTextActive]}>{a}</Text>
+                <Text style={[styles.chipText, assistant === a.id && styles.chipTextActive]}>{a.label || a.id}</Text>
               </Pressable>
             ))}
           </View>


### PR DESCRIPTION
## Goal

Make **Codex** a true peer of Claude everywhere so a user can pick it *instead of* Claude, and do a **mobile parity pass**. Started from a full audit of every place an assistant is selected/handled (backend orchestrator, dashboard MCP, web SPA, mobile app).

## Backend — the real gaps

Codex (added in v1.21.0) worked as a Hypervisor driver and Build-tab REPL, but two things were missing:

1. **Sub-agent orchestrator had no Codex** — `mcp_agent_orchestrator.py` omitted `codex` from `_HEADLESS_CAPABLE`, both `_assistant_command` branches, and `_ASSISTANTS_LIST`, so `spawn_agent(assistant="codex")` silently ran **Claude**. Now: headless `codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check <prompt>`, interactive `codex` TUI, and it's listed + headless-capable.
2. **Codex had no MCP tools** — Claude/Ante/OpenCode get the `dashboard` / `memory` / `agent-orchestrator` MCP servers registered in `start.sh`; Codex didn't. Added `codex mcp add …` (writes `~/.codex/config.toml`, idempotent, gated on the binary, best-effort). Codex now gets the **same workspace tools + persistent memory + sub-agent spawning** — in both the Build tab and the Hypervisor (`codex exec` reads `config.toml`). Independent of `codex login`.

Docs (`claude-md.txt`) now list the Codex assistant + its one-time `codex login`, and add Codex to the orchestrator harness list.

## Web

The SPA is **fully data-driven** — every picker comes from `/api/claude/assistants` or `/api/hypervisor/config`, no hardcoded catalog, no per-assistant icon maps — so Codex already appears everywhere. The only miss was a cosmetic Desktop-editor placeholder (now mentions codex).

## Mobile — closed the assistant parity gaps

- **Hypervisor**: added a **new-chat assistant picker** (chip row over the composer, from the dynamic config) — parity with the web agent select, so a mobile chat can be driven by Codex/Ante/etc. Existing threads keep their assistant.
- **New Task**: replaced the hardcoded 4-item list with a **live fetch** (`listAssistants` → `/api/claude/assistants`), falling back to a static list so it's never empty; defaults to the backend's default.
- `client.ts`: new `listAssistants()` + `Assistant` type (with mock branch).

## Tests

Orchestrator codex command/list cases added — **python 756 green, controller 76 green, web tsc+build clean, mobile tsc clean**.

## Known non-goal (matches `agy`)

Codex auth is `codex login` in a pod terminal; there's **no dashboard login button** (Claude arrives pre-authed via subscription). Documented, not changed here.

## Broader mobile-parity gaps found but NOT in this PR (net-new screens — flagging for a scope decision)

The audit also found web surfaces mobile lacks entirely: **Triggers**, **Files browser**, **Docs viewer**, and Settings sections (Appearance/theme, Git, Browser, Updates). These are new features, not codex-related — left out of this PR; happy to scope them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
