### PR TITLE
feat(gateway): declarative WhatsApp provider registry (#328)

### DIFF
--- a/charts/workspace/adapters/whatsapp.py
+++ b/charts/workspace/adapters/whatsapp.py
@@ -35,8 +35,8 @@ import json
 import os
 import urllib.parse
 import urllib.request
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from gateway import (Capabilities, DeliveryResult, InboundMessage, MediaItem,
                     OutboundMessage, RawRequest, chunk_text)
@@ -90,10 +90,80 @@ def render_choice(options: List[str], caps: Capabilities) -> InteractiveSpec:
 
 
 # ───────────────────────────────────────────────────────────────────────────
+# Provider catalog — declarative spec (issue #328)
+# ───────────────────────────────────────────────────────────────────────────
+# Each provider declares WHAT it needs (credential fields + sender field) and
+# WHAT it can do (Capabilities) as data. A registry maps provider_id → (spec,
+# adapter factory), so `build_provider(id, creds)` constructs a provider from a
+# flat creds dict and `list_providers()` exposes the specs. The spec is fully
+# JSON-serializable (via to_dict) — the Settings form in stage 3 is rendered
+# entirely from it, so adding a provider is a new adapter class + one
+# register_provider(...) call, never a UI or core change.
+@dataclass
+class CredentialField:
+    """One credential the user must supply for a provider. Also the schema the
+    stage-3 Settings form renders from and the key the stage-2 store persists
+    under, so `key` doubles as the creds-dict / storage key."""
+    key: str                    # creds-dict key AND future storage key
+    label: str                  # UI label
+    secret: bool = True         # masked in UI; redacted in stage-2 public_view()
+    placeholder: str = ''
+    help_url: str = ''
+    required: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'key': self.key,
+            'label': self.label,
+            'secret': self.secret,
+            'placeholder': self.placeholder,
+            'help_url': self.help_url,
+            'required': self.required,
+        }
+
+
+@dataclass
+class ProviderSpec:
+    """Declarative description of a messaging provider — its identity, the
+    credential fields it needs, its sending-identity field, and its
+    Capabilities. Serializable so the UI is data-driven."""
+    id: str                             # 'twilio' | 'meta'
+    display_name: str
+    credential_fields: List[CredentialField]
+    sender_field: CredentialField       # provider-specific sending identity
+    capabilities: Capabilities
+
+    def field_keys(self) -> List[str]:
+        """Every creds-dict key this provider consumes (credentials + sender)."""
+        return [f.key for f in self.credential_fields] + [self.sender_field.key]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'display_name': self.display_name,
+            'credential_fields': [f.to_dict() for f in self.credential_fields],
+            'sender_field': self.sender_field.to_dict(),
+            'capabilities': asdict(self.capabilities),
+        }
+
+
+# WhatsApp platform capabilities are the same across providers EXCEPT proactive:
+# out-of-window sends need an approved template, which the real Meta Cloud API
+# supports but the Twilio sandbox does not.
+_WA_CAPS = dict(buttons=True, max_buttons=3, max_list_rows=10, media=True,
+                typing_indicator=True, max_text_len=WHATSAPP_MAX_TEXT)
+TWILIO_CAPS = Capabilities(proactive=False, **_WA_CAPS)
+META_CAPS = Capabilities(proactive=True, **_WA_CAPS)
+
+
+# ───────────────────────────────────────────────────────────────────────────
 # Provider seam
 # ───────────────────────────────────────────────────────────────────────────
 class _Provider:
     name = 'base'
+    # Providers declare their capabilities as a class attribute; the adapter
+    # reads provider.capabilities instead of branching on the provider type.
+    capabilities: Capabilities = Capabilities()
 
     def verify(self, raw: RawRequest) -> bool:
         raise NotImplementedError
@@ -116,6 +186,7 @@ class TwilioProvider(_Provider):
     quick-reply. Signature: base64(HMAC-SHA1(AuthToken, URL + sorted k+v))."""
 
     name = 'twilio'
+    capabilities = TWILIO_CAPS
 
     def __init__(self, *, auth_token: str = '', account_sid: str = '',
                  from_number: str = ''):
@@ -234,6 +305,7 @@ class MetaProvider(_Provider):
     body) — already matches kube-coder's generic verifier."""
 
     name = 'meta'
