### PR TITLE
feat(gateway): per-workspace credential store + config API (#329)

### DIFF
--- a/charts/workspace/adapters/whatsapp.py
+++ b/charts/workspace/adapters/whatsapp.py
@@ -35,8 +35,8 @@ import json
 import os
 import urllib.parse
 import urllib.request
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from gateway import (Capabilities, DeliveryResult, InboundMessage, MediaItem,
                     OutboundMessage, RawRequest, chunk_text)
@@ -90,10 +90,80 @@ def render_choice(options: List[str], caps: Capabilities) -> InteractiveSpec:
 
 
 # ───────────────────────────────────────────────────────────────────────────
+# Provider catalog — declarative spec (issue #328)
+# ───────────────────────────────────────────────────────────────────────────
+# Each provider declares WHAT it needs (credential fields + sender field) and
+# WHAT it can do (Capabilities) as data. A registry maps provider_id → (spec,
+# adapter factory), so `build_provider(id, creds)` constructs a provider from a
+# flat creds dict and `list_providers()` exposes the specs. The spec is fully
+# JSON-serializable (via to_dict) — the Settings form in stage 3 is rendered
+# entirely from it, so adding a provider is a new adapter class + one
+# register_provider(...) call, never a UI or core change.
+@dataclass
+class CredentialField:
+    """One credential the user must supply for a provider. Also the schema the
+    stage-3 Settings form renders from and the key the stage-2 store persists
+    under, so `key` doubles as the creds-dict / storage key."""
+    key: str                    # creds-dict key AND future storage key
+    label: str                  # UI label
+    secret: bool = True         # masked in UI; redacted in stage-2 public_view()
+    placeholder: str = ''
+    help_url: str = ''
+    required: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'key': self.key,
+            'label': self.label,
+            'secret': self.secret,
+            'placeholder': self.placeholder,
+            'help_url': self.help_url,
+            'required': self.required,
+        }
+
+
+@dataclass
+class ProviderSpec:
+    """Declarative description of a messaging provider — its identity, the
+    credential fields it needs, its sending-identity field, and its
+    Capabilities. Serializable so the UI is data-driven."""
+    id: str                             # 'twilio' | 'meta'
+    display_name: str
+    credential_fields: List[CredentialField]
+    sender_field: CredentialField       # provider-specific sending identity
+    capabilities: Capabilities
+
+    def field_keys(self) -> List[str]:
+        """Every creds-dict key this provider consumes (credentials + sender)."""
+        return [f.key for f in self.credential_fields] + [self.sender_field.key]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'id': self.id,
+            'display_name': self.display_name,
+            'credential_fields': [f.to_dict() for f in self.credential_fields],
+            'sender_field': self.sender_field.to_dict(),
+            'capabilities': asdict(self.capabilities),
+        }
+
+
+# WhatsApp platform capabilities are the same across providers EXCEPT proactive:
+# out-of-window sends need an approved template, which the real Meta Cloud API
+# supports but the Twilio sandbox does not.
+_WA_CAPS = dict(buttons=True, max_buttons=3, max_list_rows=10, media=True,
+                typing_indicator=True, max_text_len=WHATSAPP_MAX_TEXT)
+TWILIO_CAPS = Capabilities(proactive=False, **_WA_CAPS)
+META_CAPS = Capabilities(proactive=True, **_WA_CAPS)
+
+
+# ───────────────────────────────────────────────────────────────────────────
 # Provider seam
 # ───────────────────────────────────────────────────────────────────────────
 class _Provider:
     name = 'base'
+    # Providers declare their capabilities as a class attribute; the adapter
+    # reads provider.capabilities instead of branching on the provider type.
+    capabilities: Capabilities = Capabilities()
 
     def verify(self, raw: RawRequest) -> bool:
         raise NotImplementedError
@@ -116,6 +186,7 @@ class TwilioProvider(_Provider):
     quick-reply. Signature: base64(HMAC-SHA1(AuthToken, URL + sorted k+v))."""
 
     name = 'twilio'
+    capabilities = TWILIO_CAPS
 
     def __init__(self, *, auth_token: str = '', account_sid: str = '',
                  from_number: str = ''):
@@ -234,6 +305,7 @@ class MetaProvider(_Provider):
     body) — already matches kube-coder's generic verifier."""
 
     name = 'meta'
