### PR TITLE
chore(resources): right-size workspace CPU requests (350m → 150m/pod)

### DIFF
--- a/charts/workspace/templates/deployment.yaml
+++ b/charts/workspace/templates/deployment.yaml
@@ -339,8 +339,12 @@ spec:
         # Resource caps prevent a runaway `docker build` (fork bomb,
         # 10GB layer, etc.) from starving every other workspace on the
         # node. Override per-workspace via .Values.build.dindResources.
+        # The dind daemon idles near-zero when no build is running, so its
+        # CPU REQUEST (scheduler reservation) is small (50m) — it bursts to
+        # the 2-core limit during a build. A large request just strands node
+        # capacity (see the ide `resources` note in values.yaml).
         resources:
-{{ toYaml (.Values.build.dindResources | default (dict "requests" (dict "cpu" "100m" "memory" "256Mi") "limits" (dict "cpu" "2" "memory" "4Gi"))) | indent 10 }}
+{{ toYaml (.Values.build.dindResources | default (dict "requests" (dict "cpu" "50m" "memory" "256Mi") "limits" (dict "cpu" "2" "memory" "4Gi"))) | indent 10 }}
         volumeMounts:
         - name: docker-certs
           mountPath: /certs/client

--- a/charts/workspace/tests/resourcequota_test.yaml
+++ b/charts/workspace/tests/resourcequota_test.yaml
@@ -4,7 +4,7 @@ templates:
 tests:
   - it: derives the quota from the pod's resources (default kaniko workspace)
     # ide 4Gi/2 (chart default), no dind. limits = ide + overhead (2000m/4096Mi);
-    # requests = ide requests 250m/1Gi + overheadReq (500m/1024Mi).
+    # requests = ide requests 100m/1Gi + overheadReq (500m/1024Mi).
     set:
       user.name: alice
       namespace: ws-alice
@@ -20,7 +20,7 @@ tests:
           value: ws-alice
       - equal:
           path: spec.hard["requests.cpu"]
-          value: "750m"
+          value: "600m"
       - equal:
           path: spec.hard["requests.memory"]
           value: 2048Mi

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -153,7 +153,14 @@ update:
 # values.yaml rather than raising this shared default.
 resources:
   requests:
-    cpu: "250m"
+    # CPU request is the SCHEDULER RESERVATION, not a usage cap (that's limits).
+    # An idle workspace (code-server + server.py) sits well under 100m and
+    # bursts to the 2-core limit on demand regardless of this floor, so a high
+    # request just strands node capacity as unschedulable reservation. Kept low
+    # (100m) so nodes pack efficiently; a workspace that needs a guaranteed
+    # higher baseline overrides this in its own values.yaml. See #95 / the
+    # node-pool over-reservation that wedged scheduling at ~96% requested.
+    cpu: "100m"
     memory: 1Gi
   limits:
     cpu: "2"


### PR DESCRIPTION
## Problem

Workspace scheduling was wedging with `0/N nodes available: Insufficient cpu` — an **outage with no real load behind it**. All nodes sat at **~95–99% CPU *requested*** while limits were overcommitted **280–550%** (cluster idle, but "full" on reservations). A pod that needed to reschedule (e.g. after a version update) couldn't be placed.

## Root cause

CPU **request** is the scheduler *reservation*, not a usage cap (limits are the cap). An idle `ide` (code-server + server.py) sits well under 100m and bursts to its 2-core limit on demand regardless of the request; `dind` idles near-zero when no build runs. The old requests (**ide 250m + dind 100m = 350m/pod**) just stranded node capacity as unschedulable reservation.

## Change

| container | request (cpu) | was → now |
|---|---|---|
| ide (`.Values.resources`) | 250m → **100m** | |
| dind (`build.dindResources` default) | 100m → **50m** | |

Per-pod reservation drops **350m → 150m (~57%)** → ~2.3× more workspaces pack onto the same nodes. **Limits and memory are unchanged**, so real burst capacity is untouched. The per-namespace ResourceQuota auto-derives from these requests, so it tightens automatically. A workspace needing a higher guaranteed floor still overrides in its own values.yaml.

## Paired infra change (already applied)

Enabled autoscaling on the DOKS `pool-16gb-amd` node pool (**was off**, fixed 4 nodes → **min 5 / max 7**) so the cluster can add headroom instead of wedging. This PR reduces how often that headroom is actually needed (and thus cost).

Delivered to existing workspaces on their next deploy / self-serve update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
