### PR TITLE
fix(skills): wire skills/commands.py into the configmap (fixes Skills 503 on v1.31.0)

### DIFF
--- a/charts/workspace/start.sh
+++ b/charts/workspace/start.sh
@@ -728,6 +728,7 @@ install -m 0644 /browser-config/skills__init__.py            /tmp/browser/skills
 install -m 0644 /browser-config/skills_model.py              /tmp/browser/skills/model.py
 install -m 0644 /browser-config/skills_parser.py             /tmp/browser/skills/parser.py
 install -m 0644 /browser-config/skills_sync.py               /tmp/browser/skills/sync.py
+install -m 0644 /browser-config/skills_commands.py           /tmp/browser/skills/commands.py
 install -m 0644 /browser-config/skills_providers__init__.py  /tmp/browser/skills/providers/__init__.py
 install -m 0644 /browser-config/skills_providers_claude.py   /tmp/browser/skills/providers/claude.py
 install -m 0644 /browser-config/skills_providers_opencode.py /tmp/browser/skills/providers/opencode.py

--- a/charts/workspace/templates/browser-configmap.yaml
+++ b/charts/workspace/templates/browser-configmap.yaml
@@ -44,6 +44,8 @@ data:
 {{ .Files.Get "skills/parser.py" | indent 4 }}
   skills_sync.py: |
 {{ .Files.Get "skills/sync.py" | indent 4 }}
+  skills_commands.py: |
+{{ .Files.Get "skills/commands.py" | indent 4 }}
   skills_providers__init__.py: |
 {{ .Files.Get "skills/providers/__init__.py" | indent 4 }}
   skills_providers_claude.py: |


### PR DESCRIPTION
The Skills page 503s on v1.31.0. #304 added `skills/commands.py` + a module-scope `from skills.commands import discover_commands` in server.py, but never wired commands.py into `browser-configmap.yaml` / the start.sh reassembly. On redeploy the skills package is missing commands.py → import fails → `_SKILLS_AVAILABLE=false` → every `/api/skills*` route returns **503** ("skills subsystem unavailable").

**Fix:** add the `skills_commands.py` configmap key + the matching `install` line in start.sh. Config-only (ConfigMap + start.sh), reaches workspaces via helm reconcile — no image rebuild. Verified with `helm template`. Affects every workspace already on v1.31.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)