+    capabilities = META_CAPS
     GRAPH = 'https://graph.facebook.com/v19.0'
 
     def __init__(self, *, app_secret: str = '', verify_token: str = '',
@@ -427,14 +499,10 @@ class WhatsAppAdapter:
 
     def __init__(self, provider: Optional[_Provider] = None):
         self.provider = provider or _provider_from_env()
-        self.capabilities = Capabilities(
-            buttons=True, max_buttons=3, max_list_rows=10, media=True,
-            typing_indicator=True,
-            # Free-form only inside the 24-h window; proactive out-of-window
-            # requires an approved template — which we CAN do on the real Cloud
-            # API (Meta), but not the Twilio sandbox. Advertise per provider.
-            proactive=isinstance(self.provider, MetaProvider),
-            max_text_len=WHATSAPP_MAX_TEXT)
+        # Capabilities are declared by the provider (proactive out-of-window
+        # sends need an approved template — Meta Cloud API only, not the Twilio
+        # sandbox), so the adapter reads them rather than branching on type.
+        self.capabilities = self.provider.capabilities
 
     def verify(self, raw: RawRequest) -> bool:
         return self.provider.verify(raw)
@@ -449,17 +517,126 @@ class WhatsAppAdapter:
         return self.provider.send(msg, self.capabilities)
 
 
+# ───────────────────────────────────────────────────────────────────────────
+# Provider registry (issue #328)
+# ───────────────────────────────────────────────────────────────────────────
+# provider_id → (spec, factory). The factory maps a flat creds dict (keyed by
+# the spec's CredentialField.key values) onto the provider's kwargs constructor.
+DEFAULT_PROVIDER_ID = 'twilio'
+_ProviderFactory = Callable[[Dict[str, str]], _Provider]
+_REGISTRY: 'Dict[str, Tuple[ProviderSpec, _ProviderFactory]]' = {}
+
+
+def register_provider(spec: ProviderSpec, factory: _ProviderFactory) -> None:
+    """Register a provider so build_provider/list_providers can see it. Called
+    at import time; adding a provider is a new adapter class + one call here."""
+    _REGISTRY[spec.id] = (spec, factory)
+
+
+def list_providers() -> List[ProviderSpec]:
+    """All registered provider specs, in registration order (data for the UI)."""
+    return [spec for spec, _factory in _REGISTRY.values()]
+
+
+def get_provider_spec(provider_id: str) -> Optional[ProviderSpec]:
+    entry = _REGISTRY.get((provider_id or '').strip().lower())
+    return entry[0] if entry else None
+
+
+def build_provider(provider_id: str,
+                   creds: Optional[Dict[str, str]] = None) -> _Provider:
+    """Construct a provider from its id + a flat creds dict. Raises ValueError
+    on an unknown id so API callers (stage 2) fail loudly; env callers normalize
+    the id first so they never hit that path."""
+    entry = _REGISTRY.get((provider_id or '').strip().lower())
+    if entry is None:
+        raise ValueError(f'unknown provider: {provider_id!r}')
+    _spec, factory = entry
+    return factory(creds or {})
+
+
+# -- Twilio -------------------------------------------------------------------
+TWILIO_SPEC = ProviderSpec(
+    id='twilio',
+    display_name='Twilio',
+    credential_fields=[
+        CredentialField(
+            key='account_sid', label='Account SID', secret=False,
+            placeholder='ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+            help_url='https://www.twilio.com/console'),
+        CredentialField(
+            key='auth_token', label='Auth Token', secret=True,
+            help_url='https://www.twilio.com/console'),
+    ],
+    sender_field=CredentialField(
+        key='from_number', label='WhatsApp sender number', secret=False,
+        placeholder='whatsapp:+14155238886',
+        help_url='https://www.twilio.com/docs/whatsapp'),
+    capabilities=TWILIO_CAPS,
+)
+
+
+def _twilio_factory(creds: Dict[str, str]) -> _Provider:
+    return TwilioProvider(
+        auth_token=creds.get('auth_token', ''),
+        account_sid=creds.get('account_sid', ''),
+        from_number=creds.get('from_number', ''))
+
+
+# -- Meta ---------------------------------------------------------------------
+META_SPEC = ProviderSpec(
+    id='meta',
+    display_name='Meta (WhatsApp Cloud API)',
+    credential_fields=[
+        CredentialField(
+            key='access_token', label='Access Token', secret=True,
+            help_url='https://developers.facebook.com/docs/whatsapp/cloud-api/get-started'),
+        CredentialField(
+            key='app_secret', label='App Secret', secret=True,
+            help_url='https://developers.facebook.com/docs/graph-api/webhooks/getting-started'),
+        CredentialField(
+            key='verify_token', label='Webhook Verify Token', secret=False,
+            placeholder='a token you choose',
+            help_url='https://developers.facebook.com/docs/graph-api/webhooks/getting-started'),
+    ],
+    # Meta's sending identity is the opaque Phone Number ID (the WABA sender),
+    # not a dialable number — so it lives here, not among the numbered fields.
+    sender_field=CredentialField(
+        key='phone_number_id', label='Phone Number ID', secret=False,
+        placeholder='1234567890',
+        help_url='https://developers.facebook.com/docs/whatsapp/cloud-api/get-started'),
+    capabilities=META_CAPS,
+)
+
+
+def _meta_factory(creds: Dict[str, str]) -> _Provider:
+    return MetaProvider(
+        app_secret=creds.get('app_secret', ''),
+        verify_token=creds.get('verify_token', ''),
+        phone_number_id=creds.get('phone_number_id', ''),
+        access_token=creds.get('access_token', ''))
+
+
+register_provider(TWILIO_SPEC, _twilio_factory)
+register_provider(META_SPEC, _meta_factory)
+
+
 def _provider_from_env() -> _Provider:
-    """Build the configured provider from env. KC_WHATSAPP_PROVIDER selects
-    twilio (default) or meta; each reads its own credential vars."""
+    """Build the configured provider from env, via the registry. Env stays a
+    valid source for platform-managed deployments. KC_WHATSAPP_PROVIDER selects
+    twilio (default) or meta; the id is normalized to a known provider before
+    build_provider, so this never raises on a bad value (any non-'meta' → twilio,
+    preserving the pre-#328 behavior)."""
     which = os.environ.get('KC_WHATSAPP_PROVIDER', 'twilio').strip().lower()
     if which == 'meta':
-        return MetaProvider(
-            app_secret=os.environ.get('KC_META_APP_SECRET', ''),
-            verify_token=os.environ.get('KC_META_VERIFY_TOKEN', ''),
-            phone_number_id=os.environ.get('KC_META_PHONE_NUMBER_ID', ''),
-            access_token=os.environ.get('KC_META_ACCESS_TOKEN', ''))
-    return TwilioProvider(
-        auth_token=os.environ.get('KC_TWILIO_AUTH_TOKEN', ''),
-        account_sid=os.environ.get('KC_TWILIO_ACCOUNT_SID', ''),
-        from_number=os.environ.get('KC_TWILIO_FROM', ''))
+        return build_provider('meta', {
+            'app_secret': os.environ.get('KC_META_APP_SECRET', ''),
+            'verify_token': os.environ.get('KC_META_VERIFY_TOKEN', ''),
+            'phone_number_id': os.environ.get('KC_META_PHONE_NUMBER_ID', ''),
+            'access_token': os.environ.get('KC_META_ACCESS_TOKEN', ''),
+        })
+    return build_provider('twilio', {
+        'auth_token': os.environ.get('KC_TWILIO_AUTH_TOKEN', ''),
+        'account_sid': os.environ.get('KC_TWILIO_ACCOUNT_SID', ''),
+        'from_number': os.environ.get('KC_TWILIO_FROM', ''),
+    })

--- a/charts/workspace/adapters/whatsapp.py
+++ b/charts/workspace/adapters/whatsapp.py
@@ -33,6 +33,7 @@ import hashlib
 import hmac
 import json
 import os
+import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import asdict, dataclass, field
@@ -177,6 +178,12 @@ class _Provider:
     def send(self, msg: OutboundMessage, caps: Capabilities) -> DeliveryResult:
         raise NotImplementedError
 
+    def validate(self) -> 'Tuple[bool, str]':
+        """Cheaply check the configured credentials against the provider WITHOUT
+        sending a message to a real user (issue #329, POST /api/gateway/test).
+        Returns (ok, detail); detail must NEVER contain secret material."""
+        return False, 'validation not implemented for this provider'
+
 
 class TwilioProvider(_Provider):
     """Twilio WhatsApp — SMS-shaped form webhook + REST Messages API.
@@ -294,6 +301,20 @@ class TwilioProvider(_Provider):
             'Content-Type': 'application/x-www-form-urlencoded',
         })
         return _do_send(req, id_key='sid')
+
+    def validate(self) -> 'Tuple[bool, str]':
+        """Authenticated GET of the Account resource — proves the SID+token pair
+        without sending anything. 200 → ok; 401 → bad creds."""
+        if not (self.account_sid and self.auth_token):
+            return False, 'credentials not configured'
+        url = (f'https://api.twilio.com/2010-04-01/Accounts/'
+               f'{self.account_sid}.json')
+        auth = base64.b64encode(
+            f'{self.account_sid}:{self.auth_token}'.encode()).decode()
+        req = urllib.request.Request(url, method='GET', headers={
+            'Authorization': f'Basic {auth}',
+        })
+        return _do_validate(req)
 
 
 class MetaProvider(_Provider):
@@ -459,6 +480,17 @@ class MetaProvider(_Provider):
             })
         return _do_send(req, id_key='messages')
 
+    def validate(self) -> 'Tuple[bool, str]':
+        """Authenticated GET of the phone-number node — proves the access token
+        can reach the configured sender. 200 → ok; 401/403 → bad creds."""
+        if not (self.phone_number_id and self.access_token):
+            return False, 'credentials not configured'
+        url = f'{self.GRAPH}/{self.phone_number_id}'
+        req = urllib.request.Request(url, method='GET', headers={
+            'Authorization': f'Bearer {self.access_token}',
+        })
+        return _do_validate(req)
+
 
 def _allow_unsigned() -> bool:
     """Opt-in escape hatch for dev/sandbox — mirrors WebhookManager's
@@ -485,6 +517,23 @@ def _do_send(req: urllib.request.Request, *, id_key: str) -> DeliveryResult:
         return DeliveryResult(ok=True, provider_msg_id=pid, status=status)
     except Exception as e:  # network / HTTP error — surface, never crash
         return DeliveryResult(ok=False, error=f'{type(e).__name__}: {e}')
+
+
+def _do_validate(req: urllib.request.Request) -> 'Tuple[bool, str]':
+    """Execute a credential-probe GET with a short timeout; never raises and
+    never echoes secret material (the request carries the auth header, not the
+    detail we return). 2xx → ok; HTTP status / network error → a safe message."""
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            status = getattr(resp, 'status', 200)
+        return (200 <= status < 300), f'HTTP {status}'
+    except urllib.error.HTTPError as e:
+        # 401/403 → bad creds; other codes → surface the status, never the body.
+        if e.code in (401, 403):
+            return False, 'authentication failed — check credentials'
+        return False, f'provider returned HTTP {e.code}'
+    except Exception as e:  # network / DNS / timeout — never crash
+        return False, f'could not reach provider ({type(e).__name__})'
 
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -515,6 +564,11 @@ class WhatsAppAdapter:
 
     def outbound(self, msg: OutboundMessage) -> DeliveryResult:
         return self.provider.send(msg, self.capabilities)
+
+    def validate(self) -> 'Tuple[bool, str]':
+        """Test-connection: probe the configured provider's credentials without
+        sending a message to a real user (issue #329)."""
+        return self.provider.validate()
 
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -68,7 +68,10 @@ try:
     from gateway import (ConversationGateway, IdentityRegistry,
                         LocalHypervisorClient, RawRequest, GatewayPreview,
                         INTERNAL_IDENTITY)
-    from adapters.whatsapp import WhatsAppAdapter
+    from adapters.whatsapp import (WhatsAppAdapter, build_provider as
+                                   gw_build_provider, list_providers as
+                                   gw_list_providers, get_provider_spec as
+                                   gw_get_provider_spec)
     from adapters.internal import LoopbackAdapter
     _GATEWAY_AVAILABLE = True
 except Exception as _gw_import_err:  # broken install shouldn't crash the server
@@ -79,6 +82,9 @@ except Exception as _gw_import_err:  # broken install shouldn't crash the server
     GatewayPreview = None  # type: ignore
     INTERNAL_IDENTITY = 'internal:local'  # type: ignore
     WhatsAppAdapter = None  # type: ignore
+    gw_build_provider = None  # type: ignore
+    gw_list_providers = None  # type: ignore
+    gw_get_provider_spec = None  # type: ignore
     LoopbackAdapter = None  # type: ignore
     _GATEWAY_AVAILABLE = False
     print(f'[gateway] import failed: {_gw_import_err}', file=sys.stderr)
@@ -220,13 +226,42 @@ def get_gateway():
                 window_probe=preview.window_probe)
             gw.install_turn_observer()
             _GATEWAY = gw
-            _GATEWAY_ADAPTER = WhatsAppAdapter()
+            _GATEWAY_ADAPTER = _build_gateway_adapter()
             _GATEWAY_PREVIEW = preview
             _GATEWAY_LOOPBACK = LoopbackAdapter(
                 preview.transcript, publish=EventBroker.publish,
                 identity=INTERNAL_IDENTITY)
             print('[gateway] conversation gateway ready (whatsapp + loopback preview)')
         return _GATEWAY
+
+
+def _build_gateway_adapter():
+    """Construct the WhatsApp adapter from the per-workspace credential store
+    (issue #329), falling back to env (issue #328 `_provider_from_env`) when the
+    store is empty or names an unknown provider. This is what makes saving creds
+    hot-swap the live provider with no pod restart."""
+    if WhatsAppAdapter is None:
+        return None
+    raw = GatewayCredentialsManager.get_raw()
+    if raw and raw.get('provider_id') and gw_build_provider is not None:
+        try:
+            provider = gw_build_provider(raw['provider_id'], raw.get('creds') or {})
+            return WhatsAppAdapter(provider=provider)
+        except ValueError:
+            # Stored provider id is unknown (e.g. removed) — fall back to env so
+            # the channel degrades gracefully rather than 500-ing.
+            pass
+    return WhatsAppAdapter()
+
+
+def rebuild_gateway_adapter():
+    """Rebuild the live adapter from the store after a credential change so the
+    inbound webhook path and capability probes see the new provider immediately.
+    No-op if the gateway subsystem was never constructed."""
+    global _GATEWAY_ADAPTER
+    with _GATEWAY_LOCK:
+        if _GATEWAY is not None:
+            _GATEWAY_ADAPTER = _build_gateway_adapter()
 
 
 def get_gateway_adapter():
@@ -3090,6 +3125,147 @@ class ProviderKeysManager:
                 if isinstance(data.get(p), str) and data[p].strip()}
 
 
