### PR TITLE
fix(release): fire signed-GHCR workflow on v* tags (not devlaptop-v*)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,10 @@
 # keyless cosign (Sigstore OIDC — no long-lived keys, logged to Rekor) plus
 # BuildKit-native SBOM and SLSA provenance attestations.
 #
-# Fires on the repo's release tags (`devlaptop-v*`, cut from green main by
-# scripts/release.sh). This is additive: the DigitalOcean deploy image still
+# Fires on the repo's release tags — `v<X.Y.Z>`, cut from green main by
+# scripts/release.sh (`TAG="$VER"`). NB: `devlaptop-v<X.Y.Z>` is the *image* tag,
+# NOT the git tag, so the trigger + metadata pattern below key off `v*`. This is
+# additive: the DigitalOcean deploy image still
 # ships via `make push`; GHCR is the signed, attested, publicly-verifiable
 # artifact. No secrets required — the built-in GITHUB_TOKEN pushes to GHCR and
 # the OIDC id-token mints the signing certificate.
@@ -19,7 +21,8 @@ name: release
 
 on:
   push:
-    tags: ["devlaptop-v*"]
+    # Release tags are `v1.2.3` (git tag), not `devlaptop-v1.2.3` (image tag).
+    tags: ["v[0-9]*"]
   workflow_dispatch:
     inputs:
       dryRun:
@@ -68,9 +71,9 @@ jobs:
         uses: docker/metadata-action@v6.2.0
         with:
           images: ${{ env.IMAGE }}
-          # devlaptop-v1.2.3 -> 1.2.3 ; also a long-sha tag; latest on tag push.
+          # v1.2.3 -> 1.2.3 ; also a long-sha tag; latest on tag push.
           tags: |
-            type=match,pattern=devlaptop-v(.*),group=1
+            type=match,pattern=v(.*),group=1
             type=sha,format=long
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 


### PR DESCRIPTION
## Bug

`.github/workflows/release.yml` (added in #316) triggers on `devlaptop-v*` tags and extracts the version with `type=match,pattern=devlaptop-v(.*)`. But `devlaptop-v<X.Y.Z>` is the **image** tag — `scripts/release.sh` creates **git tags named `v<X.Y.Z>`** (`TAG="$VER"`). So the workflow **never fires on a real release**, and the cosign-signed / SBOM / SLSA GHCR image is never published.

**Caught it live:** cutting **v1.32.1** (the first tag after #316 merged) did not trigger `release.yml` — zero runs.

## Fix

- Trigger: `tags: ["devlaptop-v*"]` → `["v[0-9]*"]`
- metadata-action: `pattern=devlaptop-v(.*)` → `pattern=v(.*)` (so `v1.32.1 → 1.32.1`)
- Corrected the header comment (git tag vs image tag).

## After merge

The **next** release tag will fire the workflow (v1.32.1's tag already exists and won't re-fire). That first green run is the prerequisite in #320 (make the GHCR package public).

Follow-up to #316 / #104.