### PR TITLE
ci(security): blocking SCA (audit-ci + pip-audit) + SBOM generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,18 +202,38 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
 
-      - name: SCA Scanning (JavaScript/TypeScript)
-        run: |
-          # The SPA uses yarn classic (yarn.lock, no package-lock.json), so
-          # `npm audit` aborted with ENOLOCK and scanned nothing. yarn audit
-          # reads yarn.lock directly. It exits non-zero when advisories exist,
-          # so keep the `|| echo` to stay non-blocking.
-          cd charts/workspace/web
-          yarn audit --level high || echo "Vulnerabilities found"
+      - name: Generate SBOM (Syft)
+        # SPDX-JSON software bill of materials for the built image, uploaded as
+        # a CI artifact. Runs regardless of the scan result so the SBOM is
+        # always available for triage.
+        uses: anchore/sbom-action@v0.24.0
         if: success() || failure()
+        with:
+          image: kube-coder-ci:latest
+          format: spdx-json
+          output-file: kube-coder-sbom.spdx.json
+          artifact-name: kube-coder-sbom.spdx.json
 
-      - name: SCA Scanning (Python)
-        run: |
-          pip install safety
-          safety check --full-report || echo "Vulnerabilities found"
+      - name: SCA Scanning (SPA dependencies)
+        # yarn-classic advisories via audit-ci (blocking). Gates on high+
+        # severity; the per-package audit-ci.jsonc allowlist covers dev/build-
+        # time advisories that don't ship in the runtime image (tracked for
+        # upgrade by Renovate). See docs/SUPPLY_CHAIN.md.
         if: success() || failure()
+        run: |
+          set -euo pipefail
+          for dir in charts/workspace/web charts/workspace-controller/web; do
+            echo "::group::audit-ci ${dir}"
+            (cd "${dir}" && npx --yes audit-ci@^7 --config audit-ci.jsonc)
+            echo "::endgroup::"
+          done
+
+      - name: SCA Scanning (Python dependencies)
+        # pip-audit (PyPA, OSV-backed, no account required) over the pinned
+        # runtime deps (blocking). Replaces the former `safety check`, which
+        # scanned only the runner's own install — the app is stdlib-only apart
+        # from these. Allowlist unfixable advisories with `--ignore-vuln <ID>`.
+        if: success() || failure()
+        run: |
+          python -m pip install --upgrade pip-audit
+          pip-audit -r devlaptop/requirements.txt --desc

--- a/charts/workspace-controller/web/audit-ci.jsonc
+++ b/charts/workspace-controller/web/audit-ci.jsonc
@@ -1,0 +1,18 @@
+{
+  // Blocking SCA gate for the controller SPA (yarn classic). Fails CI on
+  // high/critical advisories. See docs/SUPPLY_CHAIN.md.
+  //
+  // Same rationale as the dashboard SPA config: the allowlisted advisories are
+  // build/test-time devDependencies (vite / vitest / happy-dom) that never ship
+  // in the runtime image. Renovate proposes the upgrades weekly; prune an entry
+  // once the corresponding dep is bumped past its patched version.
+  "high": true,
+  "allowlist": [
+    "GHSA-37j7-fg3j-429f", // happy-dom  <20.0.0   VM context escape
+    "GHSA-w4gp-fjgq-3q4g", // happy-dom  <20.8.9   fetch credentials
+    "GHSA-6q6h-j7hj-3r64", // happy-dom  <20.8.8   ESM compiler
+    "GHSA-5xrq-8626-4rwp", // vitest     <3.2.6    UI server RCE
+    "GHSA-fx2h-pf6j-xcff"  // vite       <6.4.3    server.fs.deny bypass (Windows)
+  ],
+  "report-type": "summary"
+}

