### PR TITLE
feat(tasks): add message composer interrupt

### DIFF
--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -1344,6 +1344,34 @@ class ClaudeTaskManager:
         return updated, None
 
     @staticmethod
+    def interrupt_task(task_id):
+        """Send Escape to a live task's tmux session without killing it."""
+        task_dir = os.path.join(ClaudeTaskManager.TASKS_DIR, task_id)
+        meta_path = os.path.join(task_dir, 'task.json')
+        if not os.path.isfile(meta_path):
+            return None, 'Task not found'
+
+        with open(meta_path, 'r') as f:
+            meta = json.load(f)
+
+        session_name = meta.get('tmux_session', f'kube-coder-{task_id}')
+        check = subprocess.run(
+            ['tmux', 'has-session', '-t', session_name],
+            capture_output=True, text=True,
+        )
+        if check.returncode != 0:
+            return None, 'Session is no longer running'
+
+        result = subprocess.run(
+            ['tmux', 'send-keys', '-t', session_name, 'Escape'],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            return None, result.stderr.strip() or 'Failed to interrupt session'
+
+        return meta, None
+
+    @staticmethod
     def delete_task(task_id):
         task_dir = os.path.join(ClaudeTaskManager.TASKS_DIR, task_id)
         meta_path = os.path.join(task_dir, 'task.json')
@@ -4637,6 +4665,17 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             return
         self.send_json(task)
 
+    def handle_claude_interrupt_task(self):
+        """POST /api/claude/tasks/{id}/interrupt: stop the current turn."""
+        if not self.check_claude_auth():
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        task, err = ClaudeTaskManager.interrupt_task(self._claude_task_id)
+        if task is None:
+            self.send_json({'error': err or 'Task not found'}, 404)
+            return
+        self.send_json(task)
+
     def handle_claude_rename_task(self):
         if not self.check_claude_auth():
             self.send_json({'error': 'Unauthorized'}, 401)
@@ -7359,6 +7398,12 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
                     self._claude_task_id = m.group(1)
                     self.handle_claude_followup()
                     return
+                # /api/claude/tasks/{id}/interrupt — send Escape to Claude Code
+                m = re.match(r'^/api/claude/tasks/([A-Za-z0-9_-]+)/interrupt$', path)
+                if m:
+                    self._claude_task_id = m.group(1)
+                    self.handle_claude_interrupt_task()
+                    return
                 # /api/hypervisor/threads/{id}/messages — chat follow-up
                 m = re.match(r'^/api/hypervisor/threads/([A-Za-z0-9_-]+)/messages$', path)
                 if m:
@@ -8175,6 +8220,7 @@ if __name__ == "__main__":
     print("  GET  /api/claude/tasks/{id}         - Get task detail + output")
     print("  GET  /api/claude/tasks/{id}/output  - Get raw output")
     print("  POST /api/claude/tasks/{id}/message - Send follow-up prompt")
+    print("  POST /api/claude/tasks/{id}/interrupt - Stop the current assistant turn")
     print("  POST /api/claude/tasks/{id}/rename  - Rename a task")
     print("  DELETE /api/claude/tasks/{id}       - Kill a running task")
     print("  GET  /api/claude/auth/token         - Get bearer token (OAuth2 only)")

--- a/charts/workspace/tests/interrupt_test.py
+++ b/charts/workspace/tests/interrupt_test.py
@@ -1,0 +1,133 @@
+"""Tests for the task interrupt endpoint and tmux Escape command.
+
+Run with:
+    cd charts/workspace && python3 -m unittest tests.interrupt_test
+"""
+
+import http.server
+import json
+import os
+import sys
+import tempfile
+import threading
+import unittest
+import urllib.request
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+import server  # noqa: E402
+
+
+def _free_port():
+    import socket
+    s = socket.socket()
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _result(code=0, stderr=''):
+    return mock.Mock(returncode=code, stdout='', stderr=stderr)
+
+
+def _post(url):
+    req = urllib.request.Request(url, data=b'{}', method='POST')
+    req.add_header('Content-Type', 'application/json')
+    return urllib.request.urlopen(req, timeout=5)
+
+
+class InterruptTaskTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.old_tasks_dir = server.ClaudeTaskManager.TASKS_DIR
+        server.ClaudeTaskManager.TASKS_DIR = self.tmp.name
+
+    def tearDown(self):
+        server.ClaudeTaskManager.TASKS_DIR = self.old_tasks_dir
+        self.tmp.cleanup()
+
+    def _task(self, task_id='task-1'):
+        task_dir = os.path.join(self.tmp.name, task_id)
+        os.makedirs(task_dir)
+        meta = {'task_id': task_id, 'status': 'running', 'tmux_session': 'kube-coder-task-1'}
+        with open(os.path.join(task_dir, 'task.json'), 'w') as f:
+            json.dump(meta, f)
+        return meta
+
+    def test_interrupt_sends_escape_after_confirming_the_session_is_live(self):
+        meta = self._task()
+        with mock.patch.object(server.subprocess, 'run', side_effect=[_result(), _result()]) as run:
+            task, err = server.ClaudeTaskManager.interrupt_task('task-1')
+
+        self.assertIsNone(err)
+        self.assertEqual(task, meta)
+        self.assertEqual(
+            run.call_args_list,
+            [
+                mock.call(['tmux', 'has-session', '-t', 'kube-coder-task-1'], capture_output=True, text=True),
+                mock.call(['tmux', 'send-keys', '-t', 'kube-coder-task-1', 'Escape'], capture_output=True, text=True),
+            ],
+        )
+
+    def test_interrupt_does_not_send_escape_when_the_session_is_gone(self):
+        self._task()
+        with mock.patch.object(server.subprocess, 'run', return_value=_result(1)) as run:
+            task, err = server.ClaudeTaskManager.interrupt_task('task-1')
+
+        self.assertIsNone(task)
+        self.assertEqual(err, 'Session is no longer running')
+        run.assert_called_once_with(
+            ['tmux', 'has-session', '-t', 'kube-coder-task-1'], capture_output=True, text=True)
+
+    def test_interrupt_returns_not_found_without_running_tmux(self):
+        with mock.patch.object(server.subprocess, 'run') as run:
+            task, err = server.ClaudeTaskManager.interrupt_task('missing')
+
+        self.assertIsNone(task)
+        self.assertEqual(err, 'Task not found')
+        run.assert_not_called()
+
+
+class InterruptEndpointTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.old_auth_mode = server.AUTH_MODE
+        server.AUTH_MODE = 'basic'
+        cls.port = _free_port()
+        cls.httpd = http.server.ThreadingHTTPServer(('127.0.0.1', cls.port), server.BrowserHandler)
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+        server.AUTH_MODE = cls.old_auth_mode
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.old_tasks_dir = server.ClaudeTaskManager.TASKS_DIR
+        server.ClaudeTaskManager.TASKS_DIR = self.tmp.name
+        task_dir = os.path.join(self.tmp.name, 'task-1')
+        os.makedirs(task_dir)
+        self.meta = {'task_id': 'task-1', 'status': 'running', 'tmux_session': 'kube-coder-task-1'}
+        with open(os.path.join(task_dir, 'task.json'), 'w') as f:
+            json.dump(self.meta, f)
+
+    def tearDown(self):
+        server.ClaudeTaskManager.TASKS_DIR = self.old_tasks_dir
+        self.tmp.cleanup()
+
+    def test_post_interrupt_returns_task_metadata(self):
+        with mock.patch.object(server.subprocess, 'run', side_effect=[_result(), _result()]) as run:
+            with _post(f'http://127.0.0.1:{self.port}/api/claude/tasks/task-1/interrupt') as response:
+                self.assertEqual(response.status, 200)
+                self.assertEqual(json.loads(response.read()), self.meta)
+
+        self.assertEqual(run.call_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/web/src/api/tasks.ts
+++ b/charts/workspace/web/src/api/tasks.ts
@@ -120,6 +120,10 @@ export const createTask = (input: CreateTaskInput) => apiPost<TaskDetail>('/api/
 export const sendMessage = (id: string, prompt: string, submit = true) =>
   apiPost<TaskDetail>(`/api/claude/tasks/${id}/message`, { prompt, submit });
 
+/** Send Escape to the live assistant session without killing the task. */
+export const interruptTask = (id: string) =>
+  apiPost<TaskDetail>(`/api/claude/tasks/${id}/interrupt`, {});
+
 export const renameTask = (id: string, name: string) =>
   apiPost<TaskDetail>(`/api/claude/tasks/${id}/rename`, { name });
 

--- a/charts/workspace/web/src/routes/tasks/MessageChat.test.tsx
+++ b/charts/workspace/web/src/routes/tasks/MessageChat.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/preact';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  interruptTask: vi.fn(),
+  sendFollowup: vi.fn(),
+  pushToast: vi.fn(),
+}));
+
+vi.mock('../../api/tasks', () => ({ interruptTask: mocks.interruptTask }));
+vi.mock('../../store/tasks', () => ({ sendFollowup: mocks.sendFollowup }));
+vi.mock('../../store/ui', () => ({ pushToast: mocks.pushToast }));
+vi.mock('./TerminalPane', () => ({ TerminalPane: () => <div title="Task terminal" /> }));
+vi.mock('./sessionSignals', () => ({
+  getSessionSignals: () => ({
+    pasteRequest: { value: null },
+    imagePasteRequest: { value: null },
+  }),
+}));
+vi.mock('./imageAttach', () => ({
+  imagesFromClipboard: () => [],
+  isImageFile: () => false,
+  uploadTaskImage: vi.fn(),
+}));
+
+import { serverMode } from '../../store/server-mode';
+import { MessageChat } from './MessageChat';
+
+beforeEach(() => {
+  mocks.interruptTask.mockReset();
+  mocks.interruptTask.mockResolvedValue({ task_id: 'task-1', status: 'running' });
+  mocks.pushToast.mockReset();
+  serverMode.value = { readOnly: false, authed: true, authMode: 'basic', demoShowAll: false };
+});
+
+describe('MessageChat interrupt button', () => {
+  it('interrupts a running task', async () => {
+    render(<MessageChat taskId="task-1" status="running" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /stop/i }));
+
+    await waitFor(() => expect(mocks.interruptTask).toHaveBeenCalledWith('task-1'));
+    expect(mocks.pushToast).toHaveBeenCalledWith('Interrupt sent', { kind: 'warn' });
+  });
+
+  it('hides Stop when the task is not actively running', () => {
+    render(<MessageChat taskId="task-1" status="waiting-for-input" />);
+
+    expect(screen.queryByRole('button', { name: /stop/i })).toBeNull();
+  });
+
+  it('shows Stop disabled in a read-only deployment', () => {
+    serverMode.value = { readOnly: true, authed: true, authMode: 'basic', demoShowAll: false };
+    render(<MessageChat taskId="task-1" status="running" />);
+
+    const stop = screen.getByRole('button', { name: /stop/i });
+    expect(stop).toBeDisabled();
+    fireEvent.click(stop);
+    expect(mocks.interruptTask).not.toHaveBeenCalled();
+  });
+});