+class GatewayCredentialsManager:
+    """Per-workspace messaging-provider credentials (issue #329), persisted on
+    the PVC and read by the WhatsApp adapter at construction so saving new creds
+    hot-swaps the live provider — no pod restart. Same discipline as
+    ProviderKeysManager (one JSON on the PVC, atomic 0600 write, redacted public
+    view) but the field set is DRIVEN by the provider registry (issue #328): a
+    provider's spec declares which fields exist and which are secret, so this
+    store never hardcodes provider knowledge.
+
+    Stored shape: {"provider_id": "twilio", "creds": {<field_key>: value, ...}}.
+    `creds` is flat and keyed by the provider spec's field_keys() (credential
+    fields + the sender field), so it drops straight into build_provider().
+    """
+
+    CREDS_FILE = '/home/dev/.claude-tasks/gateway-credentials.json'
+
+    @classmethod
+    def _read(cls):
+        try:
+            with open(cls.CREDS_FILE) as f:
+                data = json.load(f)
+            return data if isinstance(data, dict) else {}
+        except (OSError, json.JSONDecodeError):
+            return {}
+
+    @classmethod
+    def _write(cls, data):
+        os.makedirs(os.path.dirname(cls.CREDS_FILE), mode=0o700, exist_ok=True)
+        tmp = cls.CREDS_FILE + '.tmp'
+        with open(tmp, 'w') as f:
+            json.dump(data, f, indent=2)
+        os.chmod(tmp, 0o600)
+        # os.replace is atomic on both POSIX and Windows (os.rename raises on
+        # Windows when the target exists), so re-saving credentials never fails.
+        os.replace(tmp, cls.CREDS_FILE)
+
+    @staticmethod
+    def _spec(provider_id):
+        """The provider spec from the registry, or None if unknown/unavailable."""
+        if gw_get_provider_spec is None:
+            return None
+        return gw_get_provider_spec(provider_id)
+
+    @classmethod
+    def get_raw(cls):
+        """The stored {provider_id, creds} incl. secret values, or None when the
+        channel is unconfigured. The ONLY getter that returns secrets — read by
+        _build_gateway_adapter() at construction, never logged or returned to a
+        client."""
+        data = cls._read()
+        pid = data.get('provider_id')
+        if not pid:
+            return None
+        creds = data.get('creds')
+        return {'provider_id': pid, 'creds': creds if isinstance(creds, dict) else {}}
+
+    @classmethod
+    def set(cls, provider_id, creds, sender_number=None):
+        """Persist provider + creds. Validates the provider against the registry,
+        keeps only fields the spec declares (allowlist), folds sender_number into
+        its spec field, and preserves an existing secret when the incoming value
+        is blank AND the provider is unchanged (so the form needn't re-enter a
+        masked secret). Switching providers starts fresh. Returns (ok, err)."""
+        provider_id = (provider_id or '').strip().lower()
+        spec = cls._spec(provider_id)
+        if spec is None:
+            return False, 'unknown provider'
+        incoming = dict(creds) if isinstance(creds, dict) else {}
+        if sender_number is not None:
+            incoming[spec.sender_field.key] = sender_number
+        allowed = set(spec.field_keys())
+        prev = cls._read()
+        same_provider = prev.get('provider_id') == provider_id
+        prev_creds = prev.get('creds') if isinstance(prev.get('creds'), dict) else {}
+        out = {}
+        for key in allowed:
+            val = incoming.get(key)
+            if isinstance(val, str) and val.strip():
+                out[key] = val.strip()
+            elif same_provider and isinstance(prev_creds.get(key), str) and prev_creds[key]:
+                # Blank/absent on update → keep the previously-stored value.
+                out[key] = prev_creds[key]
+        cls._write({'provider_id': provider_id, 'creds': out})
+        return True, None
+
+    @classmethod
+    def clear(cls):
+        """Remove the store — disables the channel (adapter falls back to env).
+        Idempotent."""
+        try:
+            os.remove(cls.CREDS_FILE)
+        except OSError:
+            pass
+        return True
+
+    @classmethod
+    def public_view(cls):
+        """Redacted view for the UI, spec-driven. Per declared field: `set` bool
+        always; secret fields add a last-4 `hint` and NEVER the value; non-secret
+        identifiers (account SID, verify token, sender number) may include
+        `value`. Empty store → {configured: false}."""
+        data = cls._read()
+        pid = data.get('provider_id')
+        spec = cls._spec(pid) if pid else None
+        if not pid or spec is None:
+            return {'configured': False, 'provider_id': None, 'fields': {}}
+        creds = data.get('creds') if isinstance(data.get('creds'), dict) else {}
+        fields = {}
+        for f in list(spec.credential_fields) + [spec.sender_field]:
+            v = creds.get(f.key)
+            is_set = isinstance(v, str) and bool(v)
+            entry = {'set': is_set}
+            if f.secret:
+                entry['hint'] = (f'…{v[-4:]}' if is_set and len(v) >= 4 else '')
+            elif is_set:
+                entry['value'] = v
+            fields[f.key] = entry
+        return {
+            'configured': True,
+            'provider_id': pid,
+            'sender_field': spec.sender_field.key,
+            'fields': fields,
+        }
+
+    @classmethod
+    def validate_stored(cls):
+        """Test-connection over the stored creds: build the provider and probe it
+        WITHOUT sending to a real user. Returns (ok, detail); detail never
+        contains secret material."""
+        raw = cls.get_raw()
+        if raw is None:
+            return False, 'no credentials configured'
+        if gw_build_provider is None:
+            return False, 'gateway unavailable'
+        try:
+            provider = gw_build_provider(raw['provider_id'], raw['creds'])
+        except ValueError:
+            return False, 'unknown provider'
+        return provider.validate()
+
+
 class SubscriptionStatusManager:
     """Read-only view of subscription-based CLI logins (Claude Max/Pro OAuth,
     Codex ChatGPT OAuth) so the Settings UI can show "logged in via subscription"
@@ -4552,6 +4728,12 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         elif claude_path == '/api/gateway/links':
             self.handle_gateway_link_list()
             return
+        elif claude_path == '/api/gateway/providers':
+            self.handle_gateway_providers()
+            return
+        elif claude_path == '/api/gateway/credentials':
+            self.handle_gateway_credentials_get()
+            return
         elif claude_path == '/api/gateway/internal/transcript':
             self.handle_gateway_internal_transcript()
             return
@@ -5024,6 +5206,10 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             m = re.match(r'^/api/gateway/link/([a-f0-9]{64})$', path)
             if m:
                 self.handle_gateway_link_delete(m.group(1))
+                return
+            # Messaging provider credentials (issue #329): clear the store.
+            if path == '/api/gateway/credentials':
+                self.handle_gateway_credentials_delete()
                 return
             m = re.match(r'^/api/crons/([a-z0-9-]+)$', path)
             if m:
@@ -6405,6 +6591,81 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             return
         ok = gw.registry.revoke(link_id)
         self.send_json({'ok': ok}, 200 if ok else 404)
+
+    # --- Messaging provider config (issue #329) ---
+    # The data-driven catalog + per-workspace credential store the Settings
+    # "Messaging / WhatsApp" section (stage 3) drives. Credentials are stored on
+    # the PVC (0600, redacted in every read), and saving hot-swaps the live
+    # adapter so the inbound webhook uses the new provider with no pod restart.
+
+    def handle_gateway_providers(self):
+        """The provider catalog + each provider's field spec (issue #328), so the
+        Settings form is entirely data-driven. No secrets — just the schema."""
+        if not self.check_claude_auth():
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        if gw_list_providers is None:
+            self.send_json({'providers': [], 'available': False})
+            return
+        self.send_json({
+            'providers': [s.to_dict() for s in gw_list_providers()],
+            'available': True,
+        })
+
+    def handle_gateway_credentials_get(self):
+        """Current selection, redacted (never a secret value)."""
+        if not self.check_claude_auth(allow_none_mode=False):
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        self.send_json({'credentials': GatewayCredentialsManager.public_view()})
+
+    def handle_gateway_credentials_put(self):
+        """Set provider + creds + sender number, then hot-swap the live adapter.
+        Responds with the redacted view (so the client never round-trips a
+        secret back)."""
+        if not self.check_claude_auth(allow_none_mode=False):
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        try:
+            data = self.read_json_body()
+        except (json.JSONDecodeError, ValueError):
+            self.send_json({'error': 'Invalid JSON body'}, 400)
+            return
+        provider_id = (data.get('provider_id') or '').strip()
+        creds = data.get('creds')
+        if creds is not None and not isinstance(creds, dict):
+            self.send_json({'error': 'creds must be an object'}, 400)
+            return
+        ok, err = GatewayCredentialsManager.set(
+            provider_id, creds or {}, sender_number=data.get('sender_number'))
+        if not ok:
+            self.send_json({'error': err}, 400)
+            return
+        rebuild_gateway_adapter()
+        self.send_json({'ok': True,
+                        'credentials': GatewayCredentialsManager.public_view()})
+
+    def handle_gateway_credentials_delete(self):
+        """Clear the store (disables the channel) and hot-swap back to the env
+        fallback."""
+        if not self.check_claude_auth(allow_none_mode=False):
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        GatewayCredentialsManager.clear()
+        rebuild_gateway_adapter()
+        self.send_json({'ok': True})
+
+    def handle_gateway_test(self):
+        """Validate the stored creds against the provider — no message to a real
+        user. 400 when nothing is configured yet."""
+        if not self.check_claude_auth(allow_none_mode=False):
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        ok, detail = GatewayCredentialsManager.validate_stored()
+        if not ok and detail == 'no credentials configured':
+            self.send_json({'ok': False, 'detail': detail}, 400)
+            return
+        self.send_json({'ok': ok, 'detail': detail})
 
     # --- Walkie-Talkie preview (in-app loopback) ---
     # Bearer-authed (it's the app user). Drives the SAME gateway core through the
@@ -8600,6 +8861,10 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         path = self._strip_route_prefix(self.path)
         if self._dispatch_app_proxy(path, 'PUT'):
             return
+        # Messaging provider credentials (issue #329) — set provider + creds.
+        if path == '/api/gateway/credentials':
+            self.handle_gateway_credentials_put()
+            return
         self.send_response(501)
         self.end_headers()
 
@@ -8838,6 +9103,9 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
                 self.handle_gateway_whatsapp_webhook()
             elif path == "/api/gateway/link":
                 self.handle_gateway_link_create()
+            # Messaging provider credentials (issue #329): test-connection.
+            elif path == "/api/gateway/test":
+                self.handle_gateway_test()
             # Walkie-Talkie in-app loopback preview (bearer-authed).
             elif path == "/api/gateway/internal/inbound":
                 self.handle_gateway_internal_inbound()

--- a/charts/workspace/tests/gateway_routes_test.py
+++ b/charts/workspace/tests/gateway_routes_test.py
@@ -33,6 +33,7 @@ except ImportError:  # pragma: no cover - platform shim
 
 import gateway as gw  # noqa: E402
 import server  # noqa: E402
+from adapters import whatsapp as wa  # noqa: E402
 
 
 class GatewayRouteTestBase(unittest.TestCase):
@@ -198,6 +199,131 @@ class VerifyHandshakeTest(GatewayRouteTestBase):
         h.end_headers.side_effect = lambda: None
         server.BrowserHandler.handle_gateway_whatsapp_verify(h)
         self.assertIn(403, statuses)
+
+
+class GatewayCredentialsRouteTest(GatewayRouteTestBase):
+    """The messaging config endpoints (issue #329): catalog, redacted
+    get/put/delete, test-connection — and the hot-swap of the live adapter on
+    save/clear."""
+
+    def setUp(self):
+        super().setUp()
+        self.tmp2 = tempfile.mkdtemp()
+        self._orig_creds = server.GatewayCredentialsManager.CREDS_FILE
+        server.GatewayCredentialsManager.CREDS_FILE = os.path.join(
+            self.tmp2, 'gateway-credentials.json')
+        # env fallback must be deterministic for the delete test.
+        self._saved_env = {k: os.environ.pop(k, None) for k in (
+            'KC_WHATSAPP_PROVIDER', 'KC_TWILIO_ACCOUNT_SID', 'KC_TWILIO_AUTH_TOKEN',
+            'KC_TWILIO_FROM')}
+
+    def tearDown(self):
+        server.GatewayCredentialsManager.CREDS_FILE = self._orig_creds
+        for k, v in self._saved_env.items():
+            if v is not None:
+                os.environ[k] = v
+        super().tearDown()
+
+    # -- catalog --
+    def test_providers_catalog(self):
+        h = self._handler()
+        server.BrowserHandler.handle_gateway_providers(h)
+        obj, status = self.last()
+        self.assertEqual(status, 200)
+        ids = [p['id'] for p in obj['providers']]
+        self.assertIn('twilio', ids)
+        self.assertIn('meta', ids)
+        self.assertTrue(obj['providers'][0]['credential_fields'])
+
+    def test_providers_unauthorized_is_401(self):
+        h = self._handler(authed=False)
+        server.BrowserHandler.handle_gateway_providers(h)
+        self.assertEqual(self.last()[1], 401)
+
+    # -- get/put/delete --
+    def test_get_empty_is_unconfigured(self):
+        h = self._handler()
+        server.BrowserHandler.handle_gateway_credentials_get(h)
+        obj, status = self.last()
+        self.assertEqual(status, 200)
+        self.assertFalse(obj['credentials']['configured'])
+
+    def test_credentials_unauthorized_is_401(self):
+        h = self._handler(authed=False)
+        server.BrowserHandler.handle_gateway_credentials_get(h)
+        self.assertEqual(self.last()[1], 401)
+
+    def test_put_sets_hot_swaps_and_redacts(self):
+        h = self._handler()
+        h.read_json_body.return_value = {
+            'provider_id': 'twilio',
+            'creds': {'account_sid': 'AC1', 'auth_token': 'super-secret-9999'},
+            'sender_number': 'whatsapp:+14155238886'}
+        server.BrowserHandler.handle_gateway_credentials_put(h)
+        obj, status = self.last()
+        self.assertEqual(status, 200)
+        self.assertTrue(obj['ok'])
+        # Response is redacted — the raw secret never round-trips back.
+        self.assertNotIn('super-secret-9999', repr(obj))
+        # Store persisted the creds.
+        raw = server.GatewayCredentialsManager.get_raw()
+        self.assertEqual(raw['creds']['auth_token'], 'super-secret-9999')
+        # Live adapter hot-swapped to a Twilio provider carrying the new creds.
+        self.assertIsInstance(server._GATEWAY_ADAPTER.provider, wa.TwilioProvider)
+        self.assertEqual(server._GATEWAY_ADAPTER.provider.account_sid, 'AC1')
+
+    def test_put_unknown_provider_is_400(self):
+        h = self._handler()
+        h.read_json_body.return_value = {'provider_id': 'nope', 'creds': {}}
+        server.BrowserHandler.handle_gateway_credentials_put(h)
+        self.assertEqual(self.last()[1], 400)
+
+    def test_put_bad_json_is_400(self):
+        h = self._handler()
+        h.read_json_body.side_effect = ValueError('bad')
+        server.BrowserHandler.handle_gateway_credentials_put(h)
+        self.assertEqual(self.last()[1], 400)
+
+    def test_get_after_put_hides_secret(self):
+        server.GatewayCredentialsManager.set(
+            'twilio', {'account_sid': 'AC1', 'auth_token': 'super-secret-9999'})
+        h = self._handler()
+        server.BrowserHandler.handle_gateway_credentials_get(h)
+        obj, status = self.last()
+        self.assertTrue(obj['credentials']['configured'])
+        self.assertNotIn('super-secret-9999', repr(obj))
+
+    def test_delete_clears_and_falls_back_to_env(self):
+        server.GatewayCredentialsManager.set(
+            'twilio', {'account_sid': 'AC1', 'auth_token': 'super-secret-9999'})
+        h = self._handler()
+        server.BrowserHandler.handle_gateway_credentials_delete(h)
+        obj, status = self.last()
+        self.assertEqual(status, 200)
+        self.assertTrue(obj['ok'])
+        self.assertIsNone(server.GatewayCredentialsManager.get_raw())
+        # Adapter rebuilt to the env fallback (no env set → empty Twilio).
+        self.assertIsInstance(server._GATEWAY_ADAPTER.provider, wa.TwilioProvider)
+        self.assertEqual(server._GATEWAY_ADAPTER.provider.account_sid, '')
+
+    # -- test-connection --
+    def test_test_empty_store_is_400(self):
+        h = self._handler()
+        server.BrowserHandler.handle_gateway_test(h)
+        obj, status = self.last()
+        self.assertEqual(status, 400)
+        self.assertFalse(obj['ok'])
+
+    def test_test_passes_with_valid_creds(self):
+        server.GatewayCredentialsManager.set(
+            'twilio', {'account_sid': 'AC1', 'auth_token': 'super-secret-9999'})
+        h = self._handler()
+        with mock.patch.object(wa.TwilioProvider, 'validate',
+                               return_value=(True, 'HTTP 200')):
+            server.BrowserHandler.handle_gateway_test(h)
+        obj, status = self.last()
+        self.assertEqual(status, 200)
+        self.assertTrue(obj['ok'])
 
 
 if __name__ == '__main__':

--- a/charts/workspace/tests/gateway_whatsapp_test.py
+++ b/charts/workspace/tests/gateway_whatsapp_test.py
@@ -330,5 +330,168 @@ class AdapterWiringTest(unittest.TestCase):
         self.assertEqual(a.capabilities.max_text_len, 4096)
 
 
+# ───────────────────────────────────────────────────────────────────────────
+# Provider registry + declarative spec (issue #328)
+# ───────────────────────────────────────────────────────────────────────────
+class ProviderRegistryTest(unittest.TestCase):
+    def test_list_providers_has_twilio_and_meta(self):
+        ids = [s.id for s in wa.list_providers()]
+        self.assertIn('twilio', ids)
+        self.assertIn('meta', ids)
+
+    def test_build_twilio_from_creds(self):
+        prov = wa.build_provider('twilio', {
+            'account_sid': 'AC123', 'auth_token': 'tok', 'from_number': 'whatsapp:+1'})
+        self.assertIsInstance(prov, wa.TwilioProvider)
+        self.assertEqual(prov.account_sid, 'AC123')
+        self.assertEqual(prov.auth_token, 'tok')
+        self.assertEqual(prov.from_number, 'whatsapp:+1')
+
+    def test_build_meta_from_creds(self):
+        prov = wa.build_provider('meta', {
+            'app_secret': 'sec', 'verify_token': 'vt',
+            'phone_number_id': 'PN1', 'access_token': 'at'})
+        self.assertIsInstance(prov, wa.MetaProvider)
+        self.assertEqual(prov.app_secret, 'sec')
+        self.assertEqual(prov.verify_token, 'vt')
+        self.assertEqual(prov.phone_number_id, 'PN1')
+        self.assertEqual(prov.access_token, 'at')
+
+    def test_build_is_case_insensitive(self):
+        self.assertIsInstance(wa.build_provider('META', {}), wa.MetaProvider)
+        self.assertIsInstance(wa.build_provider('Twilio', {}), wa.TwilioProvider)
+
+    def test_build_unknown_raises(self):
+        with self.assertRaises(ValueError):
+            wa.build_provider('nope', {})
+
+    def test_build_with_none_creds_is_empty(self):
+        prov = wa.build_provider('twilio', None)
+        self.assertEqual(prov.account_sid, '')
+        self.assertEqual(prov.auth_token, '')
+
+    def test_build_with_empty_creds_is_empty(self):
+        prov = wa.build_provider('meta', {})
+        self.assertEqual(prov.app_secret, '')
+        self.assertEqual(prov.phone_number_id, '')
+
+    def test_get_provider_spec(self):
+        self.assertEqual(wa.get_provider_spec('twilio').id, 'twilio')
+        self.assertIsNone(wa.get_provider_spec('nope'))
+
+
+class ProviderSpecSerializationTest(unittest.TestCase):
+    def test_specs_are_json_serializable(self):
+        for spec in wa.list_providers():
+            # Must not raise — the stage-3 Settings form is driven by this.
+            json.dumps(spec.to_dict())
+
+    def test_serialization_round_trips(self):
+        for spec in wa.list_providers():
+            d = spec.to_dict()
+            self.assertEqual(json.loads(json.dumps(d)), d)
+
+    def test_spec_shape_is_complete(self):
+        d = wa.get_provider_spec('twilio').to_dict()
+        self.assertEqual(d['id'], 'twilio')
+        self.assertTrue(d['display_name'])
+        self.assertTrue(d['credential_fields'])
+        for f in d['credential_fields']:
+            self.assertIn('key', f)
+            self.assertIn('label', f)
+            self.assertIn('secret', f)
+        self.assertIn('key', d['sender_field'])
+        # Capabilities serialize as their dataclass fields.
+        self.assertIn('proactive', d['capabilities'])
+        self.assertIn('max_text_len', d['capabilities'])
+
+    def test_secret_flags_are_correct(self):
+        tw = {f.key: f for f in wa.get_provider_spec('twilio').credential_fields}
+        self.assertTrue(tw['auth_token'].secret)
+        self.assertFalse(tw['account_sid'].secret)
+        mt = {f.key: f for f in wa.get_provider_spec('meta').credential_fields}
+        self.assertTrue(mt['app_secret'].secret)
+        self.assertTrue(mt['access_token'].secret)
+        self.assertFalse(mt['verify_token'].secret)
+        # Sender fields are non-secret identifiers, not credentials.
+        self.assertFalse(wa.get_provider_spec('meta').sender_field.secret)
+
+    def test_field_keys_cover_factory_inputs(self):
+        # Every key the factory reads must be declared on the spec, so the
+        # stage-2 store and stage-3 form know the full set.
+        self.assertEqual(
+            set(wa.get_provider_spec('twilio').field_keys()),
+            {'account_sid', 'auth_token', 'from_number'})
+        self.assertEqual(
+            set(wa.get_provider_spec('meta').field_keys()),
+            {'access_token', 'app_secret', 'verify_token', 'phone_number_id'})
+
+
+class ProviderCapabilitiesTest(unittest.TestCase):
+    def test_capabilities_declared_per_spec(self):
+        self.assertFalse(wa.get_provider_spec('twilio').capabilities.proactive)
+        self.assertTrue(wa.get_provider_spec('meta').capabilities.proactive)
+
+    def test_whatsapp_limits_shared_across_providers(self):
+        for pid in ('twilio', 'meta'):
+            caps = wa.get_provider_spec(pid).capabilities
+            self.assertTrue(caps.buttons)
+            self.assertEqual(caps.max_buttons, 3)
+            self.assertEqual(caps.max_list_rows, 10)
+            self.assertEqual(caps.max_text_len, 4096)
+
+    def test_adapter_reads_provider_capabilities(self):
+        self.assertIs(
+            wa.WhatsAppAdapter(provider=wa.MetaProvider()).capabilities,
+            wa.MetaProvider.capabilities)
+
+
+class ProviderFromEnvTest(unittest.TestCase):
+    """The env path stays valid for platform-managed deploys and must behave
+    exactly as before #328."""
+
+    _VARS = ('KC_WHATSAPP_PROVIDER', 'KC_META_APP_SECRET', 'KC_META_VERIFY_TOKEN',
+             'KC_META_PHONE_NUMBER_ID', 'KC_META_ACCESS_TOKEN',
+             'KC_TWILIO_AUTH_TOKEN', 'KC_TWILIO_ACCOUNT_SID', 'KC_TWILIO_FROM')
+
+    def setUp(self):
+        self._saved = {k: os.environ.pop(k, None) for k in self._VARS}
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_default_is_twilio(self):
+        self.assertIsInstance(wa._provider_from_env(), wa.TwilioProvider)
+
+    def test_meta_selected(self):
+        os.environ['KC_WHATSAPP_PROVIDER'] = 'meta'
+        self.assertIsInstance(wa._provider_from_env(), wa.MetaProvider)
+
+    def test_unknown_value_falls_back_to_twilio(self):
+        os.environ['KC_WHATSAPP_PROVIDER'] = 'bogus'
+        self.assertIsInstance(wa._provider_from_env(), wa.TwilioProvider)
+
+    def test_reads_twilio_credentials(self):
+        os.environ['KC_TWILIO_ACCOUNT_SID'] = 'AC9'
+        os.environ['KC_TWILIO_AUTH_TOKEN'] = 'tk9'
+        os.environ['KC_TWILIO_FROM'] = 'whatsapp:+19'
+        prov = wa._provider_from_env()
+        self.assertEqual(prov.account_sid, 'AC9')
+        self.assertEqual(prov.auth_token, 'tk9')
+        self.assertEqual(prov.from_number, 'whatsapp:+19')
+
+    def test_reads_meta_credentials(self):
+        os.environ['KC_WHATSAPP_PROVIDER'] = 'meta'
+        os.environ['KC_META_APP_SECRET'] = 's9'
+        os.environ['KC_META_PHONE_NUMBER_ID'] = 'PN9'
+        prov = wa._provider_from_env()
+        self.assertEqual(prov.app_secret, 's9')
+        self.assertEqual(prov.phone_number_id, 'PN9')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/charts/workspace/tests/gateway_whatsapp_test.py
+++ b/charts/workspace/tests/gateway_whatsapp_test.py
@@ -18,6 +18,8 @@ import json
 import os
 import sys
 import unittest
+import urllib.error
+from unittest import mock
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(HERE))
@@ -444,6 +446,64 @@ class ProviderCapabilitiesTest(unittest.TestCase):
         self.assertIs(
             wa.WhatsAppAdapter(provider=wa.MetaProvider()).capabilities,
             wa.MetaProvider.capabilities)
