### PR TITLE
feat(settings): Messaging / WhatsApp section — web + mobile (#330)

### DIFF
--- a/charts/workspace/web/src/api/client.ts
+++ b/charts/workspace/web/src/api/client.ts
@@ -166,6 +166,7 @@ export async function api<T = unknown>(path: string, opts: Options = {}): Promis
 
 export const apiGet = <T>(path: string, query?: Options['query']) => api<T>(path, { method: 'GET', query });
 export const apiPost = <T>(path: string, body?: unknown) => api<T>(path, { method: 'POST', body });
+export const apiPut = <T>(path: string, body?: unknown) => api<T>(path, { method: 'PUT', body });
 export const apiDelete = <T>(path: string) => api<T>(path, { method: 'DELETE' });
 
 /**

--- a/charts/workspace/web/src/api/gateway.test.ts
+++ b/charts/workspace/web/src/api/gateway.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import {
+  getProviders,
+  getCredentials,
+  putCredentials,
+  deleteCredentials,
+  testConnection,
+  createLink,
+  listLinks,
+  deleteLink,
+} from './gateway';
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function capture(body: unknown) {
+  const calls: { url: string; method: string; body?: string }[] = [];
+  globalThis.fetch = vi.fn(async (u: string, init?: RequestInit) => {
+    calls.push({ url: u, method: init?.method ?? 'GET', body: init?.body as string | undefined });
+    return {
+      ok: true,
+      status: 200,
+      statusText: '',
+      headers: { get: (k: string) => (k.toLowerCase() === 'content-type' ? 'application/json' : null) },
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+describe('gateway api', () => {
+  it('getProviders GETs the catalog', async () => {
+    const calls = capture({ providers: [], available: true });
+    await getProviders();
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toContain('/api/gateway/providers');
+  });
+
+  it('getCredentials GETs the redacted view', async () => {
+    const calls = capture({ credentials: { configured: false, provider_id: null, fields: {} } });
+    await getCredentials();
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toContain('/api/gateway/credentials');
+  });
+
+  it('putCredentials PUTs the body', async () => {
+    const calls = capture({ ok: true, credentials: {} });
+    await putCredentials({ provider_id: 'twilio', creds: { account_sid: 'AC1' }, sender_number: 'whatsapp:+1' });
+    expect(calls[0].method).toBe('PUT');
+    expect(calls[0].url).toContain('/api/gateway/credentials');
+    expect(JSON.parse(calls[0].body!)).toEqual({
+      provider_id: 'twilio',
+      creds: { account_sid: 'AC1' },
+      sender_number: 'whatsapp:+1',
+    });
+  });
+
+  it('deleteCredentials DELETEs', async () => {
+    const calls = capture({ ok: true });
+    await deleteCredentials();
+    expect(calls[0].method).toBe('DELETE');
+    expect(calls[0].url).toContain('/api/gateway/credentials');
+  });
+
+  it('testConnection POSTs to /test', async () => {
+    const calls = capture({ ok: true, detail: 'HTTP 200' });
+    await testConnection();
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toContain('/api/gateway/test');
+  });
+
+  it('createLink POSTs a workspace', async () => {
+    const calls = capture({ code: '123456', expires_in: 600, whatsapp_number: '', workspace: 'ws' });
+    await createLink('ws');
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toContain('/api/gateway/link');
+    expect(JSON.parse(calls[0].body!)).toEqual({ workspace: 'ws' });
+  });
+
+  it('listLinks GETs the bindings', async () => {
+    const calls = capture({ links: [], available: true });
+    await listLinks();
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toContain('/api/gateway/links');
+  });
+
+  it('deleteLink DELETEs by id', async () => {
+    const calls = capture({ ok: true });
+    await deleteLink('abc123');
+    expect(calls[0].method).toBe('DELETE');
+    expect(calls[0].url).toContain('/api/gateway/link/abc123');
+  });
+});

--- a/charts/workspace/web/src/api/gateway.ts
+++ b/charts/workspace/web/src/api/gateway.ts
@@ -1,0 +1,109 @@
+import { apiGet, apiPost, apiPut, apiDelete } from './client';
+
+/**
+ * Client for the Conversation Gateway config + link endpoints (issues #328/#329).
+ *
+ * The provider catalog is data-driven: GET /api/gateway/providers returns each
+ * provider's declared credential fields (from the registry in
+ * adapters/whatsapp.py), so the Settings form renders whatever the selected
+ * provider needs with zero UI changes. Credentials are stored per-workspace and
+ * always returned REDACTED — secret fields expose only `set` + a last-4 `hint`,
+ * never the value. Mirrors api/providerKeys.ts + api/gatewayPreview.ts.
+ */
+
+// ── provider catalog (mirrors ProviderSpec.to_dict / CredentialField.to_dict) ──
+export interface CredentialField {
+  key: string;
+  label: string;
+  secret: boolean;
+  placeholder: string;
+  help_url: string;
+  required: boolean;
+}
+
+export interface ProviderCapabilities {
+  proactive: boolean;
+  max_text_len: number;
+  [k: string]: unknown;
+}
+
+export interface ProviderSpec {
+  id: string;
+  display_name: string;
+  credential_fields: CredentialField[];
+  sender_field: CredentialField;
+  capabilities: ProviderCapabilities;
+}
+
+// ── redacted credential state (mirrors GatewayCredentialsManager.public_view) ──
+export interface CredentialFieldState {
+  set: boolean;
+  hint?: string; // secret fields: "…9999"; never the value
+  value?: string; // non-secret fields only (SID, verify token, sender number)
+}
+
+export interface CredentialsView {
+  configured: boolean;
+  provider_id: string | null;
+  sender_field?: string;
+  fields: Record<string, CredentialFieldState>;
+}
+
+// ── identity bindings (mirrors IdentityRegistry.public_view) ──
+export interface LinkBinding {
+  workspace: string;
+  workspace_host: string;
+  is_default: boolean;
+  has_thread: boolean;
+  token_set: boolean;
+  bound_at: number;
+}
+
+export interface GatewayLink {
+  id: string;
+  channel: string;
+  created_at: number;
+  updated_at: number;
+  bindings: LinkBinding[];
+}
+
+export interface PairingCode {
+  code: string;
+  expires_in: number;
+  whatsapp_number: string;
+  workspace: string;
+}
+
+// ── config API ──
+export const getProviders = () =>
+  apiGet<{ providers: ProviderSpec[]; available: boolean }>('/api/gateway/providers');
+
+export const getCredentials = () =>
+  apiGet<{ credentials: CredentialsView }>('/api/gateway/credentials');
+
+export const putCredentials = (body: {
+  provider_id: string;
+  creds: Record<string, string>;
+  sender_number?: string;
+}) => apiPut<{ ok: true; credentials: CredentialsView }>('/api/gateway/credentials', body);
+
+export const deleteCredentials = () =>
+  apiDelete<{ ok: true }>('/api/gateway/credentials');
+
+export const testConnection = () =>
+  apiPost<{ ok: boolean; detail: string }>('/api/gateway/test');
+
+// ── link (pairing) API — endpoints from issue #306 ──
+export const createLink = (workspace = 'workspace') =>
+  apiPost<PairingCode>('/api/gateway/link', { workspace });
+
+export const listLinks = () =>
+  apiGet<{
+    links: GatewayLink[];
+    available: boolean;
+    whatsapp_number?: string;
+    proactive?: boolean;
+  }>('/api/gateway/links');
+
+export const deleteLink = (id: string) =>
+  apiDelete<{ ok: boolean }>(`/api/gateway/link/${id}`);

--- a/charts/workspace/web/src/routes/settings/MessagingSection.test.tsx
+++ b/charts/workspace/web/src/routes/settings/MessagingSection.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/preact';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import type {
+  ProviderSpec,
+  CredentialsView,
+  GatewayLink,
+} from '../../api/gateway';
+
+// ── canned catalog: Twilio + Meta, mirroring the #328 registry specs ──
+const TWILIO: ProviderSpec = {
+  id: 'twilio',
+  display_name: 'Twilio',
+  credential_fields: [
+    { key: 'account_sid', label: 'Account SID', secret: false, placeholder: 'AC…', help_url: '', required: true },
+    { key: 'auth_token', label: 'Auth Token', secret: true, placeholder: '', help_url: '', required: true },
+  ],
+  sender_field: { key: 'from_number', label: 'WhatsApp sender number', secret: false, placeholder: 'whatsapp:+1', help_url: '', required: true },
+  capabilities: { proactive: false, max_text_len: 4096 },
+};
+const META: ProviderSpec = {
+  id: 'meta',
+  display_name: 'Meta (WhatsApp Cloud API)',
+  credential_fields: [
+    { key: 'access_token', label: 'Access Token', secret: true, placeholder: '', help_url: '', required: true },
+    { key: 'app_secret', label: 'App Secret', secret: true, placeholder: '', help_url: '', required: true },
+    { key: 'verify_token', label: 'Webhook Verify Token', secret: false, placeholder: '', help_url: '', required: true },
+  ],
+  sender_field: { key: 'phone_number_id', label: 'Phone Number ID', secret: false, placeholder: '123', help_url: '', required: true },
+  capabilities: { proactive: true, max_text_len: 4096 },
+};
+
+let credView: CredentialsView = { configured: false, provider_id: null, fields: {} };
+let linkList: GatewayLink[] = [];
+const putSpy = vi.fn();
+const delCredSpy = vi.fn();
+const delLinkSpy = vi.fn();
+let testResult = { ok: true, detail: 'HTTP 200' };
+
+vi.mock('../../api/gateway', () => ({
+  getProviders: () => Promise.resolve({ providers: [TWILIO, META], available: true }),
+  getCredentials: () => Promise.resolve({ credentials: credView }),
+  putCredentials: (b: unknown) => { putSpy(b); return Promise.resolve({ ok: true, credentials: credView }); },
+  deleteCredentials: () => { delCredSpy(); return Promise.resolve({ ok: true }); },
+  testConnection: () => Promise.resolve(testResult),
+  createLink: () => Promise.resolve({ code: '483920', expires_in: 600, whatsapp_number: '', workspace: 'ws' }),
+  listLinks: () => Promise.resolve({ links: linkList, available: true }),
+  deleteLink: (id: string) => { delLinkSpy(id); return Promise.resolve({ ok: true }); },
+}));
+
+import { MessagingSection } from './MessagingSection';
+
+describe('MessagingSection', () => {
+  beforeEach(() => {
+    credView = { configured: false, provider_id: null, fields: {} };
+    linkList = [];
+    testResult = { ok: true, detail: 'HTTP 200' };
+    putSpy.mockClear();
+    delCredSpy.mockClear();
+    delLinkSpy.mockClear();
+  });
+
+  it('renders the default provider fields (data-driven)', async () => {
+    render(<MessagingSection />);
+    // Twilio is first → its fields show.
+    expect(await screen.findByText('Account SID')).toBeTruthy();
+    expect(screen.getByText('Auth Token')).toBeTruthy();
+    expect(screen.getByText('WhatsApp sender number')).toBeTruthy();
+  });
+
+  it('switching to Meta renders exactly Meta\'s declared fields', async () => {
+    render(<MessagingSection />);
+    fireEvent.click(await screen.findByText('Meta (WhatsApp Cloud API)'));
+    await waitFor(() => expect(screen.getByText('Access Token')).toBeTruthy());
+    expect(screen.getByText('App Secret')).toBeTruthy();
+    expect(screen.getByText('Webhook Verify Token')).toBeTruthy();
+    expect(screen.getByText('Phone Number ID')).toBeTruthy();
+    // Twilio-only field is gone.
+    expect(screen.queryByText('Account SID')).toBeNull();
+  });
+
+  it('shows masked state and never leaks the secret', async () => {
+    credView = {
+      configured: true,
+      provider_id: 'twilio',
+      sender_field: 'from_number',
+      fields: {
+        account_sid: { set: true, value: 'AC1' },
+        auth_token: { set: true, hint: '…9999' },
+        from_number: { set: true, value: 'whatsapp:+14155238886' },
+      },
+    };
+    render(<MessagingSection />);
+    expect(await screen.findByText('set · …9999')).toBeTruthy();
+    // The raw secret is never present.
+    expect(document.body.innerHTML).not.toContain('super-secret');
+    expect(screen.getByText('connected')).toBeTruthy();
+  });
+
+  it('Save calls putCredentials with provider_id and sender_number', async () => {
+    render(<MessagingSection />);
+    const sid = (await screen.findByPlaceholderText('AC…')) as HTMLInputElement;
+    fireEvent.input(sid, { target: { value: 'AC123' } });
+    const sender = screen.getByPlaceholderText('whatsapp:+1') as HTMLInputElement;
+    fireEvent.input(sender, { target: { value: 'whatsapp:+19' } });
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() => expect(putSpy).toHaveBeenCalled());
+    const body = putSpy.mock.calls[0][0];
+    expect(body.provider_id).toBe('twilio');
+    expect(body.sender_number).toBe('whatsapp:+19');
+    expect(body.creds.account_sid).toBe('AC123');
+  });
+
+  it('Test connection shows a pass pill', async () => {
+    credView = { configured: true, provider_id: 'twilio', sender_field: 'from_number', fields: {} };
+    render(<MessagingSection />);
+    fireEvent.click(await screen.findByText('Test connection'));
+    await waitFor(() => expect(screen.getByText(/connection ok/)).toBeTruthy());
+  });
+
+  it('Test connection shows a failure pill', async () => {
+    credView = { configured: true, provider_id: 'twilio', sender_field: 'from_number', fields: {} };
+    testResult = { ok: false, detail: 'authentication failed' };
+    render(<MessagingSection />);
+    fireEvent.click(await screen.findByText('Test connection'));
+    await waitFor(() => expect(screen.getByText(/failed · authentication failed/)).toBeTruthy());
+  });
+
+  it('renders linked numbers and unlinks through the confirm', async () => {
+    linkList = [{
+      id: 'a'.repeat(64), channel: 'whatsapp', created_at: 0, updated_at: 0,
+      bindings: [{ workspace: 'default', workspace_host: 'ws.example.com', is_default: true, has_thread: false, token_set: true, bound_at: 0 }],
+    }];
+    render(<MessagingSection />);
+    expect(await screen.findByText('default')).toBeTruthy();
+    fireEvent.click(screen.getByText('Unlink')); // opens the confirm dialog
+    // The dialog renders via a Portal into document.body — query the document.
+    const confirm = await waitFor(() => {
+      const el = document.querySelector('button.cd-confirm') as HTMLButtonElement | null;
+      if (!el) throw new Error('confirm not shown yet');
+      return el;
+    });
+    fireEvent.click(confirm);
+    await waitFor(() => expect(delLinkSpy).toHaveBeenCalledWith('a'.repeat(64)));
+  });
+
+  it('Disconnect clears credentials through the confirm', async () => {
+    credView = { configured: true, provider_id: 'twilio', sender_field: 'from_number', fields: {} };
+    render(<MessagingSection />);
+    fireEvent.click(await screen.findByText('Disconnect'));
+    const confirm = await waitFor(() => {
+      const el = document.querySelector('button.cd-confirm') as HTMLButtonElement | null;
+      if (!el) throw new Error('confirm not shown yet');
+      return el;
+    });
+    fireEvent.click(confirm);
+    await waitFor(() => expect(delCredSpy).toHaveBeenCalled());
+  });
+});