--- a/charts/workspace/web/audit-ci.jsonc
+++ b/charts/workspace/web/audit-ci.jsonc
@@ -1,0 +1,20 @@
+{
+  // Blocking SCA gate for the dashboard SPA (yarn classic). Fails CI on
+  // high/critical advisories. See docs/SUPPLY_CHAIN.md.
+  //
+  // The allowlisted advisories below are all in build/test-time
+  // devDependencies (vite dev server, vitest UI, happy-dom test DOM). None
+  // ship in the runtime image, which carries only the built static assets —
+  // so they are not reachable in the deployed artifact. Patched versions
+  // exist; Renovate proposes the upgrades weekly. Prune an entry once the
+  // corresponding dep is bumped past its patched version.
+  "high": true,
+  "allowlist": [
+    "GHSA-37j7-fg3j-429f", // happy-dom  <20.0.0   VM context escape
+    "GHSA-w4gp-fjgq-3q4g", // happy-dom  <20.8.9   fetch credentials
+    "GHSA-6q6h-j7hj-3r64", // happy-dom  <20.8.8   ESM compiler
+    "GHSA-5xrq-8626-4rwp", // vitest     <3.2.6    UI server RCE
+    "GHSA-fx2h-pf6j-xcff"  // vite       <6.4.3    server.fs.deny bypass (Windows)
+  ],
+  "report-type": "summary"
+}

--- a/devlaptop/Dockerfile
+++ b/devlaptop/Dockerfile
@@ -216,9 +216,11 @@ RUN ARCH=$(dpkg --print-architecture) \
 # Python deps for memory-system embeddings (Voyage AI / OpenAI) and HTTP
 # retries. Installed eagerly so Phase 2 activation needs only a value flip.
 # --break-system-packages is required on Ubuntu 24.04 (PEP 668).
-RUN pip3 install --break-system-packages --no-cache-dir \
-    voyageai==0.4.0 \
-    httpx==0.28.1
+# Pins live in devlaptop/requirements.txt (single source of truth: the image
+# installs from it and CI pip-audits it). Build context is the repo root.
+COPY devlaptop/requirements.txt /tmp/requirements.txt
+RUN pip3 install --break-system-packages --no-cache-dir -r /tmp/requirements.txt \
+    && rm -f /tmp/requirements.txt
 
 # Install browser with noVNC for web access.
 # `file` lets the post-download tarball check below work.

--- a/devlaptop/requirements.txt
+++ b/devlaptop/requirements.txt
@@ -1,0 +1,9 @@
+# Runtime Python dependencies for the devlaptop image.
+#
+# The dashboard (server.py) and controller (controller.py) are otherwise
+# stdlib-only; these two packages back the memory-system embeddings
+# (Voyage AI / OpenAI) and HTTP retries. This file is the single source of
+# truth — the image installs from it (devlaptop/Dockerfile) and CI runs
+# pip-audit against it (.github/workflows/ci.yml). Renovate keeps it bumped.
+voyageai==0.4.0
+httpx==0.28.1

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -72,9 +72,42 @@ Two artifacts have no datasource Renovate can track and are bumped by hand
   at `https://product-details.mozilla.org/1.0/firefox_versions.json`
   (`LATEST_FIREFOX_VERSION`).
 
-## Remaining work (follow-up PRs on #104)
+## Software Composition Analysis (SCA)
 
-- [ ] **Blocking SCA** — make `yarn audit` / `safety` in `ci.yml` fail the build
-      at a chosen severity, with a curated allowlist (mirrors `.trivyignore`).
-- [ ] **SBOM** — generate with Syft in CI and attach to releases.
-- [ ] **Signing** — cosign keyless image signing + provenance attestation.
+CI fails on high/critical dependency advisories, with curated allowlists for
+accepted/unfixable cases (the `.trivyignore` pattern, applied to source deps):
+
+| Layer | Tool | Gate | Allowlist |
+|-------|------|------|-----------|
+| SPA deps (yarn classic) | `audit-ci` | high+ | `charts/*/web/audit-ci.jsonc` (GHSA IDs) |
+| Python deps | `pip-audit` | any | `--ignore-vuln <ID>` in `ci.yml` |
+| Image (OS + Python + Node CLIs) | Trivy | CRITICAL/HIGH | `.trivyignore` + `ignore-unfixed` |
+
+Notes:
+- The SPA allowlist currently holds five **dev/build-time** advisories
+  (vite / vitest / happy-dom) that never ship in the runtime image, which
+  carries only built static assets. Renovate proposes their upgrades weekly;
+  prune each entry once the dep is bumped past its patched version.
+- Python runtime deps are pinned in **`devlaptop/requirements.txt`** — the
+  single source of truth the image installs from *and* CI audits. The app is
+  otherwise stdlib-only.
+- **`pip-audit`** (PyPA, OSV-backed, no account) replaces the former
+  `safety check`, which required an account for its DB and, without a target
+  file, scanned only the runner's own install rather than the project.
+
+## Software Bill of Materials (SBOM)
+
+CI generates an SPDX-JSON SBOM of the built image with Syft
+(`anchore/sbom-action`) and uploads it as the `kube-coder-sbom.spdx.json`
+artifact on every run.
+
+## Remaining work (follow-up on #104)
+
+- [ ] **Image signing** — cosign keyless signing + provenance/SBOM attestation.
+      Blocked on a publish pipeline: CI builds with `push: false` (smoke test)
+      and images ship via `make push` (kaniko → the DigitalOcean registry), so
+      there is no CI-pushed digest to sign. Recommended next step: add a
+      publish-and-sign job (e.g. push to GHCR on tags using the built-in
+      `GITHUB_TOKEN`, then `cosign sign` + `cosign attest` the SBOM), or wire
+      cosign into `scripts/buildx-push.sh`. Needs a maintainer decision on
+      publish topology before wiring.


### PR DESCRIPTION
## Summary
Second slice of #104 — makes dependency scanning **block** the build (chosen severity + curated allowlists) and emits an **SBOM** for the built image.

> **Stacked on #314** (base = `sc-hardening-104`). GitHub will auto-retarget this to `main` once #314 merges. Review/merge #314 first.

## Blocking SCA
| Layer | Tool | Gate | Allowlist |
|-------|------|------|-----------|
| SPA deps (yarn classic) | `audit-ci@7` | high+ | `charts/*/web/audit-ci.jsonc` |
| Python deps | `pip-audit` | any | `--ignore-vuln` in `ci.yml` |
| Image (already present) | Trivy | CRITICAL/HIGH | `.trivyignore` + `ignore-unfixed` |

- **SPA:** replaces the non-blocking `yarn audit || echo` with `audit-ci` over **both** SPAs (CI previously audited only the dashboard). The 5 allowlisted GHSAs are all **dev/build-time** deps (vite/vitest/happy-dom) that never land in the runtime image (which ships only built static assets); Renovate (#314) tracks their upgrades. Each entry is commented with package + patched version.
- **Python:** extracts the two runtime pins (`voyageai`, `httpx`) into **`devlaptop/requirements.txt`** as the single source of truth — the image now installs from it and CI audits it. Replaces the former `safety check`, which needed an account and (with no target file) scanned only the runner's own install rather than the project. `pip-audit` is the auth-free PyPA/OSV equivalent; both deps are currently clean per OSV.

## SBOM
`anchore/sbom-action` generates an SPDX-JSON SBOM of the built image and uploads it as the `kube-coder-sbom.spdx.json` CI artifact.

## Deferred (documented in `docs/SUPPLY_CHAIN.md`)
**cosign signing** — CI builds with `push: false` (smoke test) and images ship via `make push` (kaniko → DO registry), so there's no CI-pushed digest to sign. Recommended next step: a publish-and-sign job (push to GHCR on tags using the built-in `GITHUB_TOKEN`, then `cosign sign` + `cosign attest` the SBOM), or wire cosign into `scripts/buildx-push.sh`. Needs a maintainer call on publish topology first — happy to do it as PR #3 once you decide.

## Verification
- `actionlint` + YAML parse → clean ✅
- `audit-ci` → **green on both SPAs** (5 advisories allowlisted, correctly surfaces a below-gate moderate dompurify) ✅
- `docker buildx build --check` → no warnings ✅
- `pip-audit` deps → 0 vulns via OSV (`voyageai 0.4.0`, `httpx 0.28.1` + transitives) ✅

Refs #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Reopened from #315 (auto-closed when the stacked base branch \`sc-hardening-104\` was deleted on merge of #314); rebased onto main._