+    capabilities = META_CAPS
     GRAPH = 'https://graph.facebook.com/v19.0'
 
     def __init__(self, *, app_secret: str = '', verify_token: str = '',
@@ -427,14 +499,10 @@ class WhatsAppAdapter:
 
     def __init__(self, provider: Optional[_Provider] = None):
         self.provider = provider or _provider_from_env()
-        self.capabilities = Capabilities(
-            buttons=True, max_buttons=3, max_list_rows=10, media=True,
-            typing_indicator=True,
-            # Free-form only inside the 24-h window; proactive out-of-window
-            # requires an approved template — which we CAN do on the real Cloud
-            # API (Meta), but not the Twilio sandbox. Advertise per provider.
-            proactive=isinstance(self.provider, MetaProvider),
-            max_text_len=WHATSAPP_MAX_TEXT)
+        # Capabilities are declared by the provider (proactive out-of-window
+        # sends need an approved template — Meta Cloud API only, not the Twilio
+        # sandbox), so the adapter reads them rather than branching on type.
+        self.capabilities = self.provider.capabilities
 
     def verify(self, raw: RawRequest) -> bool:
         return self.provider.verify(raw)
@@ -449,17 +517,126 @@ class WhatsAppAdapter:
         return self.provider.send(msg, self.capabilities)
 
 
+# ───────────────────────────────────────────────────────────────────────────
+# Provider registry (issue #328)
+# ───────────────────────────────────────────────────────────────────────────
+# provider_id → (spec, factory). The factory maps a flat creds dict (keyed by
+# the spec's CredentialField.key values) onto the provider's kwargs constructor.
+DEFAULT_PROVIDER_ID = 'twilio'
+_ProviderFactory = Callable[[Dict[str, str]], _Provider]
+_REGISTRY: 'Dict[str, Tuple[ProviderSpec, _ProviderFactory]]' = {}
+
+
+def register_provider(spec: ProviderSpec, factory: _ProviderFactory) -> None:
+    """Register a provider so build_provider/list_providers can see it. Called
+    at import time; adding a provider is a new adapter class + one call here."""
+    _REGISTRY[spec.id] = (spec, factory)
+
+
+def list_providers() -> List[ProviderSpec]:
+    """All registered provider specs, in registration order (data for the UI)."""
+    return [spec for spec, _factory in _REGISTRY.values()]
+
+
+def get_provider_spec(provider_id: str) -> Optional[ProviderSpec]:
+    entry = _REGISTRY.get((provider_id or '').strip().lower())
+    return entry[0] if entry else None
+
+
+def build_provider(provider_id: str,
+                   creds: Optional[Dict[str, str]] = None) -> _Provider:
+    """Construct a provider from its id + a flat creds dict. Raises ValueError
+    on an unknown id so API callers (stage 2) fail loudly; env callers normalize
+    the id first so they never hit that path."""
+    entry = _REGISTRY.get((provider_id or '').strip().lower())
+    if entry is None:
+        raise ValueError(f'unknown provider: {provider_id!r}')
+    _spec, factory = entry
+    return factory(creds or {})
+
+
+# -- Twilio -------------------------------------------------------------------
+TWILIO_SPEC = ProviderSpec(
+    id='twilio',
+    display_name='Twilio',
+    credential_fields=[
+        CredentialField(
+            key='account_sid', label='Account SID', secret=False,
+            placeholder='ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+            help_url='https://www.twilio.com/console'),
+        CredentialField(
+            key='auth_token', label='Auth Token', secret=True,
+            help_url='https://www.twilio.com/console'),
+    ],
+    sender_field=CredentialField(
+        key='from_number', label='WhatsApp sender number', secret=False,
+        placeholder='whatsapp:+14155238886',
+        help_url='https://www.twilio.com/docs/whatsapp'),
+    capabilities=TWILIO_CAPS,
+)
+
+
+def _twilio_factory(creds: Dict[str, str]) -> _Provider:
+    return TwilioProvider(
+        auth_token=creds.get('auth_token', ''),
+        account_sid=creds.get('account_sid', ''),
+        from_number=creds.get('from_number', ''))
+
+
+# -- Meta ---------------------------------------------------------------------
+META_SPEC = ProviderSpec(
+    id='meta',
+    display_name='Meta (WhatsApp Cloud API)',
+    credential_fields=[
+        CredentialField(
+            key='access_token', label='Access Token', secret=True,
+            help_url='https://developers.facebook.com/docs/whatsapp/cloud-api/get-started'),
+        CredentialField(
+            key='app_secret', label='App Secret', secret=True,
+            help_url='https://developers.facebook.com/docs/graph-api/webhooks/getting-started'),
+        CredentialField(
+            key='verify_token', label='Webhook Verify Token', secret=False,
+            placeholder='a token you choose',
+            help_url='https://developers.facebook.com/docs/graph-api/webhooks/getting-started'),
+    ],
+    # Meta's sending identity is the opaque Phone Number ID (the WABA sender),
+    # not a dialable number — so it lives here, not among the numbered fields.
+    sender_field=CredentialField(
+        key='phone_number_id', label='Phone Number ID', secret=False,
+        placeholder='1234567890',
+        help_url='https://developers.facebook.com/docs/whatsapp/cloud-api/get-started'),
+    capabilities=META_CAPS,
+)
+
+
+def _meta_factory(creds: Dict[str, str]) -> _Provider:
+    return MetaProvider(
+        app_secret=creds.get('app_secret', ''),
+        verify_token=creds.get('verify_token', ''),
+        phone_number_id=creds.get('phone_number_id', ''),
+        access_token=creds.get('access_token', ''))
+
+
+register_provider(TWILIO_SPEC, _twilio_factory)
+register_provider(META_SPEC, _meta_factory)
+
+
 def _provider_from_env() -> _Provider:
-    """Build the configured provider from env. KC_WHATSAPP_PROVIDER selects
-    twilio (default) or meta; each reads its own credential vars."""
+    """Build the configured provider from env, via the registry. Env stays a
+    valid source for platform-managed deployments. KC_WHATSAPP_PROVIDER selects
+    twilio (default) or meta; the id is normalized to a known provider before
+    build_provider, so this never raises on a bad value (any non-'meta' → twilio,
+    preserving the pre-#328 behavior)."""
     which = os.environ.get('KC_WHATSAPP_PROVIDER', 'twilio').strip().lower()
     if which == 'meta':
-        return MetaProvider(
-            app_secret=os.environ.get('KC_META_APP_SECRET', ''),
-            verify_token=os.environ.get('KC_META_VERIFY_TOKEN', ''),
-            phone_number_id=os.environ.get('KC_META_PHONE_NUMBER_ID', ''),
-            access_token=os.environ.get('KC_META_ACCESS_TOKEN', ''))
-    return TwilioProvider(
-        auth_token=os.environ.get('KC_TWILIO_AUTH_TOKEN', ''),
-        account_sid=os.environ.get('KC_TWILIO_ACCOUNT_SID', ''),
-        from_number=os.environ.get('KC_TWILIO_FROM', ''))
+        return build_provider('meta', {
+            'app_secret': os.environ.get('KC_META_APP_SECRET', ''),
+            'verify_token': os.environ.get('KC_META_VERIFY_TOKEN', ''),
+            'phone_number_id': os.environ.get('KC_META_PHONE_NUMBER_ID', ''),
+            'access_token': os.environ.get('KC_META_ACCESS_TOKEN', ''),
+        })
+    return build_provider('twilio', {
+        'auth_token': os.environ.get('KC_TWILIO_AUTH_TOKEN', ''),
+        'account_sid': os.environ.get('KC_TWILIO_ACCOUNT_SID', ''),
+        'from_number': os.environ.get('KC_TWILIO_FROM', ''),
+    })

--- a/charts/workspace/tests/gateway_whatsapp_test.py
+++ b/charts/workspace/tests/gateway_whatsapp_test.py
@@ -330,5 +330,168 @@ class AdapterWiringTest(unittest.TestCase):
         self.assertEqual(a.capabilities.max_text_len, 4096)
 
 
+# ───────────────────────────────────────────────────────────────────────────
+# Provider registry + declarative spec (issue #328)
+# ───────────────────────────────────────────────────────────────────────────
+class ProviderRegistryTest(unittest.TestCase):
+    def test_list_providers_has_twilio_and_meta(self):
+        ids = [s.id for s in wa.list_providers()]
+        self.assertIn('twilio', ids)
+        self.assertIn('meta', ids)
+
+    def test_build_twilio_from_creds(self):
+        prov = wa.build_provider('twilio', {
+            'account_sid': 'AC123', 'auth_token': 'tok', 'from_number': 'whatsapp:+1'})
+        self.assertIsInstance(prov, wa.TwilioProvider)
+        self.assertEqual(prov.account_sid, 'AC123')
+        self.assertEqual(prov.auth_token, 'tok')
+        self.assertEqual(prov.from_number, 'whatsapp:+1')
+
+    def test_build_meta_from_creds(self):
+        prov = wa.build_provider('meta', {
+            'app_secret': 'sec', 'verify_token': 'vt',
+            'phone_number_id': 'PN1', 'access_token': 'at'})
+        self.assertIsInstance(prov, wa.MetaProvider)
+        self.assertEqual(prov.app_secret, 'sec')
+        self.assertEqual(prov.verify_token, 'vt')
+        self.assertEqual(prov.phone_number_id, 'PN1')
+        self.assertEqual(prov.access_token, 'at')
+
+    def test_build_is_case_insensitive(self):
+        self.assertIsInstance(wa.build_provider('META', {}), wa.MetaProvider)
+        self.assertIsInstance(wa.build_provider('Twilio', {}), wa.TwilioProvider)
+
+    def test_build_unknown_raises(self):
+        with self.assertRaises(ValueError):
+            wa.build_provider('nope', {})
+
+    def test_build_with_none_creds_is_empty(self):
+        prov = wa.build_provider('twilio', None)
+        self.assertEqual(prov.account_sid, '')
+        self.assertEqual(prov.auth_token, '')
+
+    def test_build_with_empty_creds_is_empty(self):
+        prov = wa.build_provider('meta', {})
+        self.assertEqual(prov.app_secret, '')
+        self.assertEqual(prov.phone_number_id, '')
+
+    def test_get_provider_spec(self):
+        self.assertEqual(wa.get_provider_spec('twilio').id, 'twilio')
+        self.assertIsNone(wa.get_provider_spec('nope'))
+
+
+class ProviderSpecSerializationTest(unittest.TestCase):
+    def test_specs_are_json_serializable(self):
+        for spec in wa.list_providers():
+            # Must not raise — the stage-3 Settings form is driven by this.
+            json.dumps(spec.to_dict())
+
+    def test_serialization_round_trips(self):
+        for spec in wa.list_providers():
+            d = spec.to_dict()
+            self.assertEqual(json.loads(json.dumps(d)), d)
+
+    def test_spec_shape_is_complete(self):
+        d = wa.get_provider_spec('twilio').to_dict()
+        self.assertEqual(d['id'], 'twilio')
+        self.assertTrue(d['display_name'])
+        self.assertTrue(d['credential_fields'])
+        for f in d['credential_fields']:
+            self.assertIn('key', f)
+            self.assertIn('label', f)
+            self.assertIn('secret', f)
+        self.assertIn('key', d['sender_field'])
+        # Capabilities serialize as their dataclass fields.
+        self.assertIn('proactive', d['capabilities'])
+        self.assertIn('max_text_len', d['capabilities'])
+
+    def test_secret_flags_are_correct(self):
+        tw = {f.key: f for f in wa.get_provider_spec('twilio').credential_fields}
+        self.assertTrue(tw['auth_token'].secret)
+        self.assertFalse(tw['account_sid'].secret)
+        mt = {f.key: f for f in wa.get_provider_spec('meta').credential_fields}
+        self.assertTrue(mt['app_secret'].secret)
+        self.assertTrue(mt['access_token'].secret)
+        self.assertFalse(mt['verify_token'].secret)
+        # Sender fields are non-secret identifiers, not credentials.
+        self.assertFalse(wa.get_provider_spec('meta').sender_field.secret)
+
+    def test_field_keys_cover_factory_inputs(self):
+        # Every key the factory reads must be declared on the spec, so the
+        # stage-2 store and stage-3 form know the full set.
+        self.assertEqual(
+            set(wa.get_provider_spec('twilio').field_keys()),
+            {'account_sid', 'auth_token', 'from_number'})
+        self.assertEqual(
+            set(wa.get_provider_spec('meta').field_keys()),
+            {'access_token', 'app_secret', 'verify_token', 'phone_number_id'})
+
+
+class ProviderCapabilitiesTest(unittest.TestCase):
+    def test_capabilities_declared_per_spec(self):
+        self.assertFalse(wa.get_provider_spec('twilio').capabilities.proactive)
+        self.assertTrue(wa.get_provider_spec('meta').capabilities.proactive)
+
+    def test_whatsapp_limits_shared_across_providers(self):
+        for pid in ('twilio', 'meta'):
+            caps = wa.get_provider_spec(pid).capabilities
+            self.assertTrue(caps.buttons)
+            self.assertEqual(caps.max_buttons, 3)
+            self.assertEqual(caps.max_list_rows, 10)
+            self.assertEqual(caps.max_text_len, 4096)
+
+    def test_adapter_reads_provider_capabilities(self):
+        self.assertIs(
+            wa.WhatsAppAdapter(provider=wa.MetaProvider()).capabilities,
+            wa.MetaProvider.capabilities)
+
+
+class ProviderFromEnvTest(unittest.TestCase):
+    """The env path stays valid for platform-managed deploys and must behave
+    exactly as before #328."""
+
+    _VARS = ('KC_WHATSAPP_PROVIDER', 'KC_META_APP_SECRET', 'KC_META_VERIFY_TOKEN',
+             'KC_META_PHONE_NUMBER_ID', 'KC_META_ACCESS_TOKEN',
+             'KC_TWILIO_AUTH_TOKEN', 'KC_TWILIO_ACCOUNT_SID', 'KC_TWILIO_FROM')
+
+    def setUp(self):
+        self._saved = {k: os.environ.pop(k, None) for k in self._VARS}
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_default_is_twilio(self):
+        self.assertIsInstance(wa._provider_from_env(), wa.TwilioProvider)
+
+    def test_meta_selected(self):
+        os.environ['KC_WHATSAPP_PROVIDER'] = 'meta'
+        self.assertIsInstance(wa._provider_from_env(), wa.MetaProvider)
+
+    def test_unknown_value_falls_back_to_twilio(self):
+        os.environ['KC_WHATSAPP_PROVIDER'] = 'bogus'
+        self.assertIsInstance(wa._provider_from_env(), wa.TwilioProvider)
+
+    def test_reads_twilio_credentials(self):
+        os.environ['KC_TWILIO_ACCOUNT_SID'] = 'AC9'
+        os.environ['KC_TWILIO_AUTH_TOKEN'] = 'tk9'
+        os.environ['KC_TWILIO_FROM'] = 'whatsapp:+19'
+        prov = wa._provider_from_env()
+        self.assertEqual(prov.account_sid, 'AC9')
+        self.assertEqual(prov.auth_token, 'tk9')
+        self.assertEqual(prov.from_number, 'whatsapp:+19')
+
+    def test_reads_meta_credentials(self):
+        os.environ['KC_WHATSAPP_PROVIDER'] = 'meta'
+        os.environ['KC_META_APP_SECRET'] = 's9'
+        os.environ['KC_META_PHONE_NUMBER_ID'] = 'PN9'
+        prov = wa._provider_from_env()
+        self.assertEqual(prov.app_secret, 's9')
+        self.assertEqual(prov.phone_number_id, 'PN9')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Stage 1/5 of #325 — productionize the WhatsApp gateway (Model B). Closes #328.

Pure backend refactor of the `_Provider` seam in `adapters/whatsapp.py` into a declarative, registered provider catalog. **No behavior change** — unblocks the per-workspace credential store (#329) and the data-driven Settings form (#330).

### What's added
- **`CredentialField`** dataclass — one credential a provider needs: `key`, `label`, `secret`, `placeholder`, `help_url`, `required`. `to_dict()` makes it JSON-serializable so the Stage-3 form renders from it.
- **`ProviderSpec`** dataclass — `id`, `display_name`, `credential_fields`, `sender_field`, `capabilities`; plus `field_keys()` + `to_dict()`.
- **Registry** — `register_provider`, `list_providers`, `get_provider_spec`, `build_provider(provider_id, creds)`. Adding a provider = new adapter class + one `register_provider()` call, never a core change.
- **`TWILIO_SPEC` / `META_SPEC`** + factories that map a flat creds dict onto the existing kwargs constructors.
- Per-provider **`Capabilities`** (`TWILIO_CAPS` no-proactive, `META_CAPS` proactive templates) declared as a class attribute; `WhatsAppAdapter` reads `provider.capabilities` — the `isinstance(...)` branch is gone.
- `_provider_from_env()` is now a thin wrapper over `build_provider()` (env stays valid for platform-managed deploys; identical behavior for the existing `server.py` caller).

`TwilioProvider` / `MetaProvider` keep their kwargs constructors, so `adapters/internal.py` and every existing test are untouched.

### Design note
Meta's `sender_field` is `phone_number_id` (the opaque WABA sending identity); Twilio's is the human `from_number` — modeled per-provider so the Stage-3 form labels each correctly.

### Tests
16 new cases in `gateway_whatsapp_test.py` (registry build for both providers, case-insensitive ids, unknown-id `ValueError`, `None`/`{}` creds, spec JSON round-trip, secret-flag correctness, `field_keys` coverage, per-spec capabilities, env-wrapper behavior preservation). **`gateway_whatsapp_test`: 58/58 green.**

### Non-goals (later stages)
No credential store, endpoints, UI, chart changes, or new providers.