+
+
+class ProviderValidateTest(unittest.TestCase):
+    """Test-connection probe (issue #329): an authenticated GET that proves the
+    credentials without sending a message. Network is mocked; the returned
+    detail must never carry secret material."""
+
+    def _mock_ok(self, status=200):
+        resp = mock.MagicMock()
+        resp.status = status
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = False
+        return resp
+
+    def test_twilio_missing_creds(self):
+        ok, detail = wa.TwilioProvider().validate()
+        self.assertFalse(ok)
+        self.assertIn('not configured', detail)
+
+    def test_twilio_ok(self):
+        prov = wa.TwilioProvider(account_sid='AC1', auth_token='sekret9999')
+        with mock.patch('urllib.request.urlopen', return_value=self._mock_ok()):
+            ok, detail = prov.validate()
+        self.assertTrue(ok)
+        self.assertNotIn('sekret9999', detail)
+
+    def test_twilio_bad_creds_is_401(self):
+        prov = wa.TwilioProvider(account_sid='AC1', auth_token='sekret9999')
+        err = urllib.error.HTTPError('u', 401, 'Unauthorized', {}, None)
+        with mock.patch('urllib.request.urlopen', side_effect=err):
+            ok, detail = prov.validate()
+        self.assertFalse(ok)
+        self.assertIn('authentication failed', detail)
+        self.assertNotIn('sekret9999', detail)
+
+    def test_twilio_network_error_is_safe(self):
+        prov = wa.TwilioProvider(account_sid='AC1', auth_token='sekret9999')
+        with mock.patch('urllib.request.urlopen', side_effect=OSError('boom')):
+            ok, detail = prov.validate()
+        self.assertFalse(ok)
+        self.assertIn('could not reach provider', detail)
+
+    def test_meta_missing_creds(self):
+        ok, detail = wa.MetaProvider().validate()
+        self.assertFalse(ok)
+        self.assertIn('not configured', detail)
+
+    def test_meta_ok(self):
+        prov = wa.MetaProvider(access_token='at', phone_number_id='PN1')
+        with mock.patch('urllib.request.urlopen', return_value=self._mock_ok()):
+            ok, detail = prov.validate()
+        self.assertTrue(ok)
+
+    def test_adapter_delegates_to_provider(self):
+        prov = wa.MetaProvider(access_token='at', phone_number_id='PN1')
+        with mock.patch('urllib.request.urlopen', return_value=self._mock_ok()):
+            ok, _ = wa.WhatsAppAdapter(provider=prov).validate()
+        self.assertTrue(ok)
 
 
 class ProviderFromEnvTest(unittest.TestCase):