--- a/charts/workspace/web/src/routes/settings/MessagingSection.tsx
+++ b/charts/workspace/web/src/routes/settings/MessagingSection.tsx
@@ -1,0 +1,462 @@
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import {
+  getProviders,
+  getCredentials,
+  putCredentials,
+  deleteCredentials,
+  testConnection,
+  createLink,
+  listLinks,
+  deleteLink,
+  type ProviderSpec,
+  type CredentialField,
+  type CredentialsView,
+  type GatewayLink,
+  type PairingCode,
+} from '../../api/gateway';
+import { Button } from '../../components/primitives/Button';
+import { Input } from '../../components/primitives/Input';
+import { Pill } from '../../components/primitives/Pill';
+import { Icon } from '../../components/Icon';
+import { ConfirmDialog } from '../../components/ConfirmDialog';
+import { pushToast } from '../../store/ui';
+
+function fmtCountdown(sec: number): string {
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+async function copy(text: string, label: string) {
+  try {
+    await navigator.clipboard.writeText(text);
+    pushToast(`${label} copied`, { kind: 'success' });
+  } catch {
+    pushToast(`Couldn't copy ${label.toLowerCase()} — select it and copy manually`, { kind: 'warn' });
+  }
+}
+
+/** The dialable WhatsApp number for a wa.me deep link, or null when the sender
+ *  isn't a real number (Meta's phone_number_id is an opaque id, not dialable). */
+function dialableSender(view: CredentialsView | null): string | null {
+  if (!view || !view.sender_field) return null;
+  const raw = view.fields[view.sender_field]?.value || '';
+  if (!(raw.startsWith('whatsapp:') || raw.startsWith('+'))) return null;
+  const digits = raw.replace(/^whatsapp:/, '').replace(/[^\d]/g, '');
+  return digits.length >= 6 ? digits : null;
+}
+
+export function MessagingSection() {
+  const [providers, setProviders] = useState<ProviderSpec[] | null>(null);
+  const [available, setAvailable] = useState(true);
+  const [cred, setCred] = useState<CredentialsView | null>(null);
+  const [providerId, setProviderId] = useState<string>('');
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+  const [testResult, setTestResult] = useState<{ ok: boolean; detail: string } | null>(null);
+  const [links, setLinks] = useState<GatewayLink[]>([]);
+  const [code, setCode] = useState<PairingCode | null>(null);
+  const [remaining, setRemaining] = useState(0);
+  const [confirmDisconnect, setConfirmDisconnect] = useState(false);
+  const [unlinkTarget, setUnlinkTarget] = useState<string | null>(null);
+  const codeTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const spec = useMemo(
+    () => providers?.find((p) => p.id === providerId) ?? null,
+    [providers, providerId],
+  );
+
+  // Seed the draft inputs from a redacted view: pre-fill non-secret fields with
+  // their stored value; leave secret fields blank (the Pill shows set · hint).
+  function seedDrafts(view: CredentialsView | null, s: ProviderSpec | null) {
+    const next: Record<string, string> = {};
+    if (view && s && view.provider_id === s.id) {
+      for (const f of [...s.credential_fields, s.sender_field]) {
+        if (!f.secret) next[f.key] = view.fields[f.key]?.value ?? '';
+      }
+    }
+    setDrafts(next);
+  }
+
+  async function refresh() {
+    try {
+      const [pr, cr] = await Promise.all([getProviders(), getCredentials()]);
+      setProviders(pr.providers);
+      setAvailable(pr.available);
+      setCred(cr.credentials);
+      const pid = cr.credentials.provider_id || pr.providers[0]?.id || '';
+      setProviderId(pid);
+      seedDrafts(cr.credentials, pr.providers.find((p) => p.id === pid) ?? null);
+    } catch {
+      // gateway/server unavailable — leave nulls (renders the "unavailable" note)
+      setAvailable(false);
+    }
+  }
+
+  async function refreshLinks() {
+    try {
+      const r = await listLinks();
+      setLinks(r.links || []);
+    } catch {
+      /* leave prior links */
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+    void refreshLinks();
+    return () => {
+      if (codeTimer.current) clearInterval(codeTimer.current);
+    };
+  }, []);
+
+  // Countdown for a freshly minted pairing code.
+  useEffect(() => {
+    if (codeTimer.current) clearInterval(codeTimer.current);
+    if (!code) return;
+    codeTimer.current = setInterval(() => {
+      setRemaining((r) => {
+        if (r <= 1) {
+          if (codeTimer.current) clearInterval(codeTimer.current);
+          setCode(null);
+          return 0;
+        }
+        return r - 1;
+      });
+    }, 1000);
+    return () => {
+      if (codeTimer.current) clearInterval(codeTimer.current);
+    };
+  }, [code]);
+
+  function onPickProvider(pid: string) {
+    setProviderId(pid);
+    setTestResult(null);
+    seedDrafts(cred, providers?.find((p) => p.id === pid) ?? null);
+  }
+
+  async function onSave() {
+    if (!spec) return;
+    setBusy(true);
+    try {
+      const creds: Record<string, string> = {};
+      for (const f of spec.credential_fields) creds[f.key] = drafts[f.key] ?? '';
+      await putCredentials({
+        provider_id: spec.id,
+        creds,
+        sender_number: drafts[spec.sender_field.key] ?? '',
+      });
+      pushToast('Credentials saved', { kind: 'success' });
+      setTestResult(null);
+      await refresh();
+    } catch (err) {
+      pushToast(err instanceof Error ? err.message : 'Save failed', { kind: 'danger' });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onDisconnect() {
+    setConfirmDisconnect(false);
+    setBusy(true);
+    try {
+      await deleteCredentials();
+      pushToast('Messaging disconnected', { kind: 'info' });
+      setTestResult(null);
+      await refresh();
+    } catch (err) {
+      pushToast(err instanceof Error ? err.message : 'Disconnect failed', { kind: 'danger' });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onTest() {
+    setBusy(true);
+    setTestResult(null);
+    try {
+      setTestResult(await testConnection());
+    } catch (err) {
+      setTestResult({ ok: false, detail: err instanceof Error ? err.message : 'Test failed' });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onLink() {
+    setBusy(true);
+    try {
+      const c = await createLink();
+      setCode(c);
+      setRemaining(c.expires_in || 600);
+      await refreshLinks();
+    } catch (err) {
+      pushToast(err instanceof Error ? err.message : 'Could not create a pairing code', { kind: 'danger' });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onUnlink(id: string) {
+    setUnlinkTarget(null);
+    setBusy(true);
+    try {
+      await deleteLink(id);
+      pushToast('Unlinked', { kind: 'info' });
+      await refreshLinks();
+    } catch (err) {
+      pushToast(err instanceof Error ? err.message : 'Unlink failed', { kind: 'danger' });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const configured = !!cred?.configured;
+  const webhookUrl =
+    typeof window !== 'undefined'
+      ? `https://${window.location.host}/api/gateway/whatsapp/webhook`
+      : '';
+  const verifyToken =
+    spec?.credential_fields.some((f) => f.key === 'verify_token')
+      ? cred?.fields['verify_token']?.value || (drafts['verify_token'] ?? '')
+      : '';
+  const sender = dialableSender(cred);
+
+  function fieldRow(f: CredentialField) {
+    const state = cred?.provider_id === spec?.id ? cred?.fields[f.key] : undefined;
+    return (
+      <div class="settings-row" key={f.key}>
+        <div class="settings-row-label">
+          {f.label}{' '}
+          {f.secret ? (
+            <Pill tone={state?.set ? 'success' : 'warn'} mono>
+              {state?.set ? `set · ${state.hint || '••••'}` : 'not set'}
+            </Pill>
+          ) : null}
+          {f.help_url ? (
+            <div class="settings-radio-hint muted">
+              <a href={f.help_url} target="_blank" rel="noreferrer">Where to find this ↗</a>
+            </div>
+          ) : null}
+        </div>
+        <div class="settings-row-control" style={{ gap: 'var(--size-2)' }}>
+          <Input
+            fullWidth
+            type={f.secret ? 'password' : 'text'}
+            value={drafts[f.key] ?? ''}
+            placeholder={f.secret ? (state?.set ? 'Replace…' : f.placeholder || 'Paste…') : f.placeholder}
+            onInput={(e) => {
+              const v = (e.target as HTMLInputElement).value;
+              setDrafts((d) => ({ ...d, [f.key]: v }));
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <section class="settings-section">
+      <h2 class="settings-section-title">Messaging / WhatsApp</h2>
+      <p class="settings-row-hint muted">
+        Connect your own WhatsApp provider to chat with this workspace's agent over WhatsApp. Enter
+        your provider credentials, paste the webhook URL into the provider console, then link your
+        number. Credentials are stored securely on your workspace disk and never shared.
+      </p>
+
+      {!available ? (
+        <p class="settings-row-hint muted">The messaging gateway is not available on this workspace.</p>
+      ) : !providers ? (
+        <p class="settings-row-hint muted">Loading…</p>
+      ) : (
+        <>
+          {/* Provider picker */}
+          <div class="settings-row">
+            <div class="settings-row-label">Provider</div>
+            <div class="settings-row-control">
+              <div class="seg">
+                {providers.map((p) => (
+                  <button
+                    key={p.id}
+                    class={`seg-item ${providerId === p.id ? 'seg-item-active' : ''}`}
+                    onClick={() => onPickProvider(p.id)}
+                  >
+                    {p.display_name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Data-driven credential fields + sender */}
+          {spec ? (
+            <>
+              {spec.credential_fields.map(fieldRow)}
+              {fieldRow(spec.sender_field)}
+
+              <div class="settings-row">
+                <div class="settings-row-label">
+                  Status{' '}
+                  <Pill tone={configured ? 'success' : 'warn'} mono>
+                    {configured ? 'connected' : 'not configured'}
+                  </Pill>
+                </div>
+                <div class="settings-row-control" style={{ gap: 'var(--size-2)' }}>
+                  <Button variant="primary" type="button" disabled={busy} onClick={onSave}>
+                    <Icon name="check" size={14} /> Save
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    type="button"
+                    disabled={busy || !configured}
+                    onClick={onTest}
+                  >
+                    Test connection
+                  </Button>
+                  {configured ? (
+                    <Button
+                      variant="secondary"
+                      type="button"
+                      disabled={busy}
+                      onClick={() => setConfirmDisconnect(true)}
+                    >
+                      Disconnect
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
+
+              {testResult ? (
+                <div class="settings-row">
+                  <div class="settings-row-label" />
+                  <div class="settings-row-control">
+                    <Pill tone={testResult.ok ? 'success' : 'danger'} mono>
+                      {testResult.ok ? 'connection ok' : 'failed'} · {testResult.detail}
+                    </Pill>
+                  </div>
+                </div>
+              ) : !configured ? (
+                <p class="settings-row-hint muted">Save credentials first, then test the connection.</p>
+              ) : null}
+
+              {/* Webhook helper */}
+              <div class="settings-row">
+                <div class="settings-row-label">Webhook URL</div>
+                <div class="settings-row-control settings-copy-row">
+                  <Input fullWidth readOnly value={webhookUrl} />
+                  <Button onClick={() => copy(webhookUrl, 'Webhook URL')}>
+                    <Icon name="link" size={14} /> Copy
+                  </Button>
+                </div>
+              </div>
+              {verifyToken ? (
+                <div class="settings-row">
+                  <div class="settings-row-label">Verify token</div>
+                  <div class="settings-row-control settings-copy-row">
+                    <Input fullWidth readOnly value={verifyToken} />
+                    <Button onClick={() => copy(verifyToken, 'Verify token')}>
+                      <Icon name="link" size={14} /> Copy
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+              <p class="settings-row-hint muted">
+                Paste the webhook URL{verifyToken ? ' and verify token' : ''} into your provider
+                console to receive inbound messages.
+              </p>
+
+              {/* Link management */}
+              <div class="settings-row">
+                <div class="settings-row-label">Link a number</div>
+                <div class="settings-row-control">
+                  <Button variant="primary" type="button" disabled={busy} onClick={onLink}>
+                    <Icon name="link" size={14} /> Link WhatsApp
+                  </Button>
+                </div>
+              </div>
+
+              {code ? (
+                <div class="settings-row">
+                  <div class="settings-row-label">
+                    Pairing code
+                    <div class="settings-radio-hint muted">expires in {fmtCountdown(remaining)}</div>
+                  </div>
+                  <div class="settings-row-control settings-copy-row">
+                    <Input fullWidth readOnly value={code.code} />
+                    <Button onClick={() => copy(code.code, 'Code')}>
+                      <Icon name="link" size={14} /> Copy
+                    </Button>
+                    {sender ? (
+                      <a
+                        class="btn btn-secondary btn-md"
+                        href={`https://wa.me/${sender}?text=${encodeURIComponent(code.code)}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Open in WhatsApp
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+              {code && !sender ? (
+                <p class="settings-row-hint muted">
+                  Message your WhatsApp Business number with the code above to link this number.
+                </p>
+              ) : null}
+
+              {/* Bindings */}
+              {links.length > 0 ? (
+                <div class="settings-row settings-row-control-stack">
+                  <div class="settings-row-label">Linked numbers</div>
+                  <div class="settings-row-control settings-row-control-stack">
+                    {links.map((l) =>
+                      l.bindings.map((b) => (
+                        <div class="settings-link-row" key={`${l.id}-${b.workspace}`}>
+                          <div>
+                            <div class="settings-link-ws">{b.workspace}</div>
+                            <div class="settings-radio-hint muted">
+                              {b.workspace_host || '—'}
+                              {b.is_default ? ' · default' : ''}
+                            </div>
+                          </div>
+                          <Button
+                            variant="secondary"
+                            type="button"
+                            disabled={busy}
+                            onClick={() => setUnlinkTarget(l.id)}
+                          >
+                            Unlink
+                          </Button>
+                        </div>
+                      )),
+                    )}
+                  </div>
+                </div>
+              ) : null}
+            </>
+          ) : null}
+        </>
+      )}
+
+      <ConfirmDialog
+        open={confirmDisconnect}
+        title="Disconnect messaging?"
+        body="This clears your stored provider credentials for this workspace and disables the WhatsApp channel. You can reconnect any time."
+        confirmLabel="Disconnect"
+        destructive
+        onConfirm={onDisconnect}
+        onCancel={() => setConfirmDisconnect(false)}
+      />
+      <ConfirmDialog
+        open={unlinkTarget !== null}
+        title="Unlink this number?"
+        body="The bound WhatsApp number will stop reaching this workspace until it links again."
+        confirmLabel="Unlink"
+        destructive
+        onConfirm={() => unlinkTarget && onUnlink(unlinkTarget)}
+        onCancel={() => setUnlinkTarget(null)}
+      />
+    </section>
+  );
+}

--- a/charts/workspace/web/src/routes/settings/index.tsx
+++ b/charts/workspace/web/src/routes/settings/index.tsx
@@ -4,6 +4,7 @@ import { Icon } from '../../components/Icon';
 import { GitSection } from './GitSection';
 import { ProviderKeysSection } from './ProviderKeysSection';
 import { McpServersSection } from './McpServersSection';
+import { MessagingSection } from './MessagingSection';
 import { BrowserSection } from './BrowserSection';
 import { MetricsSection } from './MetricsSection';
 import { UpdatesSection } from './UpdatesSection';
@@ -84,6 +85,8 @@ export function SettingsRoute() {
       <ProviderKeysSection />
 
       <McpServersSection />
+
+      <MessagingSection />
 
       <BrowserSection />
 

--- a/charts/workspace/web/src/routes/settings/settings.css
+++ b/charts/workspace/web/src/routes/settings/settings.css
@@ -355,3 +355,16 @@
 @media (prefers-reduced-motion: reduce) {
   .ws-restarting-spinner { animation-duration: 2.4s; }
 }
+
+/* Messaging / WhatsApp section (issue #330) — linked-number rows. */
+.settings-link-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--size-3, 12px);
+  padding: 10px 12px;
+  border: 1px solid var(--border-2);
+  border-radius: 8px;
+  background: var(--surface);
+}
+.settings-link-ws { font-weight: 600; font-size: 14px; }

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -47,6 +47,10 @@ import type {
   PreviewControlResult,
   PreviewSendResult,
   PreviewState,
+  GatewayProviderSpec,
+  GatewayCredentialsView,
+  GatewayLink,
+  GatewayPairingCode,
   SkillRecord,
   TaskDetail,
   TaskSummary,
@@ -1008,6 +1012,60 @@ export async function deleteMcpServer(name: string): Promise<McpSyncResults> {
     { method: 'DELETE' },
   );
   return r.sync;
+}
+
+// ---- Messaging gateway config (issues #328/#329/#330) ----------------------
+// Same endpoints the web dashboard uses; the provider catalog drives the
+// Settings card so a new provider needs zero mobile changes.
+const EMPTY_CREDENTIALS: GatewayCredentialsView = { configured: false, provider_id: null, fields: {} };
+
+export async function getGatewayProviders(): Promise<GatewayProviderSpec[]> {
+  if (getConfig().mock) return [];
+  const r = await request<{ providers: GatewayProviderSpec[]; available: boolean }>('/api/gateway/providers');
+  return r.providers || [];
+}
+
+export async function getGatewayCredentials(): Promise<GatewayCredentialsView> {
+  if (getConfig().mock) return EMPTY_CREDENTIALS;
+  const r = await request<{ credentials: GatewayCredentialsView }>('/api/gateway/credentials');
+  return r.credentials;
+}
+
+export async function putGatewayCredentials(body: {
+  provider_id: string;
+  creds: Record<string, string>;
+  sender_number?: string;
+}): Promise<GatewayCredentialsView> {
+  if (getConfig().mock) return EMPTY_CREDENTIALS;
+  const r = await request<{ ok: boolean; credentials: GatewayCredentialsView }>('/api/gateway/credentials', {
+    method: 'PUT',
+    body,
+  });
+  return r.credentials;
+}
+
+export async function deleteGatewayCredentials(): Promise<void> {
+  if (getConfig().mock) return;
+  await request('/api/gateway/credentials', { method: 'DELETE' });
+}
+
+export async function testGatewayConnection(): Promise<{ ok: boolean; detail: string }> {
+  if (getConfig().mock) return { ok: false, detail: 'demo mode' };
+  return request<{ ok: boolean; detail: string }>('/api/gateway/test', { method: 'POST', body: {} });
+}
+
+export async function createGatewayLink(workspace = 'workspace'): Promise<GatewayPairingCode> {
+  return request<GatewayPairingCode>('/api/gateway/link', { method: 'POST', body: { workspace } });
+}
+
+export async function listGatewayLinks(): Promise<GatewayLink[]> {
+  if (getConfig().mock) return [];
+  const r = await request<{ links: GatewayLink[]; available: boolean }>('/api/gateway/links');
+  return r.links || [];
+}
+
+export async function deleteGatewayLink(id: string): Promise<void> {
+  await request(`/api/gateway/link/${id}`, { method: 'DELETE' });
 }
 
 // ---- Assistants ------------------------------------------------------------

--- a/mobile/src/api/types.ts
+++ b/mobile/src/api/types.ts
@@ -298,3 +298,60 @@ export interface PreviewControlResult {
   linked?: boolean;
   simulate_out_of_window?: boolean;
 }
+
+// ---- Messaging gateway config (issues #328/#329/#330) ----------------------
+// Data-driven provider catalog + redacted per-workspace credential store, shared
+// with the web dashboard (charts/workspace/web/src/api/gateway.ts).
+export interface GatewayCredentialField {
+  key: string;
+  label: string;
+  secret: boolean;
+  placeholder: string;
+  help_url: string;
+  required: boolean;
+}
+
+export interface GatewayProviderSpec {
+  id: string;
+  display_name: string;
+  credential_fields: GatewayCredentialField[];
+  sender_field: GatewayCredentialField;
+  capabilities: { proactive: boolean; max_text_len: number; [k: string]: unknown };
+}
+
+export interface GatewayCredentialFieldState {
+  set: boolean;
+  hint?: string; // secret fields only, e.g. "…9999"; never the value
+  value?: string; // non-secret fields only
+}
+
+export interface GatewayCredentialsView {
+  configured: boolean;
+  provider_id: string | null;
+  sender_field?: string;
+  fields: Record<string, GatewayCredentialFieldState>;
+}
+
+export interface GatewayLinkBinding {
+  workspace: string;
+  workspace_host: string;
+  is_default: boolean;
+  has_thread: boolean;
+  token_set: boolean;
+  bound_at: number;
+}
+
+export interface GatewayLink {
+  id: string;
+  channel: string;
+  created_at: number;
+  updated_at: number;
+  bindings: GatewayLinkBinding[];
+}
+
+export interface GatewayPairingCode {
+  code: string;
+  expires_in: number;
+  whatsapp_number: string;
+  workspace: string;
+}

--- a/mobile/src/components/MessagingCard.tsx
+++ b/mobile/src/components/MessagingCard.tsx
@@ -1,0 +1,495 @@
+/** Settings card for the WhatsApp messaging gateway (issue #330 · mobile parity).
+ *  Mirrors the web dashboard's MessagingSection and ProviderKeysCard: a
+ *  data-driven provider form (fields come from the registry catalog), masked
+ *  credential status, test-connection, a webhook helper, and pairing-code link
+ *  management. Talks to the same /api/gateway/* endpoints as the web app. */
+import { Ionicons } from '@expo/vector-icons';
+import * as Clipboard from 'expo-clipboard';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Linking,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {
+  getGatewayProviders,
+  getGatewayCredentials,
+  putGatewayCredentials,
+  deleteGatewayCredentials,
+  testGatewayConnection,
+  createGatewayLink,
+  listGatewayLinks,
+  deleteGatewayLink,
+} from '../api/client';
+import type {
+  GatewayProviderSpec,
+  GatewayCredentialField,
+  GatewayCredentialsView,
+  GatewayLink,
+  GatewayPairingCode,
+} from '../api/types';
+import { useConfig } from '../store/useConfig';
+import { colors, font, radius, space } from '../theme';
+import { confirmAction } from '../util/confirm';
+import { Button, Card, Label } from './ui';
+
+function dialableSender(view: GatewayCredentialsView | null): string | null {
+  if (!view || !view.sender_field) return null;
+  const raw = view.fields[view.sender_field]?.value || '';
+  if (!(raw.startsWith('whatsapp:') || raw.startsWith('+'))) return null;
+  const digits = raw.replace(/^whatsapp:/, '').replace(/[^\d]/g, '');
+  return digits.length >= 6 ? digits : null;
+}
+
+function fmt(sec: number): string {
+  const m = Math.floor(sec / 60);
+  return `${m}:${String(sec % 60).padStart(2, '0')}`;
+}
+
+export function MessagingCard({ readOnly }: { readOnly?: boolean }) {
+  const cfg = useConfig();
+  const [providers, setProviders] = useState<GatewayProviderSpec[] | null>(null);
+  const [cred, setCred] = useState<GatewayCredentialsView | null>(null);
+  const [providerId, setProviderId] = useState('');
+  const [links, setLinks] = useState<GatewayLink[]>([]);
+  const [editing, setEditing] = useState(false);
+  const [testResult, setTestResult] = useState<{ ok: boolean; detail: string } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [code, setCode] = useState<GatewayPairingCode | null>(null);
+  const [remaining, setRemaining] = useState(0);
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const spec = providers?.find((p) => p.id === providerId) ?? null;
+  const configured = !!cred?.configured;
+
+  async function refresh() {
+    try {
+      const [pr, cr] = await Promise.all([getGatewayProviders(), getGatewayCredentials()]);
+      setProviders(pr);
+      setCred(cr);
+      setProviderId(cr.provider_id || pr[0]?.id || '');
+    } catch {
+      setProviders([]); // renders "unavailable" gracefully
+    }
+  }
+  async function refreshLinks() {
+    try {
+      setLinks(await listGatewayLinks());
+    } catch {
+      /* leave prior */
+    }
+  }
+  useEffect(() => {
+    void refresh();
+    void refreshLinks();
+    return () => {
+      if (timer.current) clearInterval(timer.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (timer.current) clearInterval(timer.current);
+    if (!code) return;
+    timer.current = setInterval(() => {
+      setRemaining((r) => {
+        if (r <= 1) {
+          if (timer.current) clearInterval(timer.current);
+          setCode(null);
+          return 0;
+        }
+        return r - 1;
+      });
+    }, 1000);
+    return () => {
+      if (timer.current) clearInterval(timer.current);
+    };
+  }, [code]);
+
+  async function copy(text: string) {
+    try {
+      await Clipboard.setStringAsync(text);
+    } catch {
+      /* clipboard unavailable */
+    }
+  }
+
+  async function onTest() {
+    setBusy(true);
+    setTestResult(null);
+    try {
+      setTestResult(await testGatewayConnection());
+    } catch (e) {
+      setTestResult({ ok: false, detail: (e as Error).message });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function onDisconnect() {
+    confirmAction({
+      title: 'Disconnect messaging?',
+      message: 'Clears your stored provider credentials and disables the WhatsApp channel.',
+      confirmLabel: 'Disconnect',
+      destructive: true,
+      onConfirm: async () => {
+        await deleteGatewayCredentials();
+        setTestResult(null);
+        await refresh();
+      },
+    });
+  }
+
+  async function onLink() {
+    setBusy(true);
+    try {
+      const c = await createGatewayLink();
+      setCode(c);
+      setRemaining(c.expires_in || 600);
+      await refreshLinks();
+    } catch {
+      /* surface nothing — button just no-ops on failure */
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function onUnlink(id: string) {
+    confirmAction({
+      title: 'Unlink this number?',
+      message: 'It will stop reaching this workspace until it links again.',
+      confirmLabel: 'Unlink',
+      destructive: true,
+      onConfirm: async () => {
+        await deleteGatewayLink(id);
+        await refreshLinks();
+      },
+    });
+  }
+
+  const webhookUrl = cfg.host ? `${cfg.host.replace(/\/$/, '')}/api/gateway/whatsapp/webhook` : '';
+  const verifyToken = spec?.credential_fields.some((f) => f.key === 'verify_token')
+    ? cred?.fields['verify_token']?.value || ''
+    : '';
+  const sender = dialableSender(cred);
+
+  if (providers && providers.length === 0) {
+    return (
+      <Card style={{ gap: space.md, marginTop: space.lg }}>
+        <Label>Messaging / WhatsApp</Label>
+        <Text style={styles.help}>The messaging gateway is not available on this workspace.</Text>
+      </Card>
+    );
+  }
+
+  return (
+    <Card style={{ gap: space.md, marginTop: space.lg }}>
+      <Label>Messaging / WhatsApp</Label>
+      <Text style={styles.help}>
+        Connect your own WhatsApp provider to chat with this workspace over WhatsApp. Credentials are
+        stored securely on your workspace disk.
+      </Text>
+
+      {/* Provider chooser */}
+      {providers ? (
+        <View style={styles.chips}>
+          {providers.map((p) => (
+            <Pressable
+              key={p.id}
+              onPress={() => { setProviderId(p.id); setTestResult(null); }}
+              style={[styles.chip, providerId === p.id && styles.chipActive]}
+            >
+              <Text style={[styles.chipText, providerId === p.id && styles.chipTextActive]}>
+                {p.display_name}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : (
+        <Text style={styles.help}>Loading…</Text>
+      )}
+
+      {/* Masked field status */}
+      {spec
+        ? [...spec.credential_fields, spec.sender_field].map((f) => {
+            const st = cred?.provider_id === spec.id ? cred?.fields[f.key] : undefined;
+            const isSet = !!st?.set;
+            const shown = f.secret ? (isSet ? `set · ${st?.hint || '••••'}` : 'not set') : st?.value || 'not set';
+            return (
+              <View key={f.key} style={styles.row}>
+                <Text style={styles.fieldLabel}>{f.label}</Text>
+                <Text style={[styles.fieldState, { color: isSet ? colors.success : colors.textFaint }]}>
+                  {shown}
+                </Text>
+              </View>
+            );
+          })
+        : null}
+
+      {/* Status + actions */}
+      <View style={styles.statusRow}>
+        <Text style={[styles.state, { color: configured ? colors.success : colors.textFaint }]}>
+          {configured ? 'Connected' : 'Not configured'}
+        </Text>
+      </View>
+      {!readOnly && spec ? (
+        <>
+          <Button title="Configure credentials" icon="key-outline" onPress={() => setEditing(true)} />
+          <Button
+            title="Test connection"
+            variant="secondary"
+            onPress={onTest}
+            loading={busy}
+            disabled={!configured}
+            style={{ marginTop: space.sm }}
+          />
+          {testResult ? (
+            <Text style={{ color: testResult.ok ? colors.success : colors.danger, fontSize: font.size.sm }}>
+              {testResult.ok ? 'Connection ok' : 'Failed'} · {testResult.detail}
+            </Text>
+          ) : null}
+        </>
+      ) : null}
+
+      {/* Webhook helper */}
+      {spec ? (
+        <>
+          <View style={styles.copyRow}>
+            <View style={{ flex: 1 }}>
+              <Label>Webhook URL</Label>
+              <Text style={styles.mono} numberOfLines={1}>{webhookUrl}</Text>
+            </View>
+            <Pressable onPress={() => copy(webhookUrl)} hitSlop={8} accessibilityLabel="Copy webhook URL">
+              <Ionicons name="copy-outline" size={20} color={colors.textMuted} />
+            </Pressable>
+          </View>
+          {verifyToken ? (
+            <View style={styles.copyRow}>
+              <View style={{ flex: 1 }}>
+                <Label>Verify token</Label>
+                <Text style={styles.mono} numberOfLines={1}>{verifyToken}</Text>
+              </View>
+              <Pressable onPress={() => copy(verifyToken)} hitSlop={8} accessibilityLabel="Copy verify token">
+                <Ionicons name="copy-outline" size={20} color={colors.textMuted} />
+              </Pressable>
+            </View>
+          ) : null}
+        </>
+      ) : null}
+
+      {/* Link management */}
+      {!readOnly ? (
+        <Button title="Link WhatsApp" icon="link-outline" onPress={onLink} loading={busy} style={{ marginTop: space.sm }} />
+      ) : null}
+      {code ? (
+        <View style={styles.codeBox}>
+          <Text style={styles.codeText}>{code.code}</Text>
+          <Text style={styles.help}>expires in {fmt(remaining)}</Text>
+          {sender ? (
+            <Button
+              title="Open in WhatsApp"
+              variant="secondary"
+              icon="logo-whatsapp"
+              onPress={() => void Linking.openURL(`https://wa.me/${sender}?text=${encodeURIComponent(code.code)}`).catch(() => {})}
+              style={{ marginTop: space.sm }}
+            />
+          ) : (
+            <Text style={styles.help}>Message your WhatsApp Business number with this code to link it.</Text>
+          )}
+        </View>
+      ) : null}
+
+      {/* Bindings */}
+      {links.length > 0 ? (
+        <View style={{ gap: space.sm }}>
+          <Label>Linked numbers</Label>
+          {links.flatMap((l) =>
+            l.bindings.map((b) => (
+              <View key={`${l.id}-${b.workspace}`} style={styles.linkRow}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.fieldLabel}>{b.workspace}</Text>
+                  <Text style={styles.help} numberOfLines={1}>{b.workspace_host || '—'}</Text>
+                </View>
+                {!readOnly ? (
+                  <Pressable onPress={() => onUnlink(l.id)} hitSlop={8} accessibilityLabel="Unlink">
+                    <Ionicons name="trash-outline" size={20} color={colors.danger} />
+                  </Pressable>
+                ) : null}
+              </View>
+            )),
+          )}
+        </View>
+      ) : null}
+
+      <MessagingEditModal
+        visible={editing}
+        spec={spec}
+        cred={cred}
+        onClose={() => setEditing(false)}
+        onDone={async () => { setEditing(false); setTestResult(null); await refresh(); }}
+        onDisconnect={onDisconnect}
+      />
+    </Card>
+  );
+}
+
+function MessagingEditModal({
+  visible,
+  spec,
+  cred,
+  onClose,
+  onDone,
+  onDisconnect,
+}: {
+  visible: boolean;
+  spec: GatewayProviderSpec | null;
+  cred: GatewayCredentialsView | null;
+  onClose: () => void;
+  onDone: () => void;
+  onDisconnect: () => void;
+}) {
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Seed non-secret fields from the redacted view whenever the sheet opens.
+  useEffect(() => {
+    if (!visible || !spec) return;
+    const next: Record<string, string> = {};
+    if (cred?.provider_id === spec.id) {
+      for (const f of [...spec.credential_fields, spec.sender_field]) {
+        if (!f.secret) next[f.key] = cred.fields[f.key]?.value ?? '';
+      }
+    }
+    setDrafts(next);
+    setError(null);
+  }, [visible, spec?.id]);
+
+  const configured = cred?.provider_id === spec?.id && !!cred?.configured;
+
+  async function save() {
+    if (!spec) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const creds: Record<string, string> = {};
+      for (const f of spec.credential_fields) creds[f.key] = drafts[f.key] ?? '';
+      await putGatewayCredentials({
+        provider_id: spec.id,
+        creds,
+        sender_number: drafts[spec.sender_field.key] ?? '',
+      });
+      onDone();
+    } catch (e) {
+      setError(`Couldn't save: ${(e as Error).message}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const fields = spec ? [...spec.credential_fields, spec.sender_field] : [];
+
+  return (
+    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+          <View style={styles.sheet}>
+            <View style={styles.head}>
+              <Text style={styles.title}>{spec?.display_name} credentials</Text>
+              <Pressable onPress={onClose} hitSlop={8} accessibilityLabel="Close">
+                <Ionicons name="close" size={22} color={colors.textMuted} />
+              </Pressable>
+            </View>
+            <ScrollView keyboardShouldPersistTaps="handled">
+              {fields.map((f: GatewayCredentialField) => {
+                const st = cred?.provider_id === spec?.id ? cred?.fields[f.key] : undefined;
+                return (
+                  <View key={f.key} style={{ marginTop: space.md }}>
+                    <Label>{f.label}</Label>
+                    <TextInput
+                      value={drafts[f.key] ?? ''}
+                      onChangeText={(v) => setDrafts((d) => ({ ...d, [f.key]: v }))}
+                      placeholder={f.secret ? (st?.set ? 'Replace…' : f.placeholder || 'Paste…') : f.placeholder}
+                      placeholderTextColor={colors.textFaint}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      secureTextEntry={f.secret}
+                      style={styles.input}
+                    />
+                  </View>
+                );
+              })}
+              {error ? <Text style={styles.error}>{error}</Text> : null}
+              <Button title="Save credentials" onPress={save} loading={busy} style={{ marginTop: space.lg }} />
+              {configured ? (
+                <Button
+                  title="Disconnect"
+                  variant="danger"
+                  icon="trash-outline"
+                  onPress={() => { onClose(); onDisconnect(); }}
+                  disabled={busy}
+                  style={{ marginTop: space.sm }}
+                />
+              ) : null}
+            </ScrollView>
+          </View>
+        </KeyboardAvoidingView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  help: { color: colors.textMuted, fontSize: font.size.sm, lineHeight: 19 },
+  chips: { flexDirection: 'row', flexWrap: 'wrap', gap: space.sm },
+  chip: {
+    paddingHorizontal: space.md,
+    paddingVertical: space.sm,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.card,
+  },
+  chipActive: { borderColor: colors.accent, backgroundColor: colors.accent },
+  chipText: { color: colors.text, fontSize: font.size.sm, fontWeight: '600' },
+  chipTextActive: { color: colors.accentText },
+  row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: space.md },
+  fieldLabel: { color: colors.text, fontSize: font.size.md },
+  fieldState: { fontSize: font.size.xs, fontWeight: '700', letterSpacing: 0.3 },
+  statusRow: { flexDirection: 'row', alignItems: 'center' },
+  state: { fontSize: font.size.xs, fontWeight: '700', textTransform: 'uppercase', letterSpacing: 0.5 },
+  copyRow: { flexDirection: 'row', alignItems: 'center', gap: space.md },
+  mono: { color: colors.text, fontSize: font.size.sm, fontFamily: font.mono },
+  codeBox: { alignItems: 'center', gap: 4, padding: space.md, backgroundColor: colors.card, borderRadius: radius.md },
+  codeText: { color: colors.text, fontSize: font.size.xl, fontWeight: '800', letterSpacing: 4, fontFamily: font.mono },
+  linkRow: { flexDirection: 'row', alignItems: 'center', gap: space.md },
+  backdrop: { flex: 1, backgroundColor: '#000a', justifyContent: 'flex-end' },
+  sheet: {
+    backgroundColor: colors.bgElevated,
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    padding: space.xl,
+    paddingBottom: space.xxl,
+    maxHeight: '85%',
+  },
+  head: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  title: { color: colors.text, fontSize: font.size.lg, fontWeight: '800' },
+  input: {
+    marginTop: space.xs,
+    backgroundColor: colors.card,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingHorizontal: space.md,
+    paddingVertical: space.md,
+    color: colors.text,
+    fontSize: font.size.md,
+  },
+  error: { color: colors.danger, fontSize: font.size.sm, marginTop: space.md },
+});

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -7,6 +7,7 @@ import { ControllerConnectModal } from '../components/ControllerConnectModal';
 import { GitIdentityCard } from '../components/GitIdentityCard';
 import { McpServersCard } from '../components/McpServersCard';
 import { ProviderKeysCard } from '../components/ProviderKeysCard';
+import { MessagingCard } from '../components/MessagingCard';
 import { UpdatesCard } from '../components/UpdatesCard';
 import { clearConnection, clearControllerConnection, hasController, isDemoHost } from '../store/config';
 import { useConfig } from '../store/useConfig';
@@ -81,6 +82,8 @@ export default function SettingsScreen() {
         {!cfg.mock ? <ProviderKeysCard readOnly={isDemo} /> : null}
 
         {!cfg.mock ? <McpServersCard readOnly={isDemo} /> : null}
+
+        {!cfg.mock ? <MessagingCard readOnly={isDemo} /> : null}
 
         {/* Identity + self-serve updates. Shown read-only on the public demo and
             in the mock build (where they render canned data), interactive on a


### PR DESCRIPTION
Stage 3/5 of #325 — productionize the WhatsApp gateway (Model B, bring-your-own credentials). Closes #330.

This is where the feature becomes **real for the end user**: a first-class "Messaging / WhatsApp" surface in **both** the dashboard Settings page **and** the mobile Settings screen, where a user connects their own WhatsApp provider end-to-end — credentials, webhook, and number linking — with no kubectl and no env editing.

> **Stacked PR.** #328 (#387) and #329 (#388) are not merged yet, so this branch carries all three commits (`71fe1b5` #328 → `169c613` #329 → `a1213b0` #330). Once those merge, this narrows to just the #330 commit. The sections below document the whole feature so it can be reviewed as one story.

---

## End-to-end flow

```
Settings UI (web + mobile)
   │  1. GET /api/gateway/providers      → provider catalog + field specs
   │  2. PUT /api/gateway/credentials    → save creds (per-workspace, 0600 on PVC)
   │                                        └─ hot-swaps the live adapter (no restart)
   │  3. POST /api/gateway/test          → authenticated probe, no message sent
   │  4. copy webhook URL (+ verify token) → paste into provider console
   │  5. POST /api/gateway/link          → 6-digit pairing code (600s TTL)
   ▼
User texts the code from their phone
   ▼
POST /api/gateway/whatsapp/webhook  (provider-signature authed, OAuth-bypassing ingress)
   ▼
ConversationGateway → IdentityRegistry binds the number → Hypervisor turn runs
   ▼
Reply delivered back over the provider's send API
```

Revocation runs the same path in reverse: **Unlink** (`DELETE /api/gateway/link/<id>` or the `unlink` keyword) drops the binding; **Disconnect** (`DELETE /api/gateway/credentials`) clears the store and disables the channel.

---

## Backend (stages 1–2, included in this stack)

**#328 — declarative provider registry** (`charts/workspace/adapters/whatsapp.py`)
Refactored the `_Provider` seam into a registered catalog. Each provider declares, as data, its `id`, display name, `credential_fields` (`key`/`label`/`secret`/`placeholder`/`help_url`/`required`), its `sender_field`, and its `Capabilities`. `build_provider(provider_id, creds)` constructs from a flat creds dict; `list_providers()` exposes the specs (JSON-serializable via `to_dict()`). Capabilities moved onto the provider classes, removing the `isinstance` branch in the adapter. `_provider_from_env()` became a thin wrapper so env stays valid for platform-managed deployments. **Adding a provider = a new adapter class + one `register_provider()` call — no core or UI changes.**

**#329 — per-workspace credential store + config API** (`charts/workspace/server.py`)
`GatewayCredentialsManager` mirrors `ProviderKeysManager`: one JSON on the PVC (`/home/dev/.claude-tasks/gateway-credentials.json`), atomic `os.replace` 0600 write, redacted `public_view()`. Stores `{provider_id, creds{}}` flat-keyed by the spec's `field_keys()` so it drops straight into `build_provider()`. `set()` is registry-validated and field-allowlisted, folds `sender_number` into its spec field, and **preserves an existing secret when the incoming value is blank** (so the form never re-enters masked secrets). Redaction is **spec-driven** — the `CredentialField.secret` flag decides what's masked. `get_gateway_adapter()` now builds from the store (env fallback), and PUT/DELETE call `rebuild_gateway_adapter()` under `_GATEWAY_LOCK` for **hot-swap with no pod restart**. Providers also gained `validate()` — an authenticated GET (Twilio account resource / Meta phone-number node) that proves credentials without messaging anyone.

---

## APIs

All auth'd; the credential/test endpoints use `allow_none_mode=False` (never reachable in the unauth public demo), matching the `provider-keys` posture.

| Method | Path | Body | Response |
|---|---|---|---|
| GET | `/api/gateway/providers` | — | `{ providers: [ProviderSpec…], available }` — drives the data-driven form |
| GET | `/api/gateway/credentials` | — | `{ credentials: <redacted view> }` |
| PUT | `/api/gateway/credentials` | `{ provider_id, creds{}, sender_number }` | `{ ok, credentials }` — saves + **hot-swaps** |
| DELETE | `/api/gateway/credentials` | — | `{ ok }` — clears the store, disables the channel |
| POST | `/api/gateway/test` | — | `{ ok, detail }` — validates creds, **no message sent**; `400` if unconfigured |
| POST | `/api/gateway/link` | `{ workspace }` | `{ code, expires_in, whatsapp_number, workspace }` |
| GET | `/api/gateway/links` | — | `{ links: [...], available }` — redacted bindings |
| DELETE | `/api/gateway/link/<id>` | — | `{ ok }` |

**Redacted credential view** — secret fields expose only `set` + a last-4 `hint`, **never the value**; non-secret identifiers may expose `value`:
```json
{
  "configured": true,
  "provider_id": "twilio",
  "sender_field": "from_number",
  "fields": {
    "account_sid": { "set": true, "value": "AC123" },
    "auth_token":  { "set": true, "hint": "…9999" },
    "from_number": { "set": true, "value": "whatsapp:+14155238886" }
  }
}
```

---

## Web implementation (`charts/workspace/web`)

- **`src/api/gateway.ts`** (new) — typed client for all eight endpoints; **`apiPut`** added to `src/api/client.ts`.
- **`src/routes/settings/MessagingSection.tsx`** (new) — one section, four blocks:
  1. **Provider picker + data-driven form** — renders `[...credential_fields, sender_field]` for the selected spec. Secret fields are `type=password` with a `set · …hint` pill; non-secret fields prefill from the redacted view. **Save** + **Disconnect** (confirm dialog).
  2. **Test connection** — inline success/danger pill with the returned detail.
  3. **Webhook helper** — the exact `https://<host>/api/gateway/whatsapp/webhook` URL (plus verify token when the provider declares one) with copy buttons.
  4. **Link management** — pairing code with a live **600s countdown**, an **Open in WhatsApp** `wa.me` deep link when the sender is dialable (Twilio), instructions instead for Meta (whose sender is an opaque `phone_number_id`), and the redacted bindings list with per-row **Unlink**.
- Registered in `settings/index.tsx`; small `settings.css` additions.

## Mobile implementation (`mobile/`)

Full parity — the mobile app hits the **same endpoints**, so stages 1–2 needed no mobile work.

- **`src/api/client.ts` + `src/api/types.ts`** — the same eight gateway calls and shared types, with mock-mode guards mirroring the provider-keys client.
- **`src/components/MessagingCard.tsx`** (new) — RN mirror of the web section, following `ProviderKeysCard`: provider chips, masked field rows (`set · …hint` / value), a bottom-sheet edit `Modal` with a `TextInput` per declared field (`secureTextEntry` for secrets), Save/Disconnect, test connection with inline result, `expo-clipboard` copy rows for the webhook URL + verify token, **Link WhatsApp** with countdown and `Linking.openURL` for `wa.me`, and bindings with **Unlink** via `confirmAction`. Errors degrade to "not configured" so the demo/mock build never hard-fails.
- Registered in **`src/screens/SettingsScreen.tsx`** (`readOnly` on the public demo).

Credentials saved on web appear (redacted) on mobile and vice-versa — it's the same per-workspace store.

---

## Security
- Secrets at rest on the PVC (0600, atomic write), **redacted in every API response, list view, and log line**. The only secret-returning getter feeds `build_provider()` and is never printed or returned.
- A blank secret on save preserves the stored one — users never retype, and the UI never round-trips a secret back.
- `POST /api/gateway/test` validates against the provider without messaging a real user, and its `detail` never contains credential material.
- Signature verification on the inbound webhook stays fail-closed.

## Tests
- **Backend:** `GatewayCredentialsManagerTests` (10 — redaction/secret-leak audit, allowlist, merge-preserve, provider switch, 0600), provider `validate()` (7), gateway routes incl. **hot-swap on PUT** and **env fallback on DELETE** (23), whatsapp registry/specs (65).
- **Web:** `gateway.test.ts` (8) pins every client path/method; `MessagingSection.test.tsx` (8) covers data-driven field rendering, the Twilio→Meta switch, masked state with **no secret in the DOM**, the Save payload, test pass/fail, redacted bindings + Unlink, and Disconnect.
- **Gates:** full web suite **352 green**, `tsc --noEmit` + `vite build` clean; mobile `tsc --noEmit` clean and the mock web export bundles.

## Non-goals (later stages)
Chart enablement + webhook-path hardening (#331); setup docs and onboarding (#332). No QR dependency; no new providers. Mobile UI parity — originally listed under #332 — lands here, so #332 narrows to docs + onboarding.
