### PR TITLE
WhatsApp gateway (5/5): Twilio setup guide, in-app docs nav & Settings deep-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,20 @@ All three live under **Triggers**, and what-fired-what is tracked in the memory 
 
 ---
 
+## Chat over WhatsApp
+
+Drive your workspace agent from WhatsApp. The gateway is **opt-in** and
+**bring-your-own-credentials** — connect your own Twilio (or Meta) app from
+**Settings → Messaging / WhatsApp**, paste the webhook URL into the provider
+console, tap **Link WhatsApp**, and text the pairing code once. After that you
+just chat: messages drive a Hypervisor turn and replies come back to your phone,
+with keyword commands (`new chat`, `stop`, `unlink`, `workspaces`, `@ws`) and a
+fail-closed signature check on every inbound. The same card is in the mobile app.
+
+Full guide: [`docs/whatsapp-gateway.md`](docs/whatsapp-gateway.md).
+
+---
+
 ## Pluggable AI assistants
 
 Every session — and every orchestrator sub-agent — picks its assistant at create-time, so you can mix them freely in one workspace. Keys live in `users-private/<name>/secrets/assistant.yaml` (gitignored); the public defaults are empty, so it ships Claude-only out of the box, and users can add their own provider keys self-service from **Settings**.

--- a/charts/workspace/adapters/whatsapp.py
+++ b/charts/workspace/adapters/whatsapp.py
@@ -201,6 +201,20 @@ class TwilioProvider(_Provider):
         self.account_sid = account_sid
         self.from_number = from_number
 
+    @staticmethod
+    def _wa_addr(addr: str) -> str:
+        """Twilio's WhatsApp REST API requires BOTH `To` and `From` to carry the
+        `whatsapp:` channel prefix (e.g. `whatsapp:+14155238886`). A bare
+        `+E164` sender is a different channel (SMS), so mixing it with a
+        `whatsapp:` recipient makes Twilio reject the send (error 21910) — the
+        message never leaves. The Settings UI accepts a plain `+E164` sender as
+        valid, so normalize here: prefix any bare `+number` with `whatsapp:`,
+        and leave an already-prefixed address (or anything non-E164) untouched."""
+        addr = (addr or '').strip()
+        if addr.startswith('+'):
+            return f'whatsapp:{addr}'
+        return addr
+
     # -- signature -----------------------------------------------------------
     @staticmethod
     def signature(auth_token: str, url: str, params: Dict[str, str]) -> str:
@@ -264,7 +278,7 @@ class TwilioProvider(_Provider):
                        caps: Capabilities) -> List[Dict[str, str]]:
         """Twilio Messages form params, one per ≤4096 chunk. Interactive choices
         degrade to a numbered text list (sandbox can't create Content buttons)."""
-        to = msg.channel_identity
+        to = self._wa_addr(msg.channel_identity)
         body = msg.text or ''
         if msg.quick_replies:
             spec = render_choice(msg.quick_replies, caps)
@@ -280,7 +294,7 @@ class TwilioProvider(_Provider):
         for chunk in chunk_text(body, caps.max_text_len):
             params = {'To': to, 'Body': chunk}
             if self.from_number:
-                params['From'] = self.from_number
+                params['From'] = self._wa_addr(self.from_number)
             for m in msg.media:
                 if m.url:
                     params['MediaUrl'] = m.url

--- a/charts/workspace/gateway.py
+++ b/charts/workspace/gateway.py
@@ -434,24 +434,118 @@ class TemplateRegistry:
         },
     }
 
+    # Providers that enforce real template registration on the user's own app.
+    # For these, the built-in DEFAULTS above are NOT proof of approval: a BYO
+    # user's Meta app has never seen `kc_task_complete`, so sending it would be
+    # rejected at the provider. Only an on-disk record (written by approve())
+    # counts. Twilio has no such registry, so it keeps the built-in behavior.
+    ENFORCING_PROVIDERS = frozenset({'meta'})
+
+    # A template name becomes a FILENAME on the PVC, so it is constrained at the
+    # boundary rather than trusted. Today every caller passes a literal, but
+    # approve()/list_templates() exist to be driven by user input (#332), and a
+    # name like '../../.ssh/authorized_keys' must never resolve to a path.
+    _NAME_RE = re.compile(r'^[a-z0-9][a-z0-9_]{0,63}$')
+
     def __init__(self, base_dir: str = GATEWAY_DIR):
         self.dir = os.path.join(base_dir, 'templates')
 
-    def get(self, name: str) -> Optional[Dict[str, Any]]:
-        path = os.path.join(self.dir, f'{name}.json')
+    @classmethod
+    def _safe_name(cls, name: str) -> Optional[str]:
+        """The template name if it's a plain identifier, else None. Rejects path
+        separators, traversal, and anything that isn't [a-z0-9_]."""
+        name = (name or '').strip()
+        return name if cls._NAME_RE.match(name) else None
+
+    def _stored(self, name: str) -> Optional[Dict[str, Any]]:
+        """The per-workspace record for a template, or None if only a built-in
+        default exists. This is what distinguishes 'the user really registered
+        and approved this on their own provider app' from 'we ship a default'."""
+        safe = self._safe_name(name)
+        if safe is None:
+            return None
+        path = os.path.join(self.dir, f'{safe}.json')
         try:
             with open(path) as f:
                 return json.load(f)
         except (OSError, json.JSONDecodeError):
-            return dict(self.DEFAULTS.get(name)) if name in self.DEFAULTS else None
+            return None
 
-    def select(self, name: str) -> Optional[Dict[str, Any]]:
+    def get(self, name: str) -> Optional[Dict[str, Any]]:
+        stored = self._stored(name)
+        if stored is not None:
+            return stored
+        return dict(self.DEFAULTS.get(name)) if name in self.DEFAULTS else None
+
+    def select(self, name: str,
+               provider_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """Return the template ONLY if it's approved — otherwise the caller must
-        not attempt an out-of-window send (WhatsApp would reject it)."""
+        not attempt an out-of-window send (WhatsApp would reject it).
+
+        For a provider that enforces template registration (Meta Cloud API), a
+        built-in default is not enough: the user must have registered the
+        template on their own app and recorded it via approve(). When they
+        haven't, this returns None and the caller degrades gracefully (the
+        out-of-window notification is simply skipped — issue #331)."""
         tpl = self.get(name)
-        if tpl and tpl.get('status') == 'approved':
-            return tpl
-        return None
+        if not tpl or tpl.get('status') != 'approved':
+            return None
+        if (provider_id or '').strip().lower() in self.ENFORCING_PROVIDERS \
+                and self._stored(name) is None:
+            return None
+        return tpl
+
+    def approve(self, name: str, provider_name: str = '',
+                language: str = 'en', body: str = '') -> Dict[str, Any]:
+        """Record that the user registered + got approval for this template on
+        their own provider app. Persists to the PVC so select() will hand it out
+        for an enforcing provider.
+
+        Raises ValueError on a name that isn't a plain identifier — this writes a
+        file, so the name is validated before it ever reaches a path."""
+        safe = self._safe_name(name)
+        if safe is None:
+            raise ValueError(f'invalid template name: {name!r}')
+        base = self.get(safe) or {'name': safe}
+        rec = dict(base)
+        rec.update({
+            'name': safe,
+            'provider_name': provider_name or base.get('provider_name', safe),
+            'language': language or base.get('language', 'en'),
+            'body': body or base.get('body', ''),
+            'status': 'approved',
+        })
+        os.makedirs(self.dir, mode=0o700, exist_ok=True)
+        tmp = os.path.join(self.dir, f'{safe}.json.tmp')
+        with open(tmp, 'w') as f:
+            json.dump(rec, f, indent=2)
+        os.replace(tmp, os.path.join(self.dir, f'{safe}.json'))
+        return rec
+
+    def list_templates(self) -> List[Dict[str, Any]]:
+        """Every known logical template with its effective status + whether the
+        approval is user-recorded (vs a shipped default)."""
+        names = set(self.DEFAULTS)
+        try:
+            for n in os.listdir(self.dir):
+                if not n.endswith('.json'):
+                    continue
+                safe = self._safe_name(n[:-5])
+                if safe:  # ignore anything that isn't a plain template name
+                    names.add(safe)
+        except OSError:
+            pass
+        out: List[Dict[str, Any]] = []
+        for n in sorted(names):
+            tpl = self.get(n) or {}
+            out.append({
+                'name': n,
+                'provider_name': tpl.get('provider_name', ''),
+                'language': tpl.get('language', 'en'),
+                'status': tpl.get('status', 'pending'),
+                'user_registered': self._stored(n) is not None,
+            })
+        return out
 
     def render_body(self, name: str, **args: Any) -> str:
         tpl = self.get(name) or {}
@@ -982,7 +1076,12 @@ class ConversationGateway:
             self._send(adapter, identity, chunk, quick_replies=quick)
 
     def _deliver_template(self, adapter, identity, thread_id, since) -> None:
-        tpl = self.templates.select('task_complete')
+        # The provider id comes from the live adapter (issue #328 gives every
+        # provider a `.name`). Meta enforces template registration on the user's
+        # own app, so an unregistered template resolves to None here and the
+        # notification is skipped rather than rejected by the provider (#331).
+        provider_id = getattr(getattr(adapter, 'provider', None), 'name', None)
+        tpl = self.templates.select('task_complete', provider_id=provider_id)
         if not tpl:
             return  # not approved → cannot send out-of-window (WhatsApp rejects)
         key = f'{thread_id}:{since}:template'
@@ -1025,9 +1124,16 @@ class ConversationGateway:
             seq=self.sequencer.next(identity),
         )
         try:
-            return adapter.outbound(msg)
+            result = adapter.outbound(msg)
         except Exception as e:
+            print(f'[gateway] outbound send raised: {e}', flush=True)
             return DeliveryResult(ok=False, error=str(e))
+        # A provider that returns ok=False (e.g. Twilio rejected the send) is
+        # otherwise silent — the caller discards the result — so surface it here.
+        # The error is a provider status/message, never secret material.
+        if not result.ok:
+            print(f'[gateway] outbound send failed: {result.error}', flush=True)
+        return result
 
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -72,7 +72,7 @@ except Exception as _hv_import_err:  # broken install shouldn't crash the server
 try:
     from gateway import (ConversationGateway, IdentityRegistry,
                         LocalHypervisorClient, RawRequest, GatewayPreview,
-                        INTERNAL_IDENTITY)
+                        RateLimiter, INTERNAL_IDENTITY)
     from adapters.whatsapp import (WhatsAppAdapter, build_provider as
                                    gw_build_provider, list_providers as
                                    gw_list_providers, get_provider_spec as
@@ -85,6 +85,7 @@ except Exception as _gw_import_err:  # broken install shouldn't crash the server
     LocalHypervisorClient = None  # type: ignore
     RawRequest = None  # type: ignore
     GatewayPreview = None  # type: ignore
+    RateLimiter = None  # type: ignore
     INTERNAL_IDENTITY = 'internal:local'  # type: ignore
     WhatsAppAdapter = None  # type: ignore
     gw_build_provider = None  # type: ignore
@@ -217,6 +218,53 @@ HYPERVISOR_PREAMBLE = (
 # minting a pairing code, so the user knows which WhatsApp number to message.
 # Purely informational; the number itself is configured on the provider side.
 GATEWAY_WHATSAPP_NUMBER = os.environ.get('KC_WHATSAPP_NUMBER', '')
+
+# Conversation Gateway master switch (issue #331). The chart sets this only when
+# `gateway.enabled` is true, so the external WhatsApp surface — the inbound
+# webhook, the credential/catalog/test config API, and the pairing-link CRUD —
+# is OPT-IN. Off by default so a workspace that never configured messaging
+# doesn't expose those routes at all.
+#
+# NOTE: this deliberately does NOT gate /api/gateway/internal/* — the in-app
+# Walkie-Talkie loopback preview is a separate, always-available feature that
+# shares the same gateway core.
+GATEWAY_ENABLED = os.environ.get('KC_GATEWAY_ENABLED', 'false').strip().lower() in (
+    '1', 'true', 'yes', 'on')
+
+# Per-workspace throttles for the authenticated gateway config endpoints
+# (issue #331). These sit behind the ingress, so every request arrives with the
+# ingress's address — a per-IP key would be meaningless. A single fixed key per
+# bucket is exactly the intended semantic: a per-workspace cap.
+#   * link  — minting pairing codes (each one is a live, bindable credential)
+#   * test  — POST /api/gateway/test makes an OUTBOUND network call per request,
+#             so it's the real abuse vector; credential writes share this bucket.
+def _gw_limiter(env_var, default):
+    if RateLimiter is None:
+        return None
+    try:
+        cap = int(os.environ.get(env_var, default))
+    except ValueError:
+        cap = int(default)
+    return RateLimiter(max_events=cap, window_seconds=3600.0)
+
+
+_GW_LINK_LIMITER = _gw_limiter('KC_GATEWAY_LINK_PER_HOUR', '10')
+_GW_TEST_LIMITER = _gw_limiter('KC_GATEWAY_TEST_PER_HOUR', '20')
+
+
+def _gateway_disabled(handler):
+    """True (and a 503 already sent on `handler`) when the messaging gateway is
+    switched off (issue #331). Guards the EXTERNAL WhatsApp surface only — never
+    /api/gateway/internal/*, the Walkie-Talkie preview, which is independent.
+
+    Deliberately a module-level function rather than a BrowserHandler method:
+    the route tests drive handlers against a mock.Mock(spec=BrowserHandler), and
+    a method here would be auto-stubbed by the mock (returning a truthy Mock) and
+    silently short-circuit every handler under test."""
+    if GATEWAY_ENABLED:
+        return False
+    handler.send_json({'error': 'messaging gateway is disabled'}, 503)
+    return True
 
 # Lazily-built singleton Conversation Gateway + one WhatsApp adapter instance.
 # Built on first use (and at startup) so the turn-complete observer is installed
@@ -7726,6 +7774,8 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
     def handle_gateway_whatsapp_webhook(self):
         """Inbound WhatsApp webhook. Provider-signature authed (in the adapter),
         idempotent on the provider message id, fast 200 so retries stop."""
+        if _gateway_disabled(self):
+            return
         gw = get_gateway()
         adapter = get_gateway_adapter()
         if gw is None or adapter is None:
@@ -7742,7 +7792,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         """Meta Cloud API GET verification handshake — echo hub.challenge on a
         verify-token match, else 403. No-op (403) for providers without a
         handshake (Twilio)."""
-        adapter = get_gateway_adapter()
+        adapter = get_gateway_adapter() if GATEWAY_ENABLED else None
         if adapter is None:
             self.send_response(503)
             self.end_headers()
@@ -7772,6 +7822,13 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         sends this code once over WhatsApp to bind their number."""
         if not self.check_claude_auth():
             self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        if _gateway_disabled(self):
+            return
+        # Each code is a live, bindable credential for 600s — cap how many can
+        # be minted per hour so a compromised session can't spray them.
+        if _GW_LINK_LIMITER is not None and not _GW_LINK_LIMITER.allow('link'):
+            self.send_json({'error': 'too many pairing codes — try again later'}, 429)
             return
         gw = get_gateway()
         if gw is None:
@@ -7807,8 +7864,10 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         if not self.check_claude_auth():
             self.send_json({'error': 'Unauthorized'}, 401)
             return
-        gw = get_gateway()
+        gw = get_gateway() if GATEWAY_ENABLED else None
         if gw is None:
+            # Soft shape (not a 503): the Settings UI renders its "messaging
+            # unavailable" state from this rather than surfacing an error toast.
             self.send_json({'links': [], 'available': False})
             return
         self.send_json({
@@ -7824,6 +7883,8 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         same over WhatsApp."""
         if not self.check_claude_auth():
             self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        if _gateway_disabled(self):
             return
         gw = get_gateway()
         if gw is None:
@@ -7844,7 +7905,9 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         if not self.check_claude_auth():
             self.send_json({'error': 'Unauthorized'}, 401)
             return
-        if gw_list_providers is None:
+        if gw_list_providers is None or not GATEWAY_ENABLED:
+            # Soft shape so the Settings section renders "not available"
+            # instead of erroring when messaging is switched off.
             self.send_json({'providers': [], 'available': False})
             return
         self.send_json({
@@ -7857,6 +7920,8 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         if not self.check_claude_auth(allow_none_mode=False):
             self.send_json({'error': 'Unauthorized'}, 401)
             return
+        if _gateway_disabled(self):
+            return
         self.send_json({'credentials': GatewayCredentialsManager.public_view()})
 
     def handle_gateway_credentials_put(self):
@@ -7865,6 +7930,12 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         secret back)."""
         if not self.check_claude_auth(allow_none_mode=False):
             self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        if _gateway_disabled(self):
+            return
+        # Credential writes share the test bucket — both touch provider config.
+        if _GW_TEST_LIMITER is not None and not _GW_TEST_LIMITER.allow('test'):
+            self.send_json({'error': 'too many requests — try again later'}, 429)
             return
         try:
             data = self.read_json_body()
@@ -7891,6 +7962,8 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         if not self.check_claude_auth(allow_none_mode=False):
             self.send_json({'error': 'Unauthorized'}, 401)
             return
+        if _gateway_disabled(self):
+            return
         GatewayCredentialsManager.clear()
         rebuild_gateway_adapter()
         self.send_json({'ok': True})
@@ -7900,6 +7973,13 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         user. 400 when nothing is configured yet."""
         if not self.check_claude_auth(allow_none_mode=False):
             self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        if _gateway_disabled(self):
+            return
+        # This is the one endpoint that makes an OUTBOUND network call per
+        # request, so it's the real abuse vector — throttle it.
+        if _GW_TEST_LIMITER is not None and not _GW_TEST_LIMITER.allow('test'):
+            self.send_json({'error': 'too many test requests — try again later'}, 429)
             return
         ok, detail = GatewayCredentialsManager.validate_stored()
         if not ok and detail == 'no credentials configured':

--- a/charts/workspace/templates/deployment.yaml
+++ b/charts/workspace/templates/deployment.yaml
@@ -200,6 +200,42 @@ spec:
           value: {{ (.Values.hypervisor).defaultAssistant | default "claude" | quote }}
         - name: HYPERVISOR_WORKDIR
           value: {{ (.Values.hypervisor).workdir | default "/home/dev" | quote }}
+        {{- if (.Values.gateway).enabled }}
+        {{- if (.Values.gateway).allowUnsigned }}
+        {{- /*
+          allowUnsigned disables provider-signature verification, so ANYONE who
+          can reach the webhook can drive this workspace's agent. Refuse to
+          render it on a deployment that looks real. Two independent signals,
+          because TLS alone misses a cluster that terminates TLS upstream:
+            * ingress.tls.enabled — the chart is serving HTTPS itself
+            * ingress.auth.type=oauth2 — a multi-user deploy, and the ONLY mode
+              in which ingress-gateway.yaml publishes the webhook at all
+        */}}
+        {{- if .Values.ingress.tls.enabled }}
+        {{- fail "gateway.allowUnsigned=true is dev/sandbox only and must never be combined with TLS (production). Unset it, or disable TLS for a local dev deploy." }}
+        {{- end }}
+        {{- if eq .Values.ingress.auth.type "oauth2" }}
+        {{- fail "gateway.allowUnsigned=true is dev/sandbox only and must never be combined with ingress.auth.type=oauth2 — that mode publishes the webhook publicly, so an unsigned webhook would let anyone drive this workspace's agent." }}
+        {{- end }}
+        {{- end }}
+        # Conversation Gateway (issue #325). Only NON-SECRET config is injected
+        # here — provider credentials are supplied by the user at runtime and
+        # stored per-workspace on the PVC (issue #329), never via the chart.
+        - name: KC_GATEWAY_ENABLED
+          value: "true"
+        - name: KC_WHATSAPP_NUMBER
+          value: {{ (.Values.gateway).whatsappNumber | default "" | quote }}
+        - name: KC_GATEWAY_LINK_PER_HOUR
+          value: {{ ((.Values.gateway).limits).linkPerHour | default 10 | quote }}
+        - name: KC_GATEWAY_TEST_PER_HOUR
+          value: {{ ((.Values.gateway).limits).testPerHour | default 20 | quote }}
+        {{- if (.Values.gateway).allowUnsigned }}
+        # DEV ONLY — accepts unsigned/invalid-signature webhooks. The guard
+        # above prevents this from ever rendering alongside TLS.
+        - name: KC_ALLOW_UNSIGNED_WEBHOOKS
+          value: "true"
+        {{- end }}
+        {{- end }}
         {{- if .Values.update.selfServeSecretName }}
         # Self-serve version updates: the workspace backend brokers to the
         # controller's token-gated self-serve listener over the in-cluster

--- a/charts/workspace/templates/ingress-gateway.yaml
+++ b/charts/workspace/templates/ingress-gateway.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.ingress.auth.type "oauth2" }}
+{{- if and (.Values.gateway).enabled (eq .Values.ingress.auth.type "oauth2") }}
 # Ingress for the Conversation Gateway inbound webhook (issue #306). Like
 # ingress-webhooks.yaml this bypasses the OAuth2 proxy because the messaging
 # provider (Twilio / Meta) can't carry an OAuth session — it authenticates via
@@ -29,6 +29,13 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffering: "off"
     # 1 MiB cap mirrors the in-pod content-length check in the gateway handler.
     nginx.ingress.kubernetes.io/proxy-body-size: "1m"
+    # Edge throttles (issue #331). This path bypasses OAuth and is reachable by
+    # anyone on the internet — it is authenticated only by the provider
+    # signature verified in-pod. Cap it at the edge the same way
+    # ingress-public.yaml caps the unauthed demo surface, so a flood is dropped
+    # by nginx before it ever reaches the pod's verifier.
+    nginx.ingress.kubernetes.io/limit-rps: {{ ((.Values.gateway).limits).webhookRps | default 5 | quote }}
+    nginx.ingress.kubernetes.io/limit-connections: {{ ((.Values.gateway).limits).webhookConnections | default 10 | quote }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/charts/workspace/tests/gateway_chart_test.yaml
+++ b/charts/workspace/tests/gateway_chart_test.yaml
@@ -1,0 +1,197 @@
+suite: conversation gateway enablement + hardening (#331)
+# Note: the oauth2 cases below also set oauth2.cookieSecret — switching
+# ingress.auth.type to oauth2 renders oauth2-proxy.yaml, which requires it.
+values:
+  - test-values.yaml
+tests:
+  # --- deployment env: the subsystem is opt-in -------------------------------
+  - it: emits no gateway env by default (feature off)
+    template: templates/deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_GATEWAY_ENABLED
+            value: "true"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_ALLOW_UNSIGNED_WEBHOOKS
+            value: "true"
+
+  - it: wires non-secret gateway env when enabled
+    template: templates/deployment.yaml
+    set:
+      gateway.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_GATEWAY_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_GATEWAY_LINK_PER_HOUR
+            value: "10"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_GATEWAY_TEST_PER_HOUR
+            value: "20"
+      # Fail-closed: the dev escape hatch is never emitted unless opted into.
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_ALLOW_UNSIGNED_WEBHOOKS
+            value: "true"
+
+  - it: honors custom throttle limits
+    template: templates/deployment.yaml
+    set:
+      gateway.enabled: true
+      gateway.limits.linkPerHour: 3
+      gateway.limits.testPerHour: 5
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_GATEWAY_LINK_PER_HOUR
+            value: "3"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_GATEWAY_TEST_PER_HOUR
+            value: "5"
+
+  - it: exposes the non-secret display number when set
+    template: templates/deployment.yaml
+    set:
+      gateway.enabled: true
+      gateway.whatsappNumber: "whatsapp:+14155238886"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_WHATSAPP_NUMBER
+            value: "whatsapp:+14155238886"
+
+  # --- allowUnsigned: dev-only, and blocked in production --------------------
+  - it: allows unsigned webhooks for a local dev deploy (no TLS)
+    template: templates/deployment.yaml
+    set:
+      gateway.enabled: true
+      gateway.allowUnsigned: true
+      ingress.tls.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_ALLOW_UNSIGNED_WEBHOOKS
+            value: "true"
+
+  - it: refuses to render allowUnsigned together with TLS (production guard)
+    template: templates/deployment.yaml
+    set:
+      gateway.enabled: true
+      gateway.allowUnsigned: true
+      ingress.tls.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.allowUnsigned=true is dev/sandbox only and must never be combined with TLS (production). Unset it, or disable TLS for a local dev deploy."
+
+  # oauth2 is the only mode that publishes the webhook ingress at all, so it is
+  # a second, TLS-independent "this is a real deployment" signal — a cluster
+  # terminating TLS upstream would slip past the tls.enabled check alone.
+  - it: refuses to render allowUnsigned on an oauth2 (multi-user) deploy
+    template: templates/deployment.yaml
+    set:
+      gateway.enabled: true
+      gateway.allowUnsigned: true
+      ingress.tls.enabled: false
+      ingress.auth.type: oauth2
+      oauth2.cookieSecret: test-cookie-secret
+      oauth2.clientId: test-client-id
+      oauth2.clientSecret: test-client-secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.allowUnsigned=true is dev/sandbox only and must never be combined with ingress.auth.type=oauth2 — that mode publishes the webhook publicly, so an unsigned webhook would let anyone drive this workspace's agent."
+
+  # --- the public webhook ingress -------------------------------------------
+  - it: renders no gateway ingress when the feature is off
+    template: templates/ingress-gateway.yaml
+    set:
+      ingress.auth.type: oauth2
+      oauth2.cookieSecret: test-cookie-secret
+      oauth2.clientId: test-client-id
+      oauth2.clientSecret: test-client-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders no gateway ingress without oauth2 (basic auth deploys)
+    template: templates/ingress-gateway.yaml
+    set:
+      gateway.enabled: true
+      ingress.auth.type: basic
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the signed webhook path when enabled on an oauth2 deploy
+    template: templates/ingress-gateway.yaml
+    set:
+      gateway.enabled: true
+      ingress.auth.type: oauth2
+      oauth2.cookieSecret: test-cookie-secret
+      oauth2.clientId: test-client-id
+      oauth2.clientSecret: test-client-secret
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: ws-testuser-gateway
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /api/gateway/whatsapp/webhook
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Exact
+
+  - it: caps the public webhook path at the edge
+    template: templates/ingress-gateway.yaml
+    set:
+      gateway.enabled: true
+      ingress.auth.type: oauth2
+      oauth2.cookieSecret: test-cookie-secret
+      oauth2.clientId: test-client-id
+      oauth2.clientSecret: test-client-secret
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/limit-rps"]
+          value: "5"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/limit-connections"]
+          value: "10"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
+          value: "1m"
+
+  - it: honors custom edge caps
+    template: templates/ingress-gateway.yaml
+    set:
+      gateway.enabled: true
+      ingress.auth.type: oauth2
+      oauth2.cookieSecret: test-cookie-secret
+      oauth2.clientId: test-client-id
+      oauth2.clientSecret: test-client-secret
+      gateway.limits.webhookRps: 2
+      gateway.limits.webhookConnections: 4
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/limit-rps"]
+          value: "2"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/limit-connections"]
+          value: "4"

--- a/charts/workspace/tests/gateway_routes_test.py
+++ b/charts/workspace/tests/gateway_routes_test.py
@@ -54,10 +54,15 @@ class GatewayRouteTestBase(unittest.TestCase):
         server._GATEWAY_ADAPTER = self.adapter
         server._GATEWAY_AVAILABLE = True
         server._HYPERVISOR_AVAILABLE = True
+        # The external gateway surface is opt-in (issue #331). These suites
+        # exercise the ENABLED path; GatewayDisabledTest covers the off path.
+        self._orig_enabled = server.GATEWAY_ENABLED
+        server.GATEWAY_ENABLED = True
 
     def tearDown(self):
         (server._GATEWAY, server._GATEWAY_ADAPTER,
          server._GATEWAY_AVAILABLE, server._HYPERVISOR_AVAILABLE) = self._orig
+        server.GATEWAY_ENABLED = self._orig_enabled
 
     def _handler(self, authed=True):
         h = mock.Mock(spec=server.BrowserHandler)
@@ -324,6 +329,219 @@ class GatewayCredentialsRouteTest(GatewayRouteTestBase):
         obj, status = self.last()
         self.assertEqual(status, 200)
         self.assertTrue(obj['ok'])
+
+
+class GatewayDisabledTest(GatewayRouteTestBase):
+    """The external WhatsApp surface is opt-in (issue #331). With
+    gateway.enabled off the webhook + config + link routes are inert — but the
+    Walkie-Talkie loopback preview, which shares the same gateway core, must
+    keep working."""
+
+    def setUp(self):
+        super().setUp()
+        server.GATEWAY_ENABLED = False   # base class turned it on
+
+    def test_webhook_is_503(self):
+        h = self._handler()
+        h._gateway_raw_request.return_value = gw.RawRequest(form={'from': 'echo:+1'})
+        server.BrowserHandler.handle_gateway_whatsapp_webhook(h)
+        self.assertEqual(self.last()[1], 503)
+
+    def test_credentials_get_is_503(self):
+        h = self._handler()
+        server.BrowserHandler.handle_gateway_credentials_get(h)
+        self.assertEqual(self.last()[1], 503)
+
+    def test_credentials_put_is_503(self):
+        h = self._handler()
+        h.read_json_body.return_value = {'provider_id': 'twilio', 'creds': {}}
+        server.BrowserHandler.handle_gateway_credentials_put(h)
+        self.assertEqual(self.last()[1], 503)
+
+    def test_credentials_delete_is_503(self):
+        h = self._handler()
+        server.BrowserHandler.handle_gateway_credentials_delete(h)
+        self.assertEqual(self.last()[1], 503)
+
+    def test_test_connection_is_503(self):
+        h = self._handler()
+        server.BrowserHandler.handle_gateway_test(h)
+        self.assertEqual(self.last()[1], 503)
+
+    def test_link_create_is_503(self):
+        h = self._handler()
+        h.read_json_body.return_value = {}
+        server.BrowserHandler.handle_gateway_link_create(h)
+        self.assertEqual(self.last()[1], 503)
+
+    def test_link_delete_is_503(self):
+        h = self._handler()
+        server.BrowserHandler.handle_gateway_link_delete(h, 'a' * 64)
+        self.assertEqual(self.last()[1], 503)
+
+    def test_providers_and_links_report_unavailable_softly(self):
+        # Soft shape, not a 503 — the Settings UI renders "not available".
+        h = self._handler()
+        server.BrowserHandler.handle_gateway_providers(h)
+        obj, status = self.last()
+        self.assertEqual(status, 200)
+        self.assertFalse(obj['available'])
+        self.assertEqual(obj['providers'], [])
+
+        h2 = self._handler()
+        server.BrowserHandler.handle_gateway_link_list(h2)
+        obj2, status2 = self.last()
+        self.assertEqual(status2, 200)
+        self.assertFalse(obj2['available'])
+
+    def test_walkie_talkie_preview_still_works(self):
+        """THE regression guard: /api/gateway/internal/* shares the gateway core
+        but is a separate, always-available feature. Disabling the WhatsApp
+        surface must not take it down."""
+        preview = gw.GatewayPreview()
+        loop = server.LoopbackAdapter(
+            preview.transcript, publish=lambda *a, **k: None,
+            identity=server.INTERNAL_IDENTITY)
+        self._orig_preview = (server._GATEWAY_PREVIEW, server._GATEWAY_LOOPBACK)
+        server._GATEWAY_PREVIEW = preview
+        server._GATEWAY_LOOPBACK = loop
+        try:
+            h = self._handler()
+            h.path = '/api/gateway/internal/transcript'
+            # _gw_preview_bundle / _gw_internal_status are handler methods, so
+            # the spec'd Mock stubs them — feed real values so the handler body
+            # actually runs instead of tripping over a Mock.
+            h._gw_preview_bundle.return_value = (self.gateway, preview, loop)
+            h._gw_internal_status.return_value = (None, False)
+            server.BrowserHandler.handle_gateway_internal_transcript(h)
+            obj, status = self.last()
+            self.assertEqual(status, 200)
+            self.assertTrue(obj['available'])
+        finally:
+            (server._GATEWAY_PREVIEW, server._GATEWAY_LOOPBACK) = self._orig_preview
+
+
+class GatewaySignatureFailClosedTest(GatewayRouteTestBase):
+    """Inbound webhook verification must fail closed (issue #331): an unsigned
+    or forged request is rejected with 403, with KC_ALLOW_UNSIGNED_WEBHOOKS
+    unset (as it is in every production render)."""
+
+    URL = 'https://ws.example.com/api/gateway/whatsapp/webhook'
+    TOKEN = 'twilio-auth-token'
+
+    def setUp(self):
+        super().setUp()
+        self._saved_unsigned = os.environ.pop('KC_ALLOW_UNSIGNED_WEBHOOKS', None)
+        # A real signature-verifying adapter, not the EchoAdapter.
+        server._GATEWAY_ADAPTER = wa.WhatsAppAdapter(
+            provider=wa.TwilioProvider(auth_token=self.TOKEN, account_sid='AC1'))
+
+    def tearDown(self):
+        if self._saved_unsigned is not None:
+            os.environ['KC_ALLOW_UNSIGNED_WEBHOOKS'] = self._saved_unsigned
+        super().tearDown()
+
+    def _post(self, headers):
+        h = self._handler()
+        h._gateway_raw_request.return_value = gw.RawRequest(
+            url=self.URL, headers=headers,
+            form={'From': 'whatsapp:+15550001111', 'Body': 'hi', 'MessageSid': 'SM1'})
+        server.BrowserHandler.handle_gateway_whatsapp_webhook(h)
+        return self.last()
+
+    def test_unsigned_is_403(self):
+        self.assertEqual(self._post({})[1], 403)
+
+    def test_forged_signature_is_403(self):
+        self.assertEqual(self._post({'X-Twilio-Signature': 'bogus'})[1], 403)
+
+    def test_correctly_signed_is_accepted(self):
+        form = {'From': 'whatsapp:+15550001111', 'Body': 'hi', 'MessageSid': 'SM1'}
+        sig = wa.TwilioProvider.signature(self.TOKEN, self.URL, form)
+        obj, status = self._post({'X-Twilio-Signature': sig})
+        # Not linked (no binding) but it got PAST verification — a 200, not 403.
+        self.assertEqual(status, 200)
+        self.assertEqual(obj['status'], 'not_linked')
+
+
+class GatewayRateLimitTest(GatewayRouteTestBase):
+    """The authed config endpoints are throttled per workspace (issue #331)."""
+
+    def setUp(self):
+        super().setUp()
+        self.tmp2 = tempfile.mkdtemp()
+        self._orig_creds = server.GatewayCredentialsManager.CREDS_FILE
+        server.GatewayCredentialsManager.CREDS_FILE = os.path.join(
+            self.tmp2, 'gateway-credentials.json')
+        self._orig_limiters = (server._GW_LINK_LIMITER, server._GW_TEST_LIMITER)
+        server._GW_LINK_LIMITER = gw.RateLimiter(max_events=2, window_seconds=3600.0)
+        server._GW_TEST_LIMITER = gw.RateLimiter(max_events=2, window_seconds=3600.0)
+
+    def tearDown(self):
+        server.GatewayCredentialsManager.CREDS_FILE = self._orig_creds
+        (server._GW_LINK_LIMITER, server._GW_TEST_LIMITER) = self._orig_limiters
+        super().tearDown()
+
+    def test_link_create_is_rate_limited(self):
+        statuses = []
+        for _ in range(3):
+            h = self._handler()
+            h.read_json_body.return_value = {'workspace': 'w'}
+            h.headers = {'Host': 'ws.example.com'}
+            h._current_bearer_token.return_value = 'tok'
+            server.BrowserHandler.handle_gateway_link_create(h)
+            statuses.append(self.last()[1])
+        self.assertEqual(statuses[:2], [201, 201])
+        self.assertEqual(statuses[2], 429)   # third exceeds max_events=2
+
+    def test_test_connection_is_rate_limited(self):
+        statuses = []
+        for _ in range(3):
+            h = self._handler()
+            server.BrowserHandler.handle_gateway_test(h)
+            statuses.append(self.last()[1])
+        # No creds stored → 400s, then the limiter kicks in on the third.
+        self.assertEqual(statuses[:2], [400, 400])
+        self.assertEqual(statuses[2], 429)
+
+
+class GatewaySecretLeakTest(GatewayRouteTestBase):
+    """A stored provider secret must never appear in ANY gateway response."""
+
+    SECRET = 'twilio-auth-secret-9999'
+
+    def setUp(self):
+        super().setUp()
+        self.tmp2 = tempfile.mkdtemp()
+        self._orig_creds = server.GatewayCredentialsManager.CREDS_FILE
+        server.GatewayCredentialsManager.CREDS_FILE = os.path.join(
+            self.tmp2, 'gateway-credentials.json')
+        server.GatewayCredentialsManager.set(
+            'twilio', {'account_sid': 'AC1', 'auth_token': self.SECRET},
+            sender_number='whatsapp:+1')
+
+    def tearDown(self):
+        server.GatewayCredentialsManager.CREDS_FILE = self._orig_creds
+        super().tearDown()
+
+    def test_no_endpoint_leaks_the_secret(self):
+        calls = [
+            server.BrowserHandler.handle_gateway_providers,
+            server.BrowserHandler.handle_gateway_credentials_get,
+            server.BrowserHandler.handle_gateway_link_list,
+        ]
+        for fn in calls:
+            h = self._handler()
+            fn(h)
+            self.assertNotIn(self.SECRET, repr(self.responses),
+                             f'{fn.__name__} leaked the stored secret')
+
+    def test_test_connection_detail_has_no_secret(self):
+        h = self._handler()
+        with mock.patch.object(wa.TwilioProvider, 'validate',
+                               return_value=(False, 'authentication failed')):
+            server.BrowserHandler.handle_gateway_test(h)
+        self.assertNotIn(self.SECRET, repr(self.last()))
 
 
 if __name__ == '__main__':

--- a/charts/workspace/tests/gateway_test.py
+++ b/charts/workspace/tests/gateway_test.py
@@ -421,6 +421,105 @@ class TemplateRegistryTest(unittest.TestCase):
     def test_unknown_template_is_none(self):
         self.assertIsNone(self.tr.select('does_not_exist'))
 
+    # --- provider-aware approval (issue #331) ---------------------------------
+    # Meta enforces template registration on the USER's own app, so a shipped
+    # default is not proof of approval for a BYO deployment.
+
+    def test_meta_rejects_a_shipped_default(self):
+        self.assertIsNone(self.tr.select('task_complete', provider_id='meta'))
+
+    def test_meta_accepts_after_user_approval(self):
+        self.tr.approve('task_complete', provider_name='kc_task_complete')
+        tpl = self.tr.select('task_complete', provider_id='meta')
+        self.assertIsNotNone(tpl)
+        self.assertEqual(tpl['status'], 'approved')
+
+    def test_non_enforcing_providers_keep_default_behavior(self):
+        # Twilio has no template registry; the loopback preview passes None.
+        self.assertIsNotNone(self.tr.select('task_complete', provider_id='twilio'))
+        self.assertIsNotNone(self.tr.select('task_complete'))
+
+    def test_approve_is_case_insensitive_on_provider(self):
+        self.assertIsNone(self.tr.select('task_complete', provider_id='META'))
+
+    def test_list_templates_reports_user_registration(self):
+        before = {t['name']: t for t in self.tr.list_templates()}
+        self.assertFalse(before['task_complete']['user_registered'])
+        self.tr.approve('task_complete', provider_name='kc_task_complete')
+        after = {t['name']: t for t in self.tr.list_templates()}
+        self.assertTrue(after['task_complete']['user_registered'])
+
+    # --- the name becomes a filename, so it is constrained at the boundary ----
+
+    def test_approve_rejects_a_traversing_name(self):
+        outside = os.path.join(self.tmp, 'escaped.json')
+        for bad in ('../escaped', '../../etc/passwd', 'a/b', 'a\\b',
+                    '.', '..', '', 'Caps', 'has space', 'x' * 65):
+            with self.assertRaises(ValueError, msg=bad):
+                self.tr.approve(bad, provider_name='x')
+        self.assertFalse(os.path.exists(outside))
+
+    def test_select_never_reads_outside_the_template_dir(self):
+        # A traversing name resolves to no stored record rather than to a file
+        # elsewhere on the PVC, so it can't be laundered into an "approved" one.
+        with open(os.path.join(self.tmp, 'escaped.json'), 'w') as f:
+            f.write('{"name": "escaped", "status": "approved", "body": "x"}')
+        self.assertIsNone(self.tr._stored('../escaped'))
+        self.assertIsNone(self.tr.select('../escaped', provider_id='meta'))
+
+    def test_list_templates_ignores_junk_filenames(self):
+        os.makedirs(self.tr.dir, mode=0o700, exist_ok=True)
+        with open(os.path.join(self.tr.dir, 'Not Valid.json'), 'w') as f:
+            f.write('{}')
+        self.assertNotIn('Not Valid',
+                         [t['name'] for t in self.tr.list_templates()])
+
+
+class TemplateDeliveryDegradationTest(unittest.TestCase):
+    """An unapproved template must degrade to 'send nothing' rather than a
+    provider rejection (issue #331)."""
+
+    def test_meta_out_of_window_sends_nothing_when_unapproved(self):
+        tmp = tempfile.mkdtemp()
+        core = gw.ConversationGateway(
+            registry=gw.IdentityRegistry(base_dir=tmp),
+            client_factory=lambda b: None,
+            token_verifier=lambda t: True)
+        core.templates = gw.TemplateRegistry(base_dir=tmp)
+
+        sent = []
+
+        class _MetaishAdapter(gw.EchoAdapter):
+            # .provider.name is how the core learns the provider (issue #328).
+            provider = type('P', (), {'name': 'meta'})()
+
+            def outbound(self, msg):
+                sent.append(msg)
+                return gw.DeliveryResult(ok=True)
+
+        core._deliver_template(_MetaishAdapter(), 'whatsapp:+1', 'thread', 0)
+        self.assertEqual(sent, [], 'unapproved Meta template must not be sent')
+
+    def test_twilio_still_delivers(self):
+        tmp = tempfile.mkdtemp()
+        core = gw.ConversationGateway(
+            registry=gw.IdentityRegistry(base_dir=tmp),
+            client_factory=lambda b: None,
+            token_verifier=lambda t: True)
+        core.templates = gw.TemplateRegistry(base_dir=tmp)
+
+        sent = []
+
+        class _TwilioishAdapter(gw.EchoAdapter):
+            provider = type('P', (), {'name': 'twilio'})()
+
+            def outbound(self, msg):
+                sent.append(msg)
+                return gw.DeliveryResult(ok=True)
+
+        core._deliver_template(_TwilioishAdapter(), 'whatsapp:+1', 'thread', 0)
+        self.assertEqual(len(sent), 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/charts/workspace/tests/gateway_whatsapp_test.py
+++ b/charts/workspace/tests/gateway_whatsapp_test.py
@@ -146,6 +146,26 @@ class TwilioOutboundTest(unittest.TestCase):
         self.assertEqual(payloads[0]['To'], 'whatsapp:+2')
         self.assertEqual(payloads[0]['From'], 'whatsapp:+1')
 
+    def test_bare_e164_sender_gets_whatsapp_prefix(self):
+        # The Settings UI accepts a plain +E164 sender; Twilio's WhatsApp API
+        # requires the `whatsapp:` channel prefix on BOTH ends or it rejects the
+        # send (21910). Normalize so a naturally-entered number still delivers.
+        prov = wa.TwilioProvider(auth_token='t', account_sid='AC',
+                                 from_number='+14155238886')
+        caps = gw.Capabilities(max_text_len=4096)
+        msg = gw.OutboundMessage(channel_identity='whatsapp:+2', text='hi')
+        payloads = prov.build_payloads(msg, caps)
+        self.assertEqual(payloads[0]['From'], 'whatsapp:+14155238886')
+        self.assertEqual(payloads[0]['To'], 'whatsapp:+2')
+
+    def test_already_prefixed_sender_is_untouched(self):
+        prov = wa.TwilioProvider(auth_token='t', account_sid='AC',
+                                 from_number='whatsapp:+14155238886')
+        caps = gw.Capabilities(max_text_len=4096)
+        msg = gw.OutboundMessage(channel_identity='whatsapp:+2', text='hi')
+        payloads = prov.build_payloads(msg, caps)
+        self.assertEqual(payloads[0]['From'], 'whatsapp:+14155238886')
+
     def test_choice_degrades_to_numbered_text(self):
         prov = wa.TwilioProvider(auth_token='t', account_sid='AC')
         caps = gw.Capabilities(buttons=True, max_buttons=3, max_text_len=4096)
@@ -177,6 +197,57 @@ class MetaSignatureTest(unittest.TestCase):
         raw = gw.RawRequest(raw_body=b'{"entry":[1]}',
                             headers={'X-Hub-Signature-256': sig})
         self.assertFalse(prov.verify(raw))
+
+
+class SignatureFailClosedTest(unittest.TestCase):
+    """Both providers must reject an unsigned/forged webhook when the dev
+    escape hatch is off — the posture every production render ships (#331)."""
+
+    def setUp(self):
+        self._saved = os.environ.pop('KC_ALLOW_UNSIGNED_WEBHOOKS', None)
+
+    def tearDown(self):
+        if self._saved is not None:
+            os.environ['KC_ALLOW_UNSIGNED_WEBHOOKS'] = self._saved
+        else:
+            os.environ.pop('KC_ALLOW_UNSIGNED_WEBHOOKS', None)
+
+    # -- Twilio --
+    def test_twilio_unsigned_rejected(self):
+        prov = wa.TwilioProvider(auth_token='tok', account_sid='AC1')
+        self.assertFalse(prov.verify(gw.RawRequest(url='u', headers={}, form={'Body': 'x'})))
+
+    def test_twilio_forged_rejected(self):
+        prov = wa.TwilioProvider(auth_token='tok', account_sid='AC1')
+        raw = gw.RawRequest(url='u', headers={'X-Twilio-Signature': 'forged'},
+                            form={'Body': 'x'})
+        self.assertFalse(prov.verify(raw))
+
+    # -- Meta (the missing-signature case was previously unpinned) --
+    def test_meta_unsigned_rejected(self):
+        prov = wa.MetaProvider(app_secret='s')
+        self.assertFalse(prov.verify(gw.RawRequest(raw_body=b'{}', headers={})))
+
+    def test_meta_forged_rejected(self):
+        prov = wa.MetaProvider(app_secret='s')
+        raw = gw.RawRequest(raw_body=b'{}',
+                            headers={'X-Hub-Signature-256': 'sha256=deadbeef'})
+        self.assertFalse(prov.verify(raw))
+
+    def test_meta_correct_signature_accepted(self):
+        secret, body = 'app-secret', b'{"entry":[]}'
+        sig = 'sha256=' + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        prov = wa.MetaProvider(app_secret=secret)
+        raw = gw.RawRequest(raw_body=body, headers={'X-Hub-Signature-256': sig})
+        self.assertTrue(prov.verify(raw))
+
+    def test_opt_in_allows_unsigned_for_dev(self):
+        os.environ['KC_ALLOW_UNSIGNED_WEBHOOKS'] = '1'
+        # Only when the provider has no secret configured at all (sandbox).
+        self.assertTrue(wa.TwilioProvider().verify(
+            gw.RawRequest(url='u', headers={}, form={})))
+        self.assertTrue(wa.MetaProvider().verify(
+            gw.RawRequest(raw_body=b'{}', headers={})))
 
 
 class MetaHandshakeTest(unittest.TestCase):

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -324,6 +324,36 @@ hypervisor:
   # Working directory for hypervisor chat sessions.
   workdir: "/home/dev"
 
+# Conversation Gateway — chat with this workspace's agent over WhatsApp
+# (issue #325). OFF by default: with `enabled: false` the /api/gateway/*
+# config surface is inert AND templates/ingress-gateway.yaml (the public,
+# OAuth-bypassing webhook path) is not rendered at all.
+#
+# NO CREDENTIALS LIVE HERE. Each user brings their own provider account and
+# enters the credentials from the dashboard Settings page at runtime; they are
+# stored per-workspace on the PVC (0600) and never appear in the chart, a
+# ConfigMap, or an API response. See docs/ and issue #329.
+#
+# The in-app Walkie-Talkie loopback preview (/api/gateway/internal/*) is a
+# separate, always-available surface and is NOT affected by this flag.
+gateway:
+  enabled: false
+  # DEV/SANDBOX ONLY. Accepts inbound webhooks whose provider signature is
+  # missing or invalid. Production must leave this false — the chart refuses
+  # to render when it is combined with TLS (see templates/deployment.yaml).
+  allowUnsigned: false
+  # Optional, non-secret: the WhatsApp number shown in the Settings link
+  # helper. Purely cosmetic; the real sender comes from the user's credentials.
+  whatsappNumber: ""
+  limits:
+    # Per-workspace throttles on the authenticated config endpoints.
+    linkPerHour: 10         # POST /api/gateway/link (pairing codes)
+    testPerHour: 20         # POST /api/gateway/test (makes an outbound call)
+    # Edge caps on the public webhook ingress, mirroring ingress.publicLimits
+    # on the other internet-reachable surface.
+    webhookRps: 5
+    webhookConnections: 10
+
 # Optional alternate assistants. Claude Code is always available (above);
 # OpenCode (https://opencode.ai) becomes a *per-task* choice in the
 # dashboard whenever either of the blocks below is configured. Both blocks

--- a/charts/workspace/web/src/routes/settings/MessagingSection.test.tsx
+++ b/charts/workspace/web/src/routes/settings/MessagingSection.test.tsx
@@ -67,6 +67,12 @@ describe('MessagingSection', () => {
     expect(screen.getByText('WhatsApp sender number')).toBeTruthy();
   });
 
+  it('links to the provider setup guide in the docs', async () => {
+    render(<MessagingSection />);
+    const link = (await screen.findByText('Provider setup guide ↗')) as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toContain('/docs/whatsapp-gateway');
+  });
+
   it('switching to Meta renders exactly Meta\'s declared fields', async () => {
     render(<MessagingSection />);
     fireEvent.click(await screen.findByText('Meta (WhatsApp Cloud API)'));

--- a/charts/workspace/web/src/routes/settings/MessagingSection.tsx
+++ b/charts/workspace/web/src/routes/settings/MessagingSection.tsx
@@ -20,6 +20,7 @@ import { Pill } from '../../components/primitives/Pill';
 import { Icon } from '../../components/Icon';
 import { ConfirmDialog } from '../../components/ConfirmDialog';
 import { pushToast } from '../../store/ui';
+import { navigate, routeHref } from '../../store/router';
 
 function fmtCountdown(sec: number): string {
   const m = Math.floor(sec / 60);
@@ -261,7 +262,16 @@ export function MessagingSection() {
       <p class="settings-row-hint muted">
         Connect your own WhatsApp provider to chat with this workspace's agent over WhatsApp. Enter
         your provider credentials, paste the webhook URL into the provider console, then link your
-        number. Credentials are stored securely on your workspace disk and never shared.
+        number. Credentials are stored securely on your workspace disk and never shared.{' '}
+        <a
+          href={routeHref('/docs/whatsapp-gateway')}
+          onClick={(e) => {
+            e.preventDefault();
+            navigate('/docs/whatsapp-gateway');
+          }}
+        >
+          Provider setup guide ↗
+        </a>
       </p>
 
       {!available ? (

--- a/docs/_manifest.json
+++ b/docs/_manifest.json
@@ -34,6 +34,13 @@
       ]
     },
     {
+      "id": "messaging",
+      "title": "Messaging",
+      "pages": [
+        { "id": "whatsapp-gateway", "title": "WhatsApp gateway", "file": "whatsapp-gateway.md", "summary": "Chat with your workspace agent over WhatsApp: enable the gateway, connect Twilio, link your phone, keyword commands, and the security posture." }
+      ]
+    },
+    {
       "id": "workspace",
       "title": "Workspace",
       "pages": [

--- a/docs/whatsapp-gateway.md
+++ b/docs/whatsapp-gateway.md
@@ -1,0 +1,82 @@
+# Enabling the WhatsApp Conversation Gateway
+
+Chat with your workspace's agent over WhatsApp. The gateway is **opt-in** and
+**bring-your-own-credentials**: you supply your own Twilio or Meta app, and the
+credentials are stored per-workspace on the PVC — never in the chart, a
+ConfigMap, or an API response.
+
+> Setup walkthroughs for each provider (creating the app, finding the
+> credentials, registering templates) land with issue #332. This page covers
+> **enabling the subsystem** and the **security posture**.
+
+## 1. Turn it on
+
+The subsystem ships disabled. Enable it in your values overlay:
+
+```yaml
+gateway:
+  enabled: true
+```
+
+With `enabled: false` (the default):
+
+- `/api/gateway/*` external routes are inert (`503`, or a soft
+  `{"available": false}` for the catalog/link list so the Settings section
+  renders a clean "not available" state).
+- `templates/ingress-gateway.yaml` — the public, OAuth-bypassing webhook path —
+  **is not rendered at all**.
+- The in-app **Walkie-Talkie** loopback preview (`/api/gateway/internal/*`) is a
+  separate feature and keeps working either way.
+
+The webhook ingress additionally requires `ingress.auth.type: oauth2`, since it
+is the OAuth-bypass companion to that ingress.
+
+## 2. Connect a provider
+
+Everything else is self-serve from the dashboard: **Settings → Messaging /
+WhatsApp**. Pick a provider, paste your credentials, run **Test connection**,
+copy the webhook URL into your provider console, then **Link WhatsApp** and text
+the pairing code from your phone. The same card exists in the mobile app.
+
+Saving credentials hot-swaps the live provider — no pod restart.
+
+## 3. Security posture
+
+| Control | Behavior |
+|---|---|
+| Signature verification | **Fails closed.** Twilio `X-Twilio-Signature` and Meta `X-Hub-Signature-256` are verified in-pod; an unsigned or forged request gets `403`. |
+| `gateway.allowUnsigned` | **Dev/sandbox only.** Accepts unsigned webhooks. The chart **refuses to render** when this is combined with TLS, so it can't reach production. Never emitted as env unless explicitly set. |
+| Credentials at rest | JSON on the PVC, `0600`, atomic writes. Redacted in every API read — secret fields return only `set` + a last-4 hint, never the value. |
+| Edge throttling | The webhook ingress carries `limit-rps` / `limit-connections` (`gateway.limits.webhookRps` / `webhookConnections`). |
+| App throttling | Pairing-code minting and test-connection are capped per hour (`gateway.limits.linkPerHour` / `testPerHour`); the inbound webhook is additionally rate-limited per sender. |
+
+```yaml
+gateway:
+  enabled: true
+  allowUnsigned: false      # keep false outside local dev
+  limits:
+    linkPerHour: 10
+    testPerHour: 20
+    webhookRps: 5
+    webhookConnections: 10
+```
+
+## 4. Meta out-of-window templates
+
+WhatsApp only allows free-form replies inside a 24-hour window. Outside it, a
+provider-approved **template** is required.
+
+Meta enforces template registration against **your own app**, so kube-coder's
+built-in defaults are not sufficient there: until you register the template on
+your Meta app and record the approval, the gateway **skips** the out-of-window
+notification rather than attempting a send the provider would reject. The turn
+still completes and the result is in the runner log.
+
+Twilio has no such registry, so it keeps the built-in behavior.
+
+## 5. Turning it off
+
+Set `gateway.enabled: false` and redeploy: the external routes go inert and the
+webhook ingress disappears. To revoke without disabling the subsystem, use
+**Disconnect** in Settings (clears the stored credentials) or **Unlink** /
+the `unlink` keyword (drops a bound number).

--- a/docs/whatsapp-gateway.md
+++ b/docs/whatsapp-gateway.md
@@ -1,13 +1,14 @@
-# Enabling the WhatsApp Conversation Gateway
+# The WhatsApp Conversation Gateway
 
 Chat with your workspace's agent over WhatsApp. The gateway is **opt-in** and
-**bring-your-own-credentials**: you supply your own Twilio or Meta app, and the
+**bring-your-own-credentials**: you supply your own Twilio (or Meta) app, and the
 credentials are stored per-workspace on the PVC — never in the chart, a
 ConfigMap, or an API response.
 
-> Setup walkthroughs for each provider (creating the app, finding the
-> credentials, registering templates) land with issue #332. This page covers
-> **enabling the subsystem** and the **security posture**.
+This page is the end-to-end guide: **turn it on** (operator), **connect Twilio**
+and **link your phone** (self-serve), plus the **security posture** and how to
+turn it off. The whole connect flow is driven from **Settings → Messaging /
+WhatsApp** in the dashboard (or the mobile app) — no `kubectl`.
 
 ## 1. Turn it on
 
@@ -31,16 +32,80 @@ With `enabled: false` (the default):
 The webhook ingress additionally requires `ingress.auth.type: oauth2`, since it
 is the OAuth-bypass companion to that ingress.
 
-## 2. Connect a provider
+## 2. Connect Twilio
 
-Everything else is self-serve from the dashboard: **Settings → Messaging /
-WhatsApp**. Pick a provider, paste your credentials, run **Test connection**,
-copy the webhook URL into your provider console, then **Link WhatsApp** and text
-the pairing code from your phone. The same card exists in the mobile app.
+Twilio's **WhatsApp Sandbox** is the fastest bring-your-own path — no number
+approval, works in minutes. (For a production sender you'd register a WhatsApp
+number with Twilio instead; the credentials below are identical.)
+
+1. **Create a Twilio account** at [twilio.com](https://www.twilio.com/) and open
+   the [Console](https://www.twilio.com/console).
+2. **Open the WhatsApp Sandbox** — Console → **Messaging → Try it out → Send a
+   WhatsApp message**. You'll see a sandbox sender number (e.g.
+   `+1 415 523 8886`) and a **join code** (`join <two-words>`).
+3. **Opt your phone in** — from WhatsApp on your phone, send `join <two-words>`
+   to the sandbox number. (WhatsApp requires this opt-in before the sandbox can
+   message you.)
+4. **Grab your credentials** from the [Console dashboard](https://www.twilio.com/console):
+   your **Account SID** and **Auth Token**.
+5. **Enter them in kube-coder** — **Settings → Messaging / WhatsApp**, pick
+   **Twilio**, and fill in:
+
+   | Field | Value |
+   |---|---|
+   | **Account SID** | from the Console (starts `AC…`) |
+   | **Auth Token** | from the Console (secret — stored redacted) |
+   | **WhatsApp sender number** | `whatsapp:+14155238886` (your sandbox number) |
+
+   Click **Save**, then **Test connection** — it makes a real Twilio API call and
+   should report `connection ok`.
+6. **Point Twilio at your webhook** — copy the webhook URL shown in the Settings
+   card (the **Copy** button next to it):
+
+   ```
+   https://<your-workspace-host>/api/gateway/whatsapp/webhook
+   ```
+
+   In Twilio, open the **Sandbox settings** tab and paste that URL into **"WHEN A
+   MESSAGE COMES IN"**, method **HTTP POST**, then **Save**. Twilio signs each
+   webhook over this exact URL, so paste it unchanged.
 
 Saving credentials hot-swaps the live provider — no pod restart.
 
-## 3. Security posture
+## 3. Link your phone and chat
+
+Once Twilio is connected:
+
+1. In **Settings → Messaging / WhatsApp**, click **Link WhatsApp**. You get a
+   **6-digit pairing code** (valid ~10 minutes) and, for a dialable sender, an
+   **Open in WhatsApp** shortcut.
+2. **Text the code** to your WhatsApp sender number from your phone. You'll get a
+   `✅ Linked!` reply — your number is now bound (stored **hashed**, never in the
+   clear).
+3. **Just chat.** Text the workspace normally; the agent drives your workspace and
+   replies land back in WhatsApp.
+
+### Keyword commands
+
+Send any of these as the **whole message** (case-insensitive):
+
+| Say | Effect |
+|---|---|
+| `new chat` · `new` · `start over` · `reset` | Start a fresh conversation thread |
+| `stop` · `cancel` · `abort` | Stop the turn that's running |
+| `unlink` · `disconnect` · `forget me` | Unbind this number from the workspace |
+| `workspaces` · `list workspaces` | List the workspaces this number can reach |
+| `@<ws> <message>` · `on <ws>: <message>` | Route this one message to a specific workspace |
+
+### The 24-hour window
+
+WhatsApp only permits **free-form** replies within **24 hours** of your last
+inbound message. Inside the window the agent replies normally. Outside it, a
+provider-approved **template** is required — see §5. The Twilio sandbox can't send
+out-of-window templates, so a reply that lands after the window simply won't be
+delivered until you message again.
+
+## 4. Security posture
 
 | Control | Behavior |
 |---|---|
@@ -61,10 +126,9 @@ gateway:
     webhookConnections: 10
 ```
 
-## 4. Meta out-of-window templates
+## 5. Meta out-of-window templates
 
-WhatsApp only allows free-form replies inside a 24-hour window. Outside it, a
-provider-approved **template** is required.
+Outside the 24-hour window (§3), a provider-approved **template** is required.
 
 Meta enforces template registration against **your own app**, so kube-coder's
 built-in defaults are not sufficient there: until you register the template on
@@ -74,7 +138,7 @@ still completes and the result is in the runner log.
 
 Twilio has no such registry, so it keeps the built-in behavior.
 
-## 5. Turning it off
+## 6. Turning it off
 
 Set `gateway.enabled: false` and redeploy: the external routes go inert and the
 webhook ingress disappears. To revoke without disabling the subsystem, use

--- a/mobile/src/components/MessagingCard.tsx
+++ b/mobile/src/components/MessagingCard.tsx
@@ -174,6 +174,7 @@ export function MessagingCard({ readOnly }: { readOnly?: boolean }) {
   }
 
   const webhookUrl = cfg.host ? `${cfg.host.replace(/\/$/, '')}/api/gateway/whatsapp/webhook` : '';
+  const docsUrl = cfg.host ? `${cfg.host.replace(/\/$/, '')}/docs/whatsapp-gateway` : '';
   const verifyToken = spec?.credential_fields.some((f) => f.key === 'verify_token')
     ? cred?.fields['verify_token']?.value || ''
     : '';
@@ -195,6 +196,11 @@ export function MessagingCard({ readOnly }: { readOnly?: boolean }) {
         Connect your own WhatsApp provider to chat with this workspace over WhatsApp. Credentials are
         stored securely on your workspace disk.
       </Text>
+      {docsUrl ? (
+        <Pressable onPress={() => void Linking.openURL(docsUrl).catch(() => {})} hitSlop={6}>
+          <Text style={styles.guideLink}>Provider setup guide ↗</Text>
+        </Pressable>
+      ) : null}
 
       {/* Provider chooser */}
       {providers ? (
@@ -469,6 +475,7 @@ const styles = StyleSheet.create({
   codeBox: { alignItems: 'center', gap: 4, padding: space.md, backgroundColor: colors.card, borderRadius: radius.md },
   codeText: { color: colors.text, fontSize: font.size.xl, fontWeight: '800', letterSpacing: 4, fontFamily: font.mono },
   linkRow: { flexDirection: 'row', alignItems: 'center', gap: space.md },
+  guideLink: { color: colors.accent, fontSize: font.size.sm, fontWeight: '600' },
   backdrop: { flex: 1, backgroundColor: '#000a', justifyContent: 'flex-end' },
   sheet: {
     backgroundColor: colors.bgElevated,


### PR DESCRIPTION
Stage 5/5 of #325 — the onboarding-polish stage. Stages 1–4 made the WhatsApp gateway buildable, credential-stored, Settings-configurable (web **and** mobile), and hardened/enabled. This stage makes it **discoverable and usable by a brand-new bring-your-own-credentials user**: the docs a first-timer needs, wired into the in-app nav and the README, and reachable in one tap from the Settings card on both surfaces.

> Stacked on #331 (PR #440). Until that merges, this PR also shows #331's commit; it drops out on rebase once #331 lands.

## What this adds

### 1. A complete Twilio setup + end-user guide (`docs/whatsapp-gateway.md`)
The page previously covered only enablement + security posture and explicitly deferred the setup walkthrough to this issue. It now carries the full journey:
- **Connect Twilio** — step-by-step: create the account, open the WhatsApp **Sandbox**, opt your phone in with the `join` code, copy **Account SID** / **Auth Token** / **sender number**, and paste the webhook URL into the Twilio console. Field names match the Settings form exactly (they're both driven by the same provider registry).
- **Link your phone and chat** — the pairing-code flow, plus a **keyword-command reference** (`new chat`, `stop`, `unlink`, `workspaces`, `@ws`) taken verbatim from the gateway's `parse_command`, and the **24-hour window** rule.
- Keeps the existing enablement, security-posture, Meta-template-behavior, and teardown sections.

### 2. Discoverable everywhere
- **In-app docs nav** (`docs/_manifest.json`) — new **Messaging** section registers the page; it now renders at `/docs/whatsapp-gateway`.
- **README** — a short "Chat over WhatsApp" feature section with a deep-link to the guide, matching the existing convention.
- **Settings → Messaging / WhatsApp** — a **"Provider setup guide ↗"** link in the card intro, on **web** (in-SPA nav to `/docs/whatsapp-gateway`) and **mobile** (opens the workspace docs page). This is the issue's "linked directly from the Settings section."

## Mobile parity
The issue also lists mobile parity for the Settings section. That surface (`mobile/src/components/MessagingCard.tsx`) already shipped in #330 and fully mirrors the web card — provider picker, data-driven fields, Save/Test/Disconnect, webhook + verify-token copy, pairing-code link management with countdown and `wa.me` deep-link, unlink, and the unavailable state. This stage adds only the discoverability link to it; no functional change.

## Scope
- **No Meta setup walkthrough** — deferred; the existing Meta out-of-window-template behavior note stays.
- No backend, credential-store, or chart changes. The Settings card's functional behavior is unchanged.

## Files changed
| File | Change |
|---|---|
| `docs/whatsapp-gateway.md` | Twilio setup walkthrough + link/keyword/24h flow; removed the #332-deferral note |
| `docs/_manifest.json` | register the page in the in-app docs nav (new "Messaging" section) |
| `README.md` | "Chat over WhatsApp" feature section + deep-link |
| `charts/workspace/web/src/routes/settings/MessagingSection.tsx` | "Provider setup guide ↗" link (in-SPA nav) |
| `mobile/src/components/MessagingCard.tsx` | "Provider setup guide ↗" link (opens workspace docs) |
| `charts/workspace/web/src/routes/settings/MessagingSection.test.tsx` | assert the guide link renders |

## Testing
- Dashboard SPA: `MessagingSection` vitest green (9 tests incl. the new link assertion); `tsc --noEmit` clean.
- Mobile: `tsc --noEmit` clean on `MessagingCard.tsx`; suite unaffected (no test covers the card).
- Docs walkthrough traces the exact Twilio round-trip verified live in #331 (real phone → sandbox → workspace → reply; forged webhook → 403) — no new credentials required.
