### PR TITLE
WhatsApp gateway (5/5): Twilio setup guide, in-app docs nav & Settings deep-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,20 @@ All three live under **Triggers**, and what-fired-what is tracked in the memory 
 
 ---
 
+## Chat over WhatsApp
+
+Drive your workspace agent from WhatsApp. The gateway is **opt-in** and
+**bring-your-own-credentials** — connect your own Twilio (or Meta) app from
+**Settings → Messaging / WhatsApp**, paste the webhook URL into the provider
+console, tap **Link WhatsApp**, and text the pairing code once. After that you
+just chat: messages drive a Hypervisor turn and replies come back to your phone,
+with keyword commands (`new chat`, `stop`, `unlink`, `workspaces`, `@ws`) and a
+fail-closed signature check on every inbound. The same card is in the mobile app.
+
+Full guide: [`docs/whatsapp-gateway.md`](docs/whatsapp-gateway.md).
+
+---
+
 ## Pluggable AI assistants
 
 Every session — and every orchestrator sub-agent — picks its assistant at create-time, so you can mix them freely in one workspace. Keys live in `users-private/<name>/secrets/assistant.yaml` (gitignored); the public defaults are empty, so it ships Claude-only out of the box, and users can add their own provider keys self-service from **Settings**.

--- a/charts/workspace/web/src/routes/settings/MessagingSection.test.tsx
+++ b/charts/workspace/web/src/routes/settings/MessagingSection.test.tsx
@@ -67,6 +67,12 @@ describe('MessagingSection', () => {
     expect(screen.getByText('WhatsApp sender number')).toBeTruthy();
   });
 
