### PR TITLE
fix(github-auth): scrub stale http.<github>.extraheader on boot so it can't wedge git

### DIFF
--- a/charts/workspace/start.sh
+++ b/charts/workspace/start.sh
@@ -128,6 +128,25 @@ tmux source-file /home/dev/.tmux.conf 2>/dev/null || true
 # Runs in READONLY_MODE too — the readonly gate is for *runtime* mutations
 # from HTTP clients, not boot-time setup. The public demo needs the docs
 # tree at /home/dev/kube-coder/docs/ to populate the in-app /docs route.
+# github.com auth in this workspace is ALWAYS brokered by the credential helper
+# (the App token, or the user's own `gh` in personal mode) — never a raw
+# per-repo `http.<url>.extraheader`. A stale extraheader is a known footgun: a
+# prior in-workspace git session (an agent fumbling auth) can persist one with a
+# now-dead token into a repo's local config, and because an extraheader wins
+# over the helper it then breaks EVERY git op in that repo (fetch/pull/push all
+# 401), even though the helper is perfectly healthy. Scrub any such stale header
+# from the workspace's own kube-coder clone AND the global config on every boot
+# so this self-heals instead of wedging the user. Safe to always remove: we
+# never legitimately set one for github.com.
+# Target the workspace's persisted global config file directly (the interactive
+# terminals' ~/.gitconfig symlinks here), not `--global` — start.sh's own $HOME
+# may differ from the terminal user's.
+git config --file /home/dev/.credentials/.config/git/config \
+  --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+if [ -d /home/dev/kube-coder/.git ]; then
+  git -C /home/dev/kube-coder config --unset-all http.https://github.com/.extraheader 2>/dev/null || true
+fi
+
 (
   if [ ! -d /home/dev/kube-coder/.git ]; then
     log_stage "cloning kube-coder source into /home/dev/kube-coder"


### PR DESCRIPTION
## Symptom

A workspace user reports "GitHub is broken after the latest update" — every git op in a repo 401s (fetch / pull / push), even though the credential helper is healthy and `curl` to the GitHub API returns 200. An in-workspace agent burned ~20 steps fighting it.

## Root cause (NOT the auth updates)

A raw per-repo `http.https://github.com/.extraheader` carrying a **now-dead token**. github.com auth in this workspace is *always* brokered by the credential helper (the App token, or the user's own `gh` in personal mode — #265) — kube-coder **never** sets an `extraheader` (confirmed: `grep -r extraheader charts/` and `git log -S extraheader` are both empty). But a prior in-workspace git session (e.g. an agent fumbling auth) can persist one into a repo's **local** config on the PVC, and because an `extraheader` **wins over the credential helper**, it then breaks that repo permanently.

Observed in the **`/home/dev/kube-coder` source clone** — exactly where an agent pulling the source to contribute works — so it reads as "GitHub is broken." The `#264`/`#265` auth changes were coincidental (they manage `credential.helper`, which works: authed `ls-remote` against a private repo succeeds; the `403 /user` the earlier debugging saw is normal for a bot/App token).

## Fix

`start.sh` now scrubs any `http.https://github.com/.extraheader` from **both** the workspace's persisted global git config and the kube-coder clone on every boot, before the clone refresh — so this class of failure **self-heals** instead of wedging the user. Safe to always remove (we never legitimately set one for github.com); best-effort, never fails boot.

## Verification

- `helm template` renders `start.sh` with the scrub ordered before the clone-refresh block.
- Live-removed the stale header from imran-ws's clone → `git fetch` works again immediately (that user is unblocked now; this PR makes it durable + fleet-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