--- a/charts/workspace/tests/server_test.py
+++ b/charts/workspace/tests/server_test.py
@@ -879,6 +879,115 @@ class ProviderKeysManagerTests(unittest.TestCase):
         self.assertEqual(server.ProviderKeysManager.env_overlay(), {'OPENROUTER_API_KEY': 'k'})
 
 
+class GatewayCredentialsManagerTests(unittest.TestCase):
+    """Per-workspace messaging credentials (issue #329): set/clear, spec-driven
+    redaction that never leaks a secret, allowlisted field set, merge that
+    preserves a blank secret, provider switch, atomic 0600 write."""
+
+    SECRET = 'twilio-auth-secret-9999'
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix='kctest-gc-')
+        self._orig_file = server.GatewayCredentialsManager.CREDS_FILE
+        server.GatewayCredentialsManager.CREDS_FILE = os.path.join(
+            self.tmpdir, 'gateway-credentials.json')
+
+    def tearDown(self):
+        server.GatewayCredentialsManager.CREDS_FILE = self._orig_file
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    @property
+    def M(self):
+        return server.GatewayCredentialsManager
+
+    def test_empty_store(self):
+        self.assertIsNone(self.M.get_raw())
+        self.assertFalse(self.M.public_view()['configured'])
+
+    def test_set_stores_flat_creds_including_sender(self):
+        ok, err = self.M.set(
+            'twilio', {'account_sid': 'AC1', 'auth_token': self.SECRET},
+            sender_number='whatsapp:+14155238886')
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        raw = self.M.get_raw()
+        self.assertEqual(raw['provider_id'], 'twilio')
+        self.assertEqual(raw['creds']['account_sid'], 'AC1')
+        self.assertEqual(raw['creds']['auth_token'], self.SECRET)
+        # Sender folds into the provider's sender_field key.
+        self.assertEqual(raw['creds']['from_number'], 'whatsapp:+14155238886')
+
+    def test_public_view_never_leaks_secret(self):
+        self.M.set('twilio', {'account_sid': 'AC1', 'auth_token': self.SECRET},
+                   sender_number='whatsapp:+1')
+        view = self.M.public_view()
+        self.assertTrue(view['configured'])
+        # Secret field: set + hint, NEVER a value.
+        self.assertTrue(view['fields']['auth_token']['set'])
+        self.assertEqual(view['fields']['auth_token']['hint'], '…9999')
+        self.assertNotIn('value', view['fields']['auth_token'])
+        # Non-secret identifiers may surface their value.
+        self.assertEqual(view['fields']['account_sid']['value'], 'AC1')
+        self.assertEqual(view['fields']['from_number']['value'], 'whatsapp:+1')
+        # The raw secret must not appear anywhere in the serialized view.
+        self.assertNotIn(self.SECRET, json.dumps(view))
+        self.assertNotIn('auth-secret', json.dumps(view))
+
+    def test_unknown_provider_rejected(self):
+        ok, err = self.M.set('nope', {'x': 'y'})
+        self.assertFalse(ok)
+        self.assertIn('unknown provider', err or '')
+        self.assertIsNone(self.M.get_raw())
+
+    def test_unknown_field_keys_dropped(self):
+        self.M.set('meta', {
+            'access_token': 'at', 'app_secret': 'as', 'verify_token': 'vt',
+            'phone_number_id': 'PN', 'EVIL': 'should-not-persist'})
+        raw = self.M.get_raw()
+        self.assertNotIn('EVIL', raw['creds'])
+        self.assertEqual(set(raw['creds']), {
+            'access_token', 'app_secret', 'verify_token', 'phone_number_id'})
+
+    def test_blank_secret_preserved_on_update(self):
+        self.M.set('twilio', {'account_sid': 'AC1', 'auth_token': self.SECRET},
+                   sender_number='whatsapp:+1')
+        # Re-save with a blank token (form left the masked secret untouched) and
+        # a new sender — the token must survive, the sender must update.
+        self.M.set('twilio', {'account_sid': 'AC1', 'auth_token': ''},
+                   sender_number='whatsapp:+2')
+        raw = self.M.get_raw()
+        self.assertEqual(raw['creds']['auth_token'], self.SECRET)
+        self.assertEqual(raw['creds']['from_number'], 'whatsapp:+2')
+
+    def test_switching_provider_starts_fresh(self):
+        self.M.set('twilio', {'account_sid': 'AC1', 'auth_token': self.SECRET})
+        self.M.set('meta', {'access_token': 'at', 'phone_number_id': 'PN'})
+        raw = self.M.get_raw()
+        self.assertEqual(raw['provider_id'], 'meta')
+        # No Twilio creds carried across the switch.
+        self.assertNotIn('auth_token', raw['creds'])
+        self.assertNotIn('account_sid', raw['creds'])
+
+    def test_clear_disables_channel(self):
+        self.M.set('twilio', {'account_sid': 'AC1', 'auth_token': self.SECRET})
+        self.assertTrue(self.M.clear())
+        self.assertIsNone(self.M.get_raw())
+        # Idempotent — clearing an already-empty store is fine.
+        self.assertTrue(self.M.clear())
+
+    def test_validate_stored_empty(self):
+        ok, detail = self.M.validate_stored()
+        self.assertFalse(ok)
+        self.assertEqual(detail, 'no credentials configured')
+
+    @unittest.skipIf(sys.platform == 'win32', 'chmod bits are a no-op on Windows')
+    def test_written_file_is_0600(self):
+        self.M.set('twilio', {'account_sid': 'AC1', 'auth_token': self.SECRET})
+        mode = os.stat(self.M.CREDS_FILE).st_mode & 0o777
+        self.assertEqual(mode, 0o600)
+
+
 class SubscriptionStatusManagerTests(unittest.TestCase):
     """Tests for SubscriptionStatusManager: reads plan/expiry from credential
     files, NEVER surfaces token material, logout only via the CLI subcommand."""