+  it('links to the provider setup guide in the docs', async () => {
+    render(<MessagingSection />);
+    const link = (await screen.findByText('Provider setup guide ↗')) as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toContain('/docs/whatsapp-gateway');
+  });
+
   it('switching to Meta renders exactly Meta\'s declared fields', async () => {
     render(<MessagingSection />);
     fireEvent.click(await screen.findByText('Meta (WhatsApp Cloud API)'));

--- a/charts/workspace/web/src/routes/settings/MessagingSection.tsx
+++ b/charts/workspace/web/src/routes/settings/MessagingSection.tsx
@@ -20,6 +20,7 @@ import { Pill } from '../../components/primitives/Pill';
 import { Icon } from '../../components/Icon';
 import { ConfirmDialog } from '../../components/ConfirmDialog';
 import { pushToast } from '../../store/ui';
+import { navigate, routeHref } from '../../store/router';
 
 function fmtCountdown(sec: number): string {
   const m = Math.floor(sec / 60);
@@ -261,7 +262,16 @@ export function MessagingSection() {
       <p class="settings-row-hint muted">
         Connect your own WhatsApp provider to chat with this workspace's agent over WhatsApp. Enter
         your provider credentials, paste the webhook URL into the provider console, then link your
-        number. Credentials are stored securely on your workspace disk and never shared.
+        number. Credentials are stored securely on your workspace disk and never shared.{' '}
+        <a
+          href={routeHref('/docs/whatsapp-gateway')}
+          onClick={(e) => {
+            e.preventDefault();
+            navigate('/docs/whatsapp-gateway');
+          }}
+        >
+          Provider setup guide ↗
+        </a>
       </p>
 
       {!available ? (

--- a/docs/_manifest.json
+++ b/docs/_manifest.json
@@ -34,6 +34,13 @@
       ]
     },
     {
+      "id": "messaging",
+      "title": "Messaging",
+      "pages": [
+        { "id": "whatsapp-gateway", "title": "WhatsApp gateway", "file": "whatsapp-gateway.md", "summary": "Chat with your workspace agent over WhatsApp: enable the gateway, connect Twilio, link your phone, keyword commands, and the security posture." }
+      ]
+    },
+    {
       "id": "workspace",
       "title": "Workspace",
       "pages": [

--- a/docs/whatsapp-gateway.md
+++ b/docs/whatsapp-gateway.md
@@ -1,13 +1,14 @@
-# Enabling the WhatsApp Conversation Gateway
+# The WhatsApp Conversation Gateway
 
 Chat with your workspace's agent over WhatsApp. The gateway is **opt-in** and
-**bring-your-own-credentials**: you supply your own Twilio or Meta app, and the
+**bring-your-own-credentials**: you supply your own Twilio (or Meta) app, and the
 credentials are stored per-workspace on the PVC — never in the chart, a
 ConfigMap, or an API response.
 
-> Setup walkthroughs for each provider (creating the app, finding the
-> credentials, registering templates) land with issue #332. This page covers
-> **enabling the subsystem** and the **security posture**.
+This page is the end-to-end guide: **turn it on** (operator), **connect Twilio**
+and **link your phone** (self-serve), plus the **security posture** and how to
+turn it off. The whole connect flow is driven from **Settings → Messaging /
+WhatsApp** in the dashboard (or the mobile app) — no `kubectl`.
 
 ## 1. Turn it on
 
@@ -31,16 +32,80 @@ With `enabled: false` (the default):
 The webhook ingress additionally requires `ingress.auth.type: oauth2`, since it
 is the OAuth-bypass companion to that ingress.
 
-## 2. Connect a provider
+## 2. Connect Twilio
 
-Everything else is self-serve from the dashboard: **Settings → Messaging /
-WhatsApp**. Pick a provider, paste your credentials, run **Test connection**,
-copy the webhook URL into your provider console, then **Link WhatsApp** and text
-the pairing code from your phone. The same card exists in the mobile app.
+Twilio's **WhatsApp Sandbox** is the fastest bring-your-own path — no number
+approval, works in minutes. (For a production sender you'd register a WhatsApp
+number with Twilio instead; the credentials below are identical.)
+
+1. **Create a Twilio account** at [twilio.com](https://www.twilio.com/) and open
+   the [Console](https://www.twilio.com/console).
+2. **Open the WhatsApp Sandbox** — Console → **Messaging → Try it out → Send a
+   WhatsApp message**. You'll see a sandbox sender number (e.g.
+   `+1 415 523 8886`) and a **join code** (`join <two-words>`).
+3. **Opt your phone in** — from WhatsApp on your phone, send `join <two-words>`
+   to the sandbox number. (WhatsApp requires this opt-in before the sandbox can
+   message you.)
+4. **Grab your credentials** from the [Console dashboard](https://www.twilio.com/console):
+   your **Account SID** and **Auth Token**.
+5. **Enter them in kube-coder** — **Settings → Messaging / WhatsApp**, pick
+   **Twilio**, and fill in:
+
+   | Field | Value |
+   |---|---|
+   | **Account SID** | from the Console (starts `AC…`) |
+   | **Auth Token** | from the Console (secret — stored redacted) |
+   | **WhatsApp sender number** | `whatsapp:+14155238886` (your sandbox number) |
+
+   Click **Save**, then **Test connection** — it makes a real Twilio API call and
+   should report `connection ok`.
+6. **Point Twilio at your webhook** — copy the webhook URL shown in the Settings
+   card (the **Copy** button next to it):
+
+   ```
+   https://<your-workspace-host>/api/gateway/whatsapp/webhook
+   ```
+
+   In Twilio, open the **Sandbox settings** tab and paste that URL into **"WHEN A
+   MESSAGE COMES IN"**, method **HTTP POST**, then **Save**. Twilio signs each
+   webhook over this exact URL, so paste it unchanged.
 
 Saving credentials hot-swaps the live provider — no pod restart.
 
-## 3. Security posture
+## 3. Link your phone and chat
+
+Once Twilio is connected:
+
+1. In **Settings → Messaging / WhatsApp**, click **Link WhatsApp**. You get a
+   **6-digit pairing code** (valid ~10 minutes) and, for a dialable sender, an
+   **Open in WhatsApp** shortcut.
+2. **Text the code** to your WhatsApp sender number from your phone. You'll get a
+   `✅ Linked!` reply — your number is now bound (stored **hashed**, never in the
+   clear).
+3. **Just chat.** Text the workspace normally; the agent drives your workspace and
+   replies land back in WhatsApp.
+
+### Keyword commands
+
+Send any of these as the **whole message** (case-insensitive):
+
+| Say | Effect |
+|---|---|
+| `new chat` · `new` · `start over` · `reset` | Start a fresh conversation thread |
+| `stop` · `cancel` · `abort` | Stop the turn that's running |
+| `unlink` · `disconnect` · `forget me` | Unbind this number from the workspace |
+| `workspaces` · `list workspaces` | List the workspaces this number can reach |
+| `@<ws> <message>` · `on <ws>: <message>` | Route this one message to a specific workspace |
+
+### The 24-hour window
+
+WhatsApp only permits **free-form** replies within **24 hours** of your last
+inbound message. Inside the window the agent replies normally. Outside it, a
+provider-approved **template** is required — see §5. The Twilio sandbox can't send
+out-of-window templates, so a reply that lands after the window simply won't be
+delivered until you message again.
+
+## 4. Security posture
 
 | Control | Behavior |
 |---|---|
@@ -61,10 +126,9 @@ gateway:
     webhookConnections: 10
 ```
 
-## 4. Meta out-of-window templates
+## 5. Meta out-of-window templates
 
-WhatsApp only allows free-form replies inside a 24-hour window. Outside it, a
-provider-approved **template** is required.
+Outside the 24-hour window (§3), a provider-approved **template** is required.
 
 Meta enforces template registration against **your own app**, so kube-coder's
 built-in defaults are not sufficient there: until you register the template on
@@ -74,7 +138,7 @@ still completes and the result is in the runner log.
 
 Twilio has no such registry, so it keeps the built-in behavior.
 
-## 5. Turning it off
+## 6. Turning it off
 
 Set `gateway.enabled: false` and redeploy: the external routes go inert and the
 webhook ingress disappears. To revoke without disabling the subsystem, use

--- a/mobile/src/components/MessagingCard.tsx
+++ b/mobile/src/components/MessagingCard.tsx
@@ -174,6 +174,7 @@ export function MessagingCard({ readOnly }: { readOnly?: boolean }) {
   }
 
   const webhookUrl = cfg.host ? `${cfg.host.replace(/\/$/, '')}/api/gateway/whatsapp/webhook` : '';
+  const docsUrl = cfg.host ? `${cfg.host.replace(/\/$/, '')}/docs/whatsapp-gateway` : '';
   const verifyToken = spec?.credential_fields.some((f) => f.key === 'verify_token')
     ? cred?.fields['verify_token']?.value || ''
     : '';
@@ -195,6 +196,11 @@ export function MessagingCard({ readOnly }: { readOnly?: boolean }) {
         Connect your own WhatsApp provider to chat with this workspace over WhatsApp. Credentials are
         stored securely on your workspace disk.
       </Text>
+      {docsUrl ? (
+        <Pressable onPress={() => void Linking.openURL(docsUrl).catch(() => {})} hitSlop={6}>
+          <Text style={styles.guideLink}>Provider setup guide ↗</Text>
+        </Pressable>
+      ) : null}
 
       {/* Provider chooser */}
       {providers ? (
@@ -469,6 +475,7 @@ const styles = StyleSheet.create({
   codeBox: { alignItems: 'center', gap: 4, padding: space.md, backgroundColor: colors.card, borderRadius: radius.md },
   codeText: { color: colors.text, fontSize: font.size.xl, fontWeight: '800', letterSpacing: 4, fontFamily: font.mono },
   linkRow: { flexDirection: 'row', alignItems: 'center', gap: space.md },
+  guideLink: { color: colors.accent, fontSize: font.size.sm, fontWeight: '600' },
   backdrop: { flex: 1, backgroundColor: '#000a', justifyContent: 'flex-end' },
   sheet: {
     backgroundColor: colors.bgElevated,


### PR DESCRIPTION
Stage 5/5 of #325 — the onboarding-polish stage, closing out the epic. Stages 1–4 made the WhatsApp gateway buildable (#328), credential-stored (#329), Settings-configurable on web **and** mobile (#330), and hardened/enabled (#331, merged in #440). This stage makes it **discoverable and usable by a brand-new bring-your-own-credentials user**: the docs a first-timer needs, wired into the in-app nav and the README, and reachable in one tap from the Settings card on both surfaces.

## What this adds

### 1. A complete Twilio setup + end-user guide (`docs/whatsapp-gateway.md`)
The page previously covered only enablement + security posture and explicitly deferred the setup walkthrough to this issue. It now carries the full journey:
- **Connect Twilio** — step-by-step: create the account, open the WhatsApp **Sandbox**, opt your phone in with the `join` code, copy **Account SID** / **Auth Token** / **sender number**, and paste the webhook URL into the Twilio console. Field names match the Settings form exactly (they're both driven by the same provider registry).
- **Link your phone and chat** — the pairing-code flow, plus a **keyword-command reference** (`new chat`, `stop`, `unlink`, `workspaces`, `@ws`) taken verbatim from the gateway's `parse_command`, and the **24-hour window** rule.
- Keeps the existing enablement, security-posture, Meta-template-behavior, and teardown sections.

### 2. Discoverable everywhere
- **In-app docs nav** (`docs/_manifest.json`) — new **Messaging** section registers the page; it now renders at `/docs/whatsapp-gateway`.
- **README** — a short "Chat over WhatsApp" feature section with a deep-link to the guide, matching the existing convention.
- **Settings → Messaging / WhatsApp** — a **"Provider setup guide ↗"** link in the card intro, on **web** (in-SPA nav to `/docs/whatsapp-gateway`) and **mobile** (opens the workspace docs page). This is the issue's "linked directly from the Settings section."

## Mobile parity
The issue also lists mobile parity for the Settings section. That surface (`mobile/src/components/MessagingCard.tsx`) already shipped in #330 and fully mirrors the web card — provider picker, data-driven fields, Save/Test/Disconnect, webhook + verify-token copy, pairing-code link management with countdown and `wa.me` deep-link, unlink, and the unavailable state. This stage adds only the discoverability link to it; no functional change.

## Scope
- **No Meta setup walkthrough** — deferred; the existing Meta out-of-window-template behavior note stays.
- No backend, credential-store, or chart changes. The Settings card's functional behavior is unchanged.

## Files changed
| File | Change |
|---|---|
| `docs/whatsapp-gateway.md` | Twilio setup walkthrough + link/keyword/24h flow; removed the #332-deferral note |
| `docs/_manifest.json` | register the page in the in-app docs nav (new "Messaging" section) |
| `README.md` | "Chat over WhatsApp" feature section + deep-link |
| `charts/workspace/web/src/routes/settings/MessagingSection.tsx` | "Provider setup guide ↗" link (in-SPA nav) |
| `mobile/src/components/MessagingCard.tsx` | "Provider setup guide ↗" link (opens workspace docs) |
| `charts/workspace/web/src/routes/settings/MessagingSection.test.tsx` | assert the guide link renders |

## Testing
- Dashboard SPA: `MessagingSection` vitest green (9 tests incl. the new link assertion); `tsc --noEmit` clean.
- Mobile: `tsc --noEmit` clean on `MessagingCard.tsx`; suite unaffected (no test covers the card).
- Docs walkthrough traces the exact Twilio round-trip verified live in #331 (real phone → sandbox → workspace → reply; forged webhook → 403) — no new credentials required.