--- a/charts/workspace/web/src/routes/tasks/MessageChat.tsx
+++ b/charts/workspace/web/src/routes/tasks/MessageChat.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
-import type { TaskStatus } from '../../api/tasks';
+import { interruptTask, type TaskStatus } from '../../api/tasks';
 import { sendFollowup } from '../../store/tasks';
 import { pushToast } from '../../store/ui';
 import { Button } from '../../components/primitives/Button';
@@ -48,6 +48,7 @@ export function MessageChat({ taskId, status }: MessageChatProps) {
 
   const [msg, setMsg] = useState('');
   const [busy, setBusy] = useState(false);
+  const [interrupting, setInterrupting] = useState(false);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [dragOver, setDragOver] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -179,6 +180,19 @@ export function MessageChat({ taskId, status }: MessageChatProps) {
     }
   }
 
+  async function onInterrupt() {
+    if (status !== 'running' || readOnly || interrupting) return;
+    setInterrupting(true);
+    try {
+      await interruptTask(taskId);
+      pushToast('Interrupt sent', { kind: 'warn' });
+    } catch (err) {
+      pushToast(err instanceof Error ? err.message : 'Interrupt failed', { kind: 'danger' });
+    } finally {
+      setInterrupting(false);
+    }
+  }
+
   function onKey(e: KeyboardEvent) {
     // Cmd/Ctrl+Enter sends; plain Enter inserts a newline.
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
@@ -270,6 +284,18 @@ export function MessageChat({ taskId, status }: MessageChatProps) {
             >
               <Icon name="image" size={14} />
             </Button>
+            {status === 'running' && (
+              <Button
+                type="button"
+                variant="danger"
+                size="sm"
+                disabled={interrupting || readOnly}
+                title="Interrupt the current assistant turn"
+                onClick={onInterrupt}
+              >
+                <Icon name="close" size={12} /> Stop
+              </Button>
+            )}
             <Button
               type="submit"
               variant="primary"


### PR DESCRIPTION
## Summary

- add a task interrupt endpoint that safely sends Escape to the live tmux session
- add a Stop button to the Send message composer for running tasks
- cover the endpoint and composer states with backend and frontend tests

## Why

The Send message tab had no way to interrupt an active Claude turn without switching to the raw Session terminal.

## Validation

- backend interrupt tests pass
- frontend test suite: 220 tests passed
- TypeScript check and production build pass