### PR DESCRIPTION
Stage 2/5 of #325 — productionize the WhatsApp gateway (Model B). Closes #329.

Gives each workspace a **user-editable, redacted messaging-credential store** plus the config endpoints the Settings UI (Stage 3, #330) will call, and rewires the live adapter to build from the store so **saving credentials hot-swaps the provider with no pod restart**. Backend-only — validatable entirely over the API.

> **Stacked on #328 / #387.** This branch builds on the provider registry from #328, which is not yet merged, so the diff currently shows both commits (`71fe1b5` #328 + `169c613` #329). Once #387 merges into `main`, this narrows to just the #329 commit.

## API

All endpoints are `check_claude_auth`'d; the credential/test endpoints use `allow_none_mode=False` (never reachable in the unauth public demo), matching the `provider-keys` posture.

| Method | Path | Body | Response |
|---|---|---|---|
| GET | `/api/gateway/providers` | — | `{ providers: [ProviderSpec…], available }` — the catalog + each provider's field spec (drives the data-driven form). No secrets. |
| GET | `/api/gateway/credentials` | — | `{ credentials: <redacted view> }` |
| PUT | `/api/gateway/credentials` | `{ provider_id, creds{}, sender_number }` | `{ ok, credentials: <redacted view> }` — sets creds and **hot-swaps** the live adapter |
| DELETE | `/api/gateway/credentials` | — | `{ ok }` — clears the store (disables the channel), adapter falls back to env |
| POST | `/api/gateway/test` | — | `{ ok, detail }` — validates stored creds against the provider; **no message sent**. `400` when nothing is configured |

**Redacted view shape** (`GET /credentials`):
```json
{
  "configured": true,
  "provider_id": "twilio",
  "sender_field": "from_number",
  "fields": {
    "account_sid":  { "set": true, "value": "AC123" },
    "auth_token":   { "set": true, "hint": "…9999" },
    "from_number":  { "set": true, "value": "whatsapp:+14155238886" }
  }
}
```
Secret fields (`auth_token`, `app_secret`, `access_token`) expose only `set` + a last-4 `hint` — **never the value**. Non-secret identifiers (account SID, verify token, sender number) may expose `value`. Empty store → `{ "configured": false, "provider_id": null, "fields": {} }`.

## What's added

**`server.py` — `GatewayCredentialsManager`** (mirrors `ProviderKeysManager`)
- One JSON on the PVC (`/home/dev/.claude-tasks/gateway-credentials.json`), atomic **`os.replace`** 0600 write, redacted `public_view()`.
- Stores `{provider_id, creds{}}` flat-keyed by the provider spec's `field_keys()` (from #328), so it drops straight into `build_provider()`.
- `set()` is **registry-validated + field-allowlisted**, folds `sender_number` into its spec field, and **preserves an existing secret when the incoming value is blank** and the provider is unchanged (so the form needn't re-enter masked secrets); switching provider starts fresh.
- Redaction is **spec-driven** — the provider's `CredentialField.secret` flag decides what's masked, so a new provider needs zero store changes.

**Hot-swap** — `get_gateway_adapter()` now builds via `_build_gateway_adapter()` from the store, falling back to env when empty; PUT/DELETE call `rebuild_gateway_adapter()` under `_GATEWAY_LOCK` so the inbound webhook path uses the new provider immediately.

**`adapters/whatsapp.py`** — `validate()` on each provider + the adapter: an authenticated GET (Twilio account resource / Meta phone-number node) that proves the credentials without messaging a real user. Error strings never contain secret material.

## Security
- Secrets at rest: PVC 0600, atomic write. Redacted in every API/log/list view.
- The only getter that returns secret values (`get_raw()`) is consumed in exactly two places — both feed `build_provider()` — and is never printed, logged, or returned to a client.
- Env stays a supported fallback for platform-managed deployments.

## Tests
- **`server_test.py`** → `GatewayCredentialsManagerTests`: redaction/secret-leak audit, field allowlist, merge-preserve-secret, provider switch, clear, 0600.
- **`gateway_whatsapp_test.py`** → provider `validate()`: ok / 401 / network-error / missing-creds, and no secret in the returned detail.
- **`gateway_routes_test.py`** → all five endpoints, incl. asserting the live adapter **hot-swaps to the new provider on PUT** and **falls back to env on DELETE**.

Suites green: `gateway_whatsapp_test` 65, `gateway_routes_test` 23, `GatewayCredentialsManagerTests` 10.

## Non-goals (later stages)
No Settings UI (#330), no chart/webhook hardening (#331), no docs/mobile (#332), no new providers.
