### PR TITLE
feat(assistant): opt-in workspace default to OpenCode Zen (free) instead of Claude (#395)

### DIFF
--- a/charts/workspace/hypervisor_session.py
+++ b/charts/workspace/hypervisor_session.py
@@ -84,7 +84,7 @@ HYPERVISOR_DIR = os.path.join(WORKSPACE_HOME, '.claude-tasks', 'hypervisor')
 # directly — keep _PROVIDER_KEY_VARS in sync with ProviderKeysManager.ALLOWED.
 _PROVIDER_KEYS_FILE = os.path.join(WORKSPACE_HOME, '.claude-tasks', 'provider-keys.json')
 _PROVIDER_KEY_VARS = ('OPENROUTER_API_KEY', 'DEEPSEEK_API_KEY',
-                      'ANTHROPIC_API_KEY', 'OPENAI_API_KEY')
+                      'ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'OPENCODE_API_KEY')
 
 
 def _provider_key_overlay() -> Dict[str, str]:

--- a/charts/workspace/mcp_agent_orchestrator.py
+++ b/charts/workspace/mcp_agent_orchestrator.py
@@ -239,7 +239,7 @@ def _append_sub_task_id(parent_task_id: str, child_task_id: str) -> None:
 # Assistants with a non-interactive one-shot "print" mode that exits when
 # the task is done. Anything not listed has no reliable headless interface
 # (kc-harness) and is always run interactively (prompt pasted into the REPL).
-_HEADLESS_CAPABLE = {'claude', 'ante', 'codex', 'antigravity', 'librefang', 'opencode-openrouter', 'opencode-deepseek'}
+_HEADLESS_CAPABLE = {'claude', 'ante', 'codex', 'antigravity', 'librefang', 'opencode-openrouter', 'opencode-deepseek', 'opencode-zen'}
 
 
 def _codex_model_flag() -> str:
@@ -252,6 +252,11 @@ def _codex_model_flag() -> str:
 def _opencode_model(assistant: str) -> str:
     if assistant == 'opencode-deepseek':
         return 'deepseek/' + os.environ.get('KC_DEEPSEEK_MODEL', 'deepseek-chat')
+    if assistant == 'opencode-zen':
+        # Provider id `opencode-zen` matches the opencode.json stanza start.sh
+        # writes; the model is one of Zen's free ids (#395). Keep the default in
+        # sync with server.py's _OPENCODE_ZEN_DEFAULT_MODEL.
+        return 'opencode-zen/' + os.environ.get('KC_OPENCODE_ZEN_MODEL', 'deepseek-v4-flash-free')
     return 'openrouter/' + os.environ.get('KC_OPENROUTER_MODEL', 'anthropic/claude-sonnet-4')
 
 
@@ -299,7 +304,7 @@ def _assistant_command(assistant: str, prompt: str = '', headless: bool = True) 
     """
     if not headless or assistant not in _HEADLESS_CAPABLE:
         # Interactive REPL — prompt delivered via tmux paste by the caller.
-        if assistant in ('opencode-openrouter', 'opencode-deepseek'):
+        if assistant in ('opencode-openrouter', 'opencode-deepseek', 'opencode-zen'):
             return f'opencode --model {_shell_quote(_opencode_model(assistant))}'
         if assistant == 'antigravity':
             m = _antigravity_model()
@@ -380,6 +385,7 @@ _ASSISTANTS_LIST = [
     {'id': 'librefang', 'label': 'LibreFang'},
     {'id': 'opencode-openrouter', 'label': 'OpenRouter'},
     {'id': 'opencode-deepseek', 'label': 'DeepSeek'},
+    {'id': 'opencode-zen', 'label': 'OpenCode Zen'},
     {'id': 'kc-harness', 'label': 'Opensource GPU'},
 ]
 
@@ -390,7 +396,11 @@ def _tool_spawn_agent(args: Dict[str, Any]) -> Dict[str, Any]:
     if not prompt:
         return {'isError': True, 'content': [{'type': 'text', 'text': 'prompt is required'}]}
 
-    assistant = args.get('assistant', 'ante')
+    # No explicit assistant → honour the workspace default (KC_DEFAULT_ASSISTANT,
+    # #395) so sub-agents on a trial workspace run on the free assistant too.
+    # Only set on workspaces that opted in; vanilla leaves it unset and keeps the
+    # historical 'ante' fallback (a keyless, always-available CLI).
+    assistant = args.get('assistant') or os.environ.get('KC_DEFAULT_ASSISTANT') or 'ante'
     # Default the sub-agent's working directory to the SPAWNING agent's cwd.
     # This MCP server is a stdio subprocess of the parent CLI, so os.getcwd()
     # is the directory the parent was launched in (its project) — a far better
@@ -758,9 +768,9 @@ TOOLS: Dict[str, Any] = {
                     'prompt': {'type': 'string', 'description': 'The task prompt/instructions'},
                     'assistant': {
                         'type': 'string',
-                        'description': 'Which agent to spawn',
-                        'enum': ['ante', 'claude', 'antigravity', 'librefang', 'opencode-openrouter', 'opencode-deepseek', 'kc-harness'],
-                        'default': 'ante',
+                        'description': 'Which agent to spawn. Omit to use the '
+                                       'workspace default assistant.',
+                        'enum': ['ante', 'claude', 'codex', 'antigravity', 'librefang', 'opencode-openrouter', 'opencode-deepseek', 'opencode-zen', 'kc-harness'],
                     },
                     'mode': {
                         'type': 'string',

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -167,7 +167,16 @@ PUBLIC_DEMO_ACK = os.environ.get('PUBLIC_DEMO_ACK', 'false').lower() == 'true'
 # tools. Threads are hypervisor-flavoured tasks (source="hypervisor") reusing
 # ClaudeTaskManager; there is no separate LLM/provider loop.
 HYPERVISOR_ENABLED = os.environ.get('HYPERVISOR_ENABLED', 'true').lower() == 'true'
-HYPERVISOR_DEFAULT_ASSISTANT = os.environ.get('HYPERVISOR_DEFAULT_ASSISTANT', 'claude')
+# Workspace-wide default assistant (issue #395). Governs BOTH the Hypervisor
+# chat and the New Build / task-create pickers so an operator can provision a
+# trial/demo workspace that defaults to a free assistant (e.g. opencode-zen)
+# instead of Claude. Empty/unset → 'claude', so vanilla deployments are
+# unchanged. HYPERVISOR_DEFAULT_ASSISTANT stays a back-compat override for the
+# Hypervisor chat only: when explicitly set it wins there; otherwise the
+# Hypervisor inherits the workspace default.
+WORKSPACE_DEFAULT_ASSISTANT = os.environ.get('KC_DEFAULT_ASSISTANT') or 'claude'
+HYPERVISOR_DEFAULT_ASSISTANT = (
+    os.environ.get('HYPERVISOR_DEFAULT_ASSISTANT') or WORKSPACE_DEFAULT_ASSISTANT)
 HYPERVISOR_WORKDIR = os.environ.get('HYPERVISOR_WORKDIR', '/home/dev')
 # AI CTO (#467) — the /cto page (project registry + CTO-persona chat + brief).
 # It rides the Hypervisor, so it's available only when BOTH this flag and the
@@ -194,6 +203,22 @@ def _is_first_cto_thread():
     except Exception:
         return False
     return not any((t.get('persona') or '') == 'cto' for t in threads)
+# OpenCode Zen (issue #395) — the free coding models on OpenCode's hosted Zen
+# gateway. The whole list is offered in the in-chat model switcher; the first
+# entry is the built-in default (a coding-oriented model), overridable per
+# deployment via KC_OPENCODE_ZEN_MODEL / KC_OPENCODE_ZEN_MODELS. Zen advertises
+# these as free-for-a-limited-time and may train on submitted data — the UI
+# surfaces that disclosure (see the trainingDisclosure flag on the assistant).
+_OPENCODE_ZEN_FREE_MODELS = (
+    'deepseek-v4-flash-free',
+    'big-pickle',
+    'mimo-v2.5-free',
+    'laguna-s-2.1-free',
+    'ling-3.0-flash-free',
+    'north-mini-code-free',
+    'nemotron-3-ultra-free',
+)
+_OPENCODE_ZEN_DEFAULT_MODEL = _OPENCODE_ZEN_FREE_MODELS[0]
 # Short context note pasted as the first message of a new chat, so the agent
 # knows its role + that it has the dashboard tools. Kept terse on purpose —
 # a big preamble front-loads noise and some CLIs handle it poorly.
@@ -1466,6 +1491,17 @@ class ClaudeTaskManager:
             'id': 'opencode-deepseek',
             'label': 'DeepSeek',
         },
+        # OpenCode Zen (#395) — OpenCode's hosted gateway of free coding models.
+        # No credit card, ~100 req/day on a one-time free signup key, so it's the
+        # zero-cost default for trial/demo workspaces. `free` drives the "free"
+        # marker in the picker; `trainingDisclosure` drives the UI note that Zen
+        # may train on submitted data.
+        'opencode-zen': {
+            'id': 'opencode-zen',
+            'label': 'OpenCode Zen',
+            'free': True,
+            'trainingDisclosure': True,
+        },
         # kc-harness — thin in-pod LLM tool-call loop at /tmp/browser/harness.py
         # See charts/workspace/harness.py for the design rationale.
         'kc-harness': {
@@ -1476,7 +1512,11 @@ class ClaudeTaskManager:
 
     @staticmethod
     def available_assistants():
-        out = [dict(ClaudeTaskManager.ASSISTANTS['claude'], default=True)]
+        # Claude is always first-listed and always installed, but it is no
+        # longer hard-flagged as the default — the configured workspace default
+        # (KC_DEFAULT_ASSISTANT, issue #395) decides which entry carries
+        # default=True and sorts to the front. See _apply_default_flag below.
+        out = [dict(ClaudeTaskManager.ASSISTANTS['claude'])]
         out.append(dict(ClaudeTaskManager.ASSISTANTS['ante']))
         # Antigravity — listed only when its `agy` CLI is actually resolvable
         # (older images predate it; /usr/local/bin/agy is a symlink to a PVC path
@@ -1512,6 +1552,16 @@ class ClaudeTaskManager:
                 ClaudeTaskManager.ASSISTANTS['opencode-deepseek'],
                 model=os.environ.get('KC_DEEPSEEK_MODEL', 'deepseek-chat'),
             ))
+        # OpenCode Zen (issue #395) — OpenCode's hosted gateway of free coding
+        # models. Unlike OpenRouter/DeepSeek it is NOT a first-class
+        # auto-discovered provider: start.sh writes an explicit opencode.json
+        # provider stanza when OPENCODE_API_KEY is set (a per-user or a shared
+        # platform key), which is the same signal we gate the dropdown on here.
+        if os.environ.get('OPENCODE_API_KEY'):
+            out.append(dict(
+                ClaudeTaskManager.ASSISTANTS['opencode-zen'],
+                model=os.environ.get('KC_OPENCODE_ZEN_MODEL', _OPENCODE_ZEN_DEFAULT_MODEL),
+            ))
         if os.environ.get('KC_FALLBACK_BASE_URL'):
             out.append(dict(
                 ClaudeTaskManager.ASSISTANTS['kc-harness'],
@@ -1524,7 +1574,31 @@ class ClaudeTaskManager:
         # is the default.
         for a in out:
             a['models'] = ClaudeTaskManager.available_models(a['id'])
-        return out
+        return ClaudeTaskManager._apply_default_flag(out)
+
+    @staticmethod
+    def _apply_default_flag(assistants):
+        """Flag the configured workspace default (KC_DEFAULT_ASSISTANT, #395)
+        with default=True and sort it to the front; every other entry gets
+        default=False. When the configured default isn't in the enabled set
+        (e.g. opencode-zen selected but no OPENCODE_API_KEY provisioned) we log
+        loudly and fall back to claude instead of silently mis-defaulting."""
+        ids = {a['id'] for a in assistants}
+        target = WORKSPACE_DEFAULT_ASSISTANT
+        if target not in ids:
+            if target != 'claude':
+                print(
+                    f'[assistant] configured default {target!r} is not enabled '
+                    f'(available: {sorted(ids)}); falling back to claude. '
+                    'Check the assistant.default value and that its API key / '
+                    'shared secret is provisioned.',
+                    file=sys.stderr)
+            target = 'claude'
+        for a in assistants:
+            a['default'] = (a['id'] == target)
+        # Stable sort: the flagged default first, everything else keeps order.
+        assistants.sort(key=lambda a: 0 if a['default'] else 1)
+        return assistants
 
     # Models the in-chat switcher offers per assistant (issue #308). An assistant
     # appears here only when its adapter threads a per-thread `--model`:
@@ -1551,6 +1625,7 @@ class ClaudeTaskManager:
         'claude': 'KC_CLAUDE_MODELS',
         'opencode-openrouter': 'KC_OPENROUTER_MODELS',
         'opencode-deepseek': 'KC_DEEPSEEK_MODELS',
+        'opencode-zen': 'KC_OPENCODE_ZEN_MODELS',
         'codex': 'KC_CODEX_MODELS',
         'antigravity': 'KC_ANTIGRAVITY_MODELS',
     }
@@ -1573,6 +1648,12 @@ class ClaudeTaskManager:
             # Native DeepSeek API ids; the opencode adapter prepends `deepseek/`.
             default = os.environ.get('KC_DEEPSEEK_MODEL', 'deepseek-chat')
             return _dedup_keep_order([default, 'deepseek-chat', 'deepseek-reasoner'])
+        if assistant_id == 'opencode-zen':
+            # Zen's free model ids; the opencode adapter prepends `opencode-zen/`.
+            # Configured default first (unchanged behaviour), then the rest of
+            # the free catalogue so they're one tap away in the switcher.
+            default = os.environ.get('KC_OPENCODE_ZEN_MODEL', _OPENCODE_ZEN_DEFAULT_MODEL)
+            return _dedup_keep_order([default, *_OPENCODE_ZEN_FREE_MODELS])
         return []
 
     @staticmethod
@@ -1602,12 +1683,29 @@ class ClaudeTaskManager:
 
     @staticmethod
     def resolve_assistant(requested):
-        """Validate the caller's choice; fall back to claude on anything
-        unknown or disabled (the dashboard hides disabled options, but
-        webhooks/crons/CLI clients are free-form so we defend the boundary)."""
+        """Validate the caller's choice; fall back to the configured workspace
+        default (KC_DEFAULT_ASSISTANT, #395), then claude, on anything unknown
+        or disabled (the dashboard hides disabled options, but webhooks/crons/
+        CLI clients are free-form so we defend the boundary). Logs loudly on
+        every fallback so a mis-provisioned default is visible instead of
+        silently reverting to claude."""
         enabled = {a['id'] for a in ClaudeTaskManager.available_assistants()}
         if requested and requested in enabled:
             return requested
+        if requested:
+            print(
+                f'[assistant] requested assistant {requested!r} is not enabled '
+                f'(available: {sorted(enabled)}); falling back to the workspace '
+                'default.',
+                file=sys.stderr)
+        default = WORKSPACE_DEFAULT_ASSISTANT
+        if default in enabled:
+            return default
+        if default != 'claude':
+            print(
+                f'[assistant] configured default {default!r} is not enabled '
+                f'(available: {sorted(enabled)}); falling back to claude.',
+                file=sys.stderr)
         return 'claude'
 
     # Unattended task sources — no human is watching the live terminal, so the
@@ -1700,6 +1798,13 @@ class ClaudeTaskManager:
         if assistant == 'opencode-deepseek':
             model = os.environ.get('KC_DEEPSEEK_MODEL', 'deepseek-chat')
             return f'opencode --model {_shell_quote(f"deepseek/{model}")}'
+        if assistant == 'opencode-zen':
+            # OpenCode Zen (#395). The provider id `opencode-zen` matches the
+            # custom provider stanza start.sh writes into opencode.json; the
+            # model is one of Zen's free ids. Quote so a hostile env var can't
+            # break out of the `bash -lc` shell_cmd built in create_task().
+            model = os.environ.get('KC_OPENCODE_ZEN_MODEL', _OPENCODE_ZEN_DEFAULT_MODEL)
+            return f'opencode --model {_shell_quote(f"opencode-zen/{model}")}'
         if assistant == 'kc-harness':
             # Reads stdin (tmux paste) and emits dashboard JSONL events.
             # KC_HARNESS_MODEL / KC_FALLBACK_MODEL pick the model; the
@@ -4393,7 +4498,7 @@ class ProviderKeysManager:
     # OPENAI_API_KEY (issue #396) also powers the voice interface's server-side
     # transcription (SpeechTranscriber) besides riding CLI spawns like the rest.
     ALLOWED = ('OPENROUTER_API_KEY', 'DEEPSEEK_API_KEY', 'ANTHROPIC_API_KEY',
-               'OPENAI_API_KEY')
+               'OPENAI_API_KEY', 'OPENCODE_API_KEY')
 
     @classmethod
     def _read(cls):

--- a/charts/workspace/start.sh
+++ b/charts/workspace/start.sh
@@ -223,8 +223,8 @@ fi
 # itself needs no on-disk config — it reads ANTHROPIC_API_KEY from env
 # or OAuths interactively. The config is rewritten on every pod start
 # so Helm value changes flow through cleanly.
-if [ -n "$OPENROUTER_API_KEY" ] || [ -n "$DEEPSEEK_API_KEY" ] || [ -n "$KC_FALLBACK_BASE_URL" ]; then
-  log_stage "writing OpenCode config (openrouter=$([ -n "$OPENROUTER_API_KEY" ] && echo on || echo off) deepseek=$([ -n "$DEEPSEEK_API_KEY" ] && echo on || echo off) fallback=$([ -n "$KC_FALLBACK_BASE_URL" ] && echo on || echo off))"
+if [ -n "$OPENROUTER_API_KEY" ] || [ -n "$DEEPSEEK_API_KEY" ] || [ -n "$KC_FALLBACK_BASE_URL" ] || [ -n "$OPENCODE_API_KEY" ]; then
+  log_stage "writing OpenCode config (openrouter=$([ -n "$OPENROUTER_API_KEY" ] && echo on || echo off) deepseek=$([ -n "$DEEPSEEK_API_KEY" ] && echo on || echo off) zen=$([ -n "$OPENCODE_API_KEY" ] && echo on || echo off) fallback=$([ -n "$KC_FALLBACK_BASE_URL" ] && echo on || echo off))"
   mkdir -p $HOME/.config/opencode
   OPENROUTER_MODEL_DEFAULT="${KC_OPENROUTER_MODEL:-anthropic/claude-sonnet-4}"
   FALLBACK_MODEL_DEFAULT="${KC_FALLBACK_MODEL:-anthropic/claude-sonnet-4}"
@@ -263,6 +263,40 @@ if os.environ.get("KC_FALLBACK_BASE_URL"):
         # which makes the model say "there is no function to run X" and
         # hallucinate webfetch-style replies instead of using bash/edit.
         "models": {os.environ.get("KC_FALLBACK_MODEL", "anthropic/claude-sonnet-4"): {"tool_call": True}},
+    }
+# OpenCode Zen (issue #395) — OpenCode's hosted gateway of free coding models.
+# Unlike OpenRouter/DeepSeek it is NOT auto-discovered, so (like the fallback
+# above) we emit an explicit custom-provider stanza. The provider id
+# "opencode-zen" must match server.py's assistant_command / orchestrator, which
+# launch `opencode --model opencode-zen/<model>`. The gateway is OpenAI
+# chat/completions compatible, so @ai-sdk/openai-compatible is the right npm.
+if os.environ.get("OPENCODE_API_KEY"):
+    # Declare the whole free catalogue (default first) — the in-chat model
+    # switcher offers all of them, and OpenCode only advertises tools for
+    # models declared here with tool_call:true. Kept in sync with server.py's
+    # _OPENCODE_ZEN_FREE_MODELS. An operator override (KC_OPENCODE_ZEN_MODEL /
+    # comma-separated KC_OPENCODE_ZEN_MODELS) is folded in so a curated or
+    # paid Zen model still gets a declaration.
+    zen_ids = [
+        "deepseek-v4-flash-free", "big-pickle", "mimo-v2.5-free",
+        "laguna-s-2.1-free", "ling-3.0-flash-free", "north-mini-code-free",
+        "nemotron-3-ultra-free",
+    ]
+    for extra in [os.environ.get("KC_OPENCODE_ZEN_MODEL", "")] + \
+            os.environ.get("KC_OPENCODE_ZEN_MODELS", "").split(","):
+        extra = extra.strip()
+        if extra and extra not in zen_ids:
+            zen_ids.insert(0, extra)
+    provider["opencode-zen"] = {
+        "npm": "@ai-sdk/openai-compatible",
+        "name": "OpenCode Zen",
+        "options": {
+            "baseURL": os.environ.get("KC_OPENCODE_ZEN_BASE_URL", "https://opencode.ai/zen/v1"),
+            "apiKey": "{env:OPENCODE_API_KEY}",
+        },
+        # tool_call: true for the same reason as the fallback provider above —
+        # without it OpenCode won't advertise tools to the Zen model.
+        "models": {m: {"tool_call": True} for m in zen_ids},
     }
 if provider:
     cfg["provider"] = provider

--- a/charts/workspace/templates/assistant-secret.yaml
+++ b/charts/workspace/templates/assistant-secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.assistant.openrouter.apiKey .Values.assistant.deepseek.apiKey .Values.assistant.fallback.baseUrl }}
+{{- if or .Values.assistant.openrouter.apiKey .Values.assistant.deepseek.apiKey .Values.assistant.fallback.baseUrl (.Values.assistant.opencodeZen).apiKey }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,6 +11,9 @@ stringData:
   {{- end }}
   {{- if .Values.assistant.deepseek.apiKey }}
   deepseek-api-key: {{ .Values.assistant.deepseek.apiKey | quote }}
+  {{- end }}
+  {{- if (.Values.assistant.opencodeZen).apiKey }}
+  opencode-api-key: {{ .Values.assistant.opencodeZen.apiKey | quote }}
   {{- end }}
   {{- if .Values.assistant.fallback.baseUrl }}
   fallback-base-url: {{ .Values.assistant.fallback.baseUrl | quote }}

--- a/charts/workspace/templates/deployment.yaml
+++ b/charts/workspace/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         checksum/claude-config: {{ include (print $.Template.BasePath "/claude-configmap.yaml") . | sha256sum }}
         checksum/terminal-entry: {{ include (print $.Template.BasePath "/terminal-entry-configmap.yaml") . | sha256sum }}
         checksum/workspace-entrypoint: {{ include (print $.Template.BasePath "/workspace-entrypoint-configmap.yaml") . | sha256sum }}
-        {{- if or .Values.assistant.openrouter.apiKey .Values.assistant.deepseek.apiKey .Values.assistant.fallback.baseUrl }}
+        {{- if or .Values.assistant.openrouter.apiKey .Values.assistant.deepseek.apiKey .Values.assistant.fallback.baseUrl (.Values.assistant.opencodeZen).apiKey }}
         checksum/assistant-secret: {{ include (print $.Template.BasePath "/assistant-secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.github.app.appId }}
@@ -113,6 +113,21 @@ spec:
         - name: KC_DEEPSEEK_MODEL
           value: {{ .Values.assistant.deepseek.model | quote }}
         {{- end }}
+        {{- if or (.Values.assistant.opencodeZen).apiKey (.Values.assistant.opencodeZen).sharedSecretName }}
+        - name: OPENCODE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              {{- if .Values.assistant.opencodeZen.apiKey }}
+              name: assistant-secrets-{{ .Values.user.name }}
+              {{- else }}
+              # Shared free OpenCode Zen key for all trial workspaces — a
+              # per-user assistant.opencodeZen.apiKey (above) takes precedence.
+              name: {{ .Values.assistant.opencodeZen.sharedSecretName }}
+              {{- end }}
+              key: opencode-api-key
+        - name: KC_OPENCODE_ZEN_MODEL
+          value: {{ .Values.assistant.opencodeZen.model | quote }}
+        {{- end }}
         {{- if (.Values.assistant.antigravity).model }}
         - name: KC_ANTIGRAVITY_MODEL
           value: {{ .Values.assistant.antigravity.model | quote }}
@@ -194,10 +209,23 @@ spec:
         # user's existing CLI agents (claude/ante/opencode/…) plus the dashboard
         # MCP tools. These just flag the feature + its default agent/workdir;
         # provider/model/keys come from the existing assistant.* config above.
+        # Workspace-wide default assistant (issue #395). Governs the Hypervisor
+        # chat, the New Build picker, and sub-agent spawning. Only emitted when
+        # explicitly set, so vanilla deployments leave it unset and every
+        # consumer keeps its existing default (server → claude, orchestrator
+        # spawn → ante) — byte-for-byte unchanged. Set assistant.default to e.g.
+        # opencode-zen to provision a trial workspace on a free assistant.
+        {{- if (.Values.assistant).default }}
+        - name: KC_DEFAULT_ASSISTANT
+          value: {{ .Values.assistant.default | quote }}
+        {{- end }}
         - name: HYPERVISOR_ENABLED
           value: {{ (.Values.hypervisor).enabled | default true | quote }}
+        # Back-compat override for the Hypervisor chat only: when
+        # hypervisor.defaultAssistant is set it wins there; otherwise the
+        # Hypervisor inherits the workspace default (assistant.default).
         - name: HYPERVISOR_DEFAULT_ASSISTANT
-          value: {{ (.Values.hypervisor).defaultAssistant | default "claude" | quote }}
+          value: {{ (.Values.hypervisor).defaultAssistant | default ((.Values.assistant).default | default "claude") | quote }}
         - name: HYPERVISOR_WORKDIR
           value: {{ (.Values.hypervisor).workdir | default "/home/dev" | quote }}
         # AI CTO (#467) — the /cto page. `dig` (not `default`) so an explicit

--- a/charts/workspace/tests/deployment_test.yaml
+++ b/charts/workspace/tests/deployment_test.yaml
@@ -195,6 +195,25 @@ tests:
           any: true
           content:
             name: KC_FALLBACK_BASE_URL
+      # OpenCode Zen (#395) is off by default too.
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: OPENCODE_API_KEY
+      # The workspace-default knob is only emitted when opted in — vanilla leaves
+      # it unset so every consumer keeps its historical default.
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: KC_DEFAULT_ASSISTANT
+      # Vanilla Hypervisor default still resolves to claude.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HYPERVISOR_DEFAULT_ASSISTANT
+            value: "claude"
 
   - it: injects OpenRouter env when openrouter.apiKey is set
     template: templates/deployment.yaml
@@ -229,6 +248,78 @@ tests:
               secretKeyRef:
                 name: coder-shared-assistant
                 key: openrouter-api-key
+
+  # ── Workspace default assistant + OpenCode Zen (issue #395) ────────────────
+
+  - it: emits KC_DEFAULT_ASSISTANT and inherits it for the Hypervisor when assistant.default is set
+    template: templates/deployment.yaml
+    set:
+      assistant.default: opencode-zen
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_DEFAULT_ASSISTANT
+            value: "opencode-zen"
+      # hypervisor.defaultAssistant unset → the Hypervisor inherits the default.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HYPERVISOR_DEFAULT_ASSISTANT
+            value: "opencode-zen"
+
+  - it: hypervisor.defaultAssistant overrides the Hypervisor default only (back-compat)
+    template: templates/deployment.yaml
+    set:
+      assistant.default: opencode-zen
+      hypervisor.defaultAssistant: claude
+    asserts:
+      # New Build / task-create still defaults to the workspace default …
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_DEFAULT_ASSISTANT
+            value: "opencode-zen"
+      # … while the Hypervisor honours its explicit override.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HYPERVISOR_DEFAULT_ASSISTANT
+            value: "claude"
+
+  - it: injects OpenCode Zen env when opencodeZen.apiKey is set
+    template: templates/deployment.yaml
+    set:
+      assistant.opencodeZen.apiKey: sk-zen-test
+      assistant.opencodeZen.model: deepseek-v4-flash-free
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OPENCODE_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: assistant-secrets-testuser
+                key: opencode-api-key
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_OPENCODE_ZEN_MODEL
+            value: "deepseek-v4-flash-free"
+
+  - it: injects OpenCode Zen env from the shared secret when sharedSecretName is set (no per-user key)
+    template: templates/deployment.yaml
+    set:
+      assistant.opencodeZen.sharedSecretName: platform-zen-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OPENCODE_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: platform-zen-key
+                key: opencode-api-key
 
   - it: should NOT wire self-serve updates by default
     template: templates/deployment.yaml
@@ -391,6 +482,23 @@ tests:
       - equal:
           path: stringData["deepseek-api-key"]
           value: "sk-ds-test"
+
+  - it: renders assistant-secret with the opencode Zen key when opencodeZen.apiKey is set (#395)
+    template: templates/assistant-secret.yaml
+    set:
+      assistant.opencodeZen.apiKey: sk-zen-test
+    asserts:
+      - equal:
+          path: stringData["opencode-api-key"]
+          value: "sk-zen-test"
+
+  - it: does NOT render assistant-secret for a Zen shared secret (external Secret, not per-user)
+    template: templates/assistant-secret.yaml
+    set:
+      assistant.opencodeZen.sharedSecretName: platform-zen-key
+    asserts:
+      - hasDocuments:
+          count: 0
 
   - it: should invoke the entrypoint script as the container command
     template: templates/deployment.yaml

--- a/charts/workspace/tests/mcp_agent_orchestrator_test.py
+++ b/charts/workspace/tests/mcp_agent_orchestrator_test.py
@@ -98,6 +98,18 @@ class AssistantCommandTests(unittest.TestCase):
         self.assertIn('--model', cmd)
         self.assertIn('openrouter/', cmd)
 
+    def test_headless_opencode_zen_uses_zen_provider_prefix(self):
+        # Provider id must match the opencode.json stanza start.sh writes (#395).
+        cmd = orch._assistant_command('opencode-zen', 'hi', headless=True)
+        self.assertIn('opencode run', cmd)
+        self.assertIn('opencode-zen/deepseek-v4-flash-free', cmd)
+
+    def test_interactive_opencode_zen_is_bare_repl(self):
+        cmd = orch._assistant_command('opencode-zen', 'ignored', headless=False)
+        self.assertIn('opencode --model', cmd)
+        self.assertIn('opencode-zen/', cmd)
+        self.assertNotIn('run', cmd)
+
     def test_interactive_claude_is_bare_repl(self):
         cmd = orch._assistant_command('claude', 'ignored', headless=False)
         self.assertEqual(cmd, 'claude')
@@ -234,6 +246,31 @@ class SpawnGuardTests(unittest.TestCase):
     def test_nonexistent_workdir_falls_back(self):
         meta = self._spawn_workdir({'workdir': '/no/such/dir/xyz'})
         self.assertEqual(meta['workdir'], '/home/dev')
+
+    def _spawn_meta(self, args, env=None):
+        with mock.patch.object(orch.subprocess, 'run', side_effect=_tmux_alive), \
+             mock.patch.object(orch, '_count_live_agent_sessions', return_value=0), \
+             mock.patch.object(orch.threading, 'Thread'), \
+             mock.patch.dict(orch.os.environ, env or {}, clear=False):
+            res = orch._tool_spawn_agent({'prompt': 'go', **args})
+        meta_path = os.path.join(self.tmp, json.loads(res['content'][0]['text'])['task_id'], 'task.json')
+        with open(meta_path) as f:
+            return json.load(f)
+
+    def test_spawn_default_is_ante_when_no_workspace_default(self):
+        # Vanilla: KC_DEFAULT_ASSISTANT unset → historical 'ante' fallback.
+        orch.os.environ.pop('KC_DEFAULT_ASSISTANT', None)
+        meta = self._spawn_meta({})
+        self.assertEqual(meta['assistant'], 'ante')
+
+    def test_spawn_honours_workspace_default(self):
+        # Trial workspace: KC_DEFAULT_ASSISTANT set → sub-agents inherit it (#395).
+        meta = self._spawn_meta({}, env={'KC_DEFAULT_ASSISTANT': 'claude'})
+        self.assertEqual(meta['assistant'], 'claude')
+
+    def test_spawn_explicit_assistant_wins_over_workspace_default(self):
+        meta = self._spawn_meta({'assistant': 'ante'}, env={'KC_DEFAULT_ASSISTANT': 'claude'})
+        self.assertEqual(meta['assistant'], 'ante')
 
 
 class ReconcileTests(unittest.TestCase):

--- a/charts/workspace/tests/server_test.py
+++ b/charts/workspace/tests/server_test.py
@@ -15,8 +15,10 @@ Run with:    python3 -m unittest tests.server_test
 """
 
 import base64
+import contextlib
 import hmac
 import hashlib
+import io
 import json
 import os
 import sys
@@ -236,11 +238,17 @@ class AssistantSelectionTests(unittest.TestCase):
         # the resolver looks at.
         self._saved_env = {k: os.environ.pop(k) for k in (
             'OPENROUTER_API_KEY', 'KC_OPENROUTER_MODEL',
+            'DEEPSEEK_API_KEY', 'KC_DEEPSEEK_MODEL',
+            'OPENCODE_API_KEY', 'KC_OPENCODE_ZEN_MODEL', 'KC_OPENCODE_ZEN_MODELS',
             'KC_ANTIGRAVITY_MODEL',
             'KC_FALLBACK_BASE_URL', 'KC_FALLBACK_API_KEY', 'KC_FALLBACK_MODEL',
             'KC_FALLBACK_PROVIDER_ID', 'KC_FALLBACK_PROVIDER_NAME',
             'KC_LIBREFANG_AGENT',
         ) if k in os.environ}
+        # available_assistants()/resolve_assistant() read the module-level
+        # WORKSPACE_DEFAULT_ASSISTANT (fixed at import from KC_DEFAULT_ASSISTANT).
+        # Snapshot it so tests can patch the workspace default and restore.
+        self._saved_default = server.WORKSPACE_DEFAULT_ASSISTANT
 
     def tearDown(self):
         server.ClaudeTaskManager.TASKS_DIR = self._orig_tasks_dir
@@ -250,12 +258,14 @@ class AssistantSelectionTests(unittest.TestCase):
         # Restore env
         for k in ('OPENROUTER_API_KEY', 'KC_OPENROUTER_MODEL',
                   'DEEPSEEK_API_KEY', 'KC_DEEPSEEK_MODEL',
+                  'OPENCODE_API_KEY', 'KC_OPENCODE_ZEN_MODEL', 'KC_OPENCODE_ZEN_MODELS',
                   'KC_ANTIGRAVITY_MODEL',
                   'KC_FALLBACK_BASE_URL', 'KC_FALLBACK_API_KEY', 'KC_FALLBACK_MODEL',
                   'KC_FALLBACK_PROVIDER_ID', 'KC_FALLBACK_PROVIDER_NAME',
                   'KC_LIBREFANG_AGENT'):
             os.environ.pop(k, None)
         os.environ.update(self._saved_env)
+        server.WORKSPACE_DEFAULT_ASSISTANT = self._saved_default
 
     def test_default_lists_claude_and_ante(self):
         avail = server.ClaudeTaskManager.available_assistants()
@@ -365,6 +375,99 @@ class AssistantSelectionTests(unittest.TestCase):
         self.assertEqual(
             server.ClaudeTaskManager.resolve_assistant('opencode-openrouter'),
             'claude',
+        )
+
+    # ── Workspace default assistant (KC_DEFAULT_ASSISTANT, issue #395) ────────
+
+    def test_vanilla_default_is_claude_first(self):
+        # No KC_DEFAULT_ASSISTANT → claude is first and the only default, exactly
+        # as before the knob existed.
+        server.WORKSPACE_DEFAULT_ASSISTANT = 'claude'
+        avail = server.ClaudeTaskManager.available_assistants()
+        self.assertEqual(avail[0]['id'], 'claude')
+        self.assertTrue(avail[0]['default'])
+        self.assertEqual([a for a in avail if a.get('default')][0]['id'], 'claude')
+
+    def test_configured_default_flagged_and_sorted_first(self):
+        # An enabled non-claude default (ante is always enabled) becomes the sole
+        # default and sorts to the front; claude loses the flag.
+        server.WORKSPACE_DEFAULT_ASSISTANT = 'ante'
+        avail = server.ClaudeTaskManager.available_assistants()
+        self.assertEqual(avail[0]['id'], 'ante')
+        self.assertTrue(avail[0]['default'])
+        defaults = [a['id'] for a in avail if a.get('default')]
+        self.assertEqual(defaults, ['ante'])
+
+    def test_configured_default_not_enabled_warns_and_falls_back(self):
+        # opencode-zen configured but no OPENCODE_API_KEY → not enabled, so the
+        # default falls back to claude AND a loud warning is emitted (never a
+        # silent revert).
+        server.WORKSPACE_DEFAULT_ASSISTANT = 'opencode-zen'
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            avail = server.ClaudeTaskManager.available_assistants()
+        self.assertEqual(avail[0]['id'], 'claude')
+        self.assertTrue(avail[0]['default'])
+        self.assertIn('opencode-zen', buf.getvalue())
+        self.assertIn('not enabled', buf.getvalue())
+
+    def test_resolve_falls_back_to_workspace_default(self):
+        # Unknown/disabled request → the configured workspace default (ante is
+        # always enabled), not hardcoded claude.
+        server.WORKSPACE_DEFAULT_ASSISTANT = 'ante'
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            self.assertEqual(server.ClaudeTaskManager.resolve_assistant('garbage'), 'ante')
+        self.assertEqual(server.ClaudeTaskManager.resolve_assistant(None), 'ante')
+
+    # ── OpenCode Zen assistant (issue #395) ───────────────────────────────────
+
+    def test_zen_listed_when_env_set(self):
+        os.environ['OPENCODE_API_KEY'] = 'sk-zen-test'
+        match = [a for a in server.ClaudeTaskManager.available_assistants()
+                 if a['id'] == 'opencode-zen']
+        self.assertEqual(len(match), 1)
+        self.assertEqual(match[0]['label'], 'OpenCode Zen')
+        self.assertTrue(match[0].get('free'))
+        self.assertTrue(match[0].get('trainingDisclosure'))
+        # Built-in default model, overridable via KC_OPENCODE_ZEN_MODEL.
+        self.assertEqual(match[0]['model'], 'deepseek-v4-flash-free')
+
+    def test_zen_not_listed_without_key(self):
+        ids = [a['id'] for a in server.ClaudeTaskManager.available_assistants()]
+        self.assertNotIn('opencode-zen', ids)
+
+    def test_zen_is_default_when_configured_and_enabled(self):
+        os.environ['OPENCODE_API_KEY'] = 'sk-zen-test'
+        server.WORKSPACE_DEFAULT_ASSISTANT = 'opencode-zen'
+        avail = server.ClaudeTaskManager.available_assistants()
+        self.assertEqual(avail[0]['id'], 'opencode-zen')
+        self.assertTrue(avail[0]['default'])
+
+    def test_command_opencode_zen(self):
+        # Provider id prefix must match the opencode.json stanza start.sh writes.
+        # _shell_quote is a safety measure that no-ops on shell-safe strings
+        # (only `/` and `-`), so a plain model id passes through unquoted —
+        # matching the sibling opencode-deepseek command.
+        self.assertEqual(
+            server.ClaudeTaskManager.assistant_command('opencode-zen'),
+            'opencode --model opencode-zen/deepseek-v4-flash-free',
+        )
+        os.environ['KC_OPENCODE_ZEN_MODEL'] = 'big-pickle'
+        self.assertEqual(
+            server.ClaudeTaskManager.assistant_command('opencode-zen'),
+            'opencode --model opencode-zen/big-pickle',
+        )
+
+    def test_zen_models_list_default_first(self):
+        models = server.ClaudeTaskManager.available_models('opencode-zen')
+        self.assertEqual(models[0], 'deepseek-v4-flash-free')
+        self.assertIn('big-pickle', models)
+        # Env override fully replaces the built-in list.
+        os.environ['KC_OPENCODE_ZEN_MODELS'] = 'big-pickle, mimo-v2.5-free'
+        self.assertEqual(
+            server.ClaudeTaskManager.available_models('opencode-zen'),
+            ['big-pickle', 'mimo-v2.5-free'],
         )
 
     def test_command_per_assistant(self):

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -318,9 +318,12 @@ claude:
 # blocks below (and the user's own ~/.ante/settings.json etc.).
 hypervisor:
   enabled: true
-  # Which assistant a new chat thread uses by default. The user can switch it
+  # Back-compat override for the Hypervisor chat's default assistant only.
+  # Empty = inherit the workspace-wide default (assistant.default, issue #395),
+  # which is what you normally want. Set it here only to give the Hypervisor a
+  # different default than the New Build picker. The user can still switch it
   # per-thread from the tab's selector (any enabled assistant).
-  defaultAssistant: "claude"
+  defaultAssistant: ""
   # Working directory for hypervisor chat sessions.
   workdir: "/home/dev"
 
@@ -369,6 +372,15 @@ gateway:
 # Public-repo defaults leave both empty, so the dashboard ships with
 # Claude-only behavior.
 assistant:
+  # Workspace-wide default assistant (issue #395) → KC_DEFAULT_ASSISTANT.
+  # Governs BOTH the Hypervisor chat and the New Build / task-create picker, so
+  # an operator can provision a trial/demo workspace that defaults to a free
+  # assistant instead of Claude. Empty = "claude" (vanilla behaviour). Set it to
+  # an assistant id that is actually enabled below, e.g. "opencode-zen" together
+  # with a Zen key in opencodeZen.apiKey / opencodeZen.sharedSecretName — if the
+  # chosen default isn't enabled the server logs a warning and falls back to
+  # claude rather than silently mis-defaulting.
+  default: ""
   # OpenCode → OpenRouter (https://openrouter.ai)
   openrouter:
     apiKey: ""                            # OPENROUTER_API_KEY (per-user; takes precedence)
@@ -384,6 +396,21 @@ assistant:
   deepseek:
     apiKey: ""                            # DEEPSEEK_API_KEY
     model: "deepseek-chat"                # or "deepseek-reasoner"
+  # OpenCode → Zen (https://opencode.ai/zen) — OpenCode's hosted gateway of
+  # free coding models (~100 req/day, no credit card, one-time free signup key).
+  # This is the zero-cost path for trial/demo workspaces: set assistant.default
+  # to "opencode-zen" and provide a key here. Unlike OpenRouter/DeepSeek, Zen is
+  # NOT auto-discovered — start.sh writes an explicit opencode.json provider
+  # stanza when OPENCODE_API_KEY is set.
+  # NOTE: Zen's free models may use submitted data to improve the model — the
+  # dashboard surfaces that disclosure; don't send confidential data on them.
+  opencodeZen:
+    apiKey: ""                            # OPENCODE_API_KEY (per-user; takes precedence)
+    model: "deepseek-v4-flash-free"       # KC_OPENCODE_ZEN_MODEL (a Zen free-model id)
+    # Optional shared free Zen key so EVERY trial workspace gets Zen without a
+    # per-user key: create one Secret (key: opencode-api-key) in the namespace
+    # and name it here. A per-user apiKey above still wins. Empty by default.
+    sharedSecretName: ""
   # Antigravity (https://antigravity.google) — Google's terminal coding agent
   # (`agy`), pre-installed in the image. Auth is OAuth Google Sign-In, NOT an
   # API key: it appears as a dashboard assistant automatically, and each user

--- a/charts/workspace/web/src/api/hypervisor.ts
+++ b/charts/workspace/web/src/api/hypervisor.ts
@@ -17,6 +17,11 @@ export interface HypervisorAssistant {
   /** Selectable models for the in-chat model switcher (#308), default first.
    *  Empty/absent → the assistant offers no model choice (switcher hidden). */
   models?: string[];
+  /** Zero-cost provider (e.g. opencode-zen, #395) — drives the "free" marker. */
+  free?: boolean;
+  /** Provider may train on submitted data (Zen free models, #395) — drives the
+   *  in-chat data-training disclosure note. */
+  trainingDisclosure?: boolean;
 }
 
 /** One entry in the composer's `/` picker: an invocable skill or a custom

--- a/charts/workspace/web/src/api/tasks.ts
+++ b/charts/workspace/web/src/api/tasks.ts
@@ -107,6 +107,11 @@ export interface AssistantOption {
   label: string;
   description?: string;
   default?: boolean;
+  /** Zero-cost provider (e.g. opencode-zen) — drives the "free" picker marker. */
+  free?: boolean;
+  /** Provider may train on submitted data (Zen free models, #395) — drives the
+   *  data-training disclosure note near the picker. */
+  trainingDisclosure?: boolean;
 }
 
 export interface WorkdirOption {

--- a/charts/workspace/web/src/components/Onboarding.tsx
+++ b/charts/workspace/web/src/components/Onboarding.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { useFocusTrap } from '../hooks/useFocusTrap';
 import { githubStatus, setGitConfig, generateSshKey, type GitHubStatus } from '../api/github';
+import { getHypervisorConfig } from '../api/hypervisor';
 import { navigate } from '../store/router';
 import { justOnboarded } from '../store/onboarding';
 import { pushToast } from '../store/ui';
@@ -21,6 +22,11 @@ export function Onboarding() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [busy, setBusy] = useState(false);
+  // The workspace's default assistant, so the copy names the agent the user
+  // will actually meet (Claude by default, e.g. "OpenCode Zen" on a trial
+  // workspace, #395). isClaude drives the free-provider upgrade-path note.
+  const [assistantLabel, setAssistantLabel] = useState('Claude Code');
+  const [assistantIsClaude, setAssistantIsClaude] = useState(true);
   const ref = useRef<HTMLDivElement | null>(null);
   useFocusTrap(show, ref);
 
@@ -38,13 +44,32 @@ export function Onboarding() {
       .catch(() => {
         // Workspace not reachable — skip onboarding silently.
       });
-    // A brand-new tester with no Claude credential must be guided to connect
-    // before the first-win build (#494) — open onboarding for that alone, even
-    // when git/SSH are already configured by the workspace.
-    void refreshClaudeReady().then((r) => {
-      if (r === false) setShow(true);
-    });
+    // Tailor onboarding to the configured default assistant (#395). A trial
+    // workspace on a free assistant (e.g. opencode-zen) needs no Claude login,
+    // so we must NOT force the Claude-connect flow there — only Claude-default
+    // workspaces get the "connect before your first build" gate (#494).
+    getHypervisorConfig()
+      .then((cfg) => {
+        const def = (cfg.assistants ?? []).find((a) => a.id === cfg.defaultAssistant);
+        const isClaude = (cfg.defaultAssistant || 'claude') === 'claude';
+        setAssistantLabel(def?.label || 'Claude Code');
+        setAssistantIsClaude(isClaude);
+        if (isClaude) {
+          void refreshClaudeReady().then((r) => {
+            if (r === false) setShow(true);
+          });
+        }
+      })
+      .catch(() => {
+        // Config unreachable — assume the Claude default and keep #494 behaviour.
+        void refreshClaudeReady().then((r) => {
+          if (r === false) setShow(true);
+        });
+      });
   }, []);
+
+  // Short verb-phrase name ("Claude" reads better than "Claude Code" mid-sentence).
+  const assistantName = assistantIsClaude ? 'Claude' : assistantLabel;
 
   function dismiss() {
     localStorage.setItem(DONE_KEY, 'true');
@@ -93,8 +118,9 @@ export function Onboarding() {
   // and #484/#485 auto-surface the preview.
   function enterCto() {
     // Backstop: never route a keyless user into the CTO with no way to build —
-    // send them to the connect step instead (#494).
-    if (claudeReady.value === false) {
+    // send them to the connect step instead (#494). Only applies to Claude-
+    // default workspaces; a free-assistant trial (#395) can build without a key.
+    if (assistantIsClaude && claudeReady.value === false) {
       setStep(4);
       return;
     }
@@ -110,7 +136,14 @@ export function Onboarding() {
       title: 'Welcome to kube-coder',
       body: (
         <>
-          <p>This workspace runs Claude Code in tmux sessions and tracks memory, triggers, and files in one place.</p>
+          <p>This workspace runs {assistantLabel} in tmux sessions and tracks memory, triggers, and files in one place.</p>
+          {!assistantIsClaude && (
+            <p class="muted">
+              It's set up on a free assistant so you can try everything right away —
+              no login needed. Want Claude or another provider? Add your own key
+              anytime in Settings → Provider keys.
+            </p>
+          )}
           <p class="muted">A few short steps. You can skip any of them.</p>
         </>
       ),
@@ -120,7 +153,7 @@ export function Onboarding() {
       title: 'Set your git identity',
       body: (
         <>
-          <p class="muted">Used for commits Claude makes on your behalf.</p>
+          <p class="muted">Used for commits {assistantName} makes on your behalf.</p>
           <div class="ob-row">
             <label class="ob-field">
               <span>Name</span>
@@ -145,7 +178,7 @@ export function Onboarding() {
       body: (
         <>
           <p class="muted">
-            Connect your personal GitHub so Claude can push to your repos and use your
+            Connect your personal GitHub so {assistantName} can push to your repos and use your
             identity. Sign in with your browser — no terminal needed.
           </p>
           <GithubConnect compact onConnected={() => setStep(3)} />
@@ -179,23 +212,33 @@ export function Onboarding() {
       ),
     },
     {
-      title: 'Connect Claude',
+      title: assistantIsClaude ? 'Connect Claude' : `You're all set on ${assistantLabel}`,
       body: (
         <>
-          <p class="muted">
-            kube-coder builds with Claude, so it needs your account before it can
-            do anything. Sign in with your Claude subscription (recommended — no
-            key to hunt for) or paste an API key.
-          </p>
-          <ClaudeCredentialSetup ready={claudeReady.value} onConnected={onClaudeConnected} />
+          {assistantIsClaude ? (
+            <>
+              <p class="muted">
+                kube-coder builds with Claude, so it needs your account before it can
+                do anything. Sign in with your Claude subscription (recommended — no
+                key to hunt for) or paste an API key.
+              </p>
+              <ClaudeCredentialSetup ready={claudeReady.value} onConnected={onClaudeConnected} />
+            </>
+          ) : (
+            <p class="muted">
+              This workspace runs on {assistantLabel} — a free assistant — so there's
+              nothing to log into. You can start building right away. Prefer Claude or
+              another provider? Add your own key anytime in Settings → Provider keys.
+            </p>
+          )}
         </>
       ),
       action: (
         <>
           <Button variant="ghost" onClick={() => setStep(5)}>
-            {claudeReady.value ? 'Continue' : 'Skip for now'}
+            {assistantIsClaude && !claudeReady.value ? 'Skip for now' : 'Continue'}
           </Button>
-          {!claudeReady.value && (
+          {assistantIsClaude && !claudeReady.value && (
             <span class="ob-note muted">Connect above to continue</span>
           )}
         </>
@@ -210,7 +253,7 @@ export function Onboarding() {
             one sentence what you'd like to build and it starts right away, with a
             live preview surfacing in the chat as it goes.
           </p>
-          {claudeReady.value === false && (
+          {assistantIsClaude && claudeReady.value === false && (
             <p class="ob-warn">
               Claude isn't connected yet — connect it first so your first build doesn't fail.
             </p>
@@ -218,7 +261,7 @@ export function Onboarding() {
         </>
       ),
       action:
-        claudeReady.value === false ? (
+        assistantIsClaude && claudeReady.value === false ? (
           <>
             <Button variant="ghost" onClick={dismiss}>Finish later</Button>
             <Button variant="primary" onClick={() => setStep(4)}>

--- a/charts/workspace/web/src/routes/hypervisor/hypervisor.css
+++ b/charts/workspace/web/src/routes/hypervisor/hypervisor.css
@@ -153,6 +153,17 @@
   padding: 0 var(--size-3) var(--size-3);
 }
 
+/* Data-training disclosure for free Zen models (#395). */
+.hv-agent-disclosure {
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--warning, #b8860b) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warning, #b8860b) 30%, var(--border));
+  border-radius: var(--radius-sm);
+  padding: 6px 8px;
+}
+
 .hv-agent-select {
   width: 100%;
   padding: 7px 9px;

--- a/charts/workspace/web/src/routes/hypervisor/index.tsx
+++ b/charts/workspace/web/src/routes/hypervisor/index.tsx
@@ -17,6 +17,7 @@ import {
   selectedModel,
   selectedWorkdir,
   assistantModels,
+  assistantNeedsDisclosure,
   setSelectedAssistant,
   setActiveThreadModel,
   initHypervisor,
@@ -306,10 +307,17 @@ export function HypervisorRoute() {
             {(cfg?.assistants ?? []).map((a) => (
               <option key={a.id} value={a.id}>
                 {a.label}
+                {a.free ? ' · free' : ''}
                 {a.model ? ` · ${a.model}` : ''}
               </option>
             ))}
           </select>
+          {assistantNeedsDisclosure(effectiveAssistant) && (
+            <span class="hv-agent-disclosure" role="note">
+              ⚠️ Free models may use your prompts + code for training — avoid
+              confidential data. Add your own key in Settings → Provider keys.
+            </span>
+          )}
         </label>
 
         {/* Where a NEW chat starts (#345). The backend has always accepted a

--- a/charts/workspace/web/src/routes/tasks/NewTaskForm.tsx
+++ b/charts/workspace/web/src/routes/tasks/NewTaskForm.tsx
@@ -80,6 +80,13 @@ export function NewTaskForm({ onClose }: { onClose: () => void }) {
     setName(randomBuildName());
   }
 
+  // The currently-selected assistant (for the free/training-disclosure note),
+  // and the label to show as the default before the list resolves. Falls back
+  // to 'claude' only when the server list hasn't loaded yet.
+  const selectedAssistant = assistants.find((a) => a.id === assistant);
+  const defaultAssistantLabel =
+    (assistants.find((a) => a.default) ?? assistants[0])?.label ?? 'claude';
+
   return (
     <form class="ntf" onSubmit={onSubmit}>
       <label class="ntf-field">
@@ -140,10 +147,11 @@ export function NewTaskForm({ onClose }: { onClose: () => void }) {
             value={assistant}
             onChange={(e) => setAssistant((e.target as HTMLSelectElement).value)}
           >
-            {assistants.length === 0 && <option value="">claude (default)</option>}
+            {assistants.length === 0 && <option value="">{defaultAssistantLabel} (default)</option>}
             {assistants.map((a) => (
               <option key={a.id} value={a.id}>
                 {a.label || a.id}
+                {a.free ? ' · free' : ''}
                 {a.default ? ' · default' : ''}
               </option>
             ))}
@@ -152,9 +160,17 @@ export function NewTaskForm({ onClose }: { onClose: () => void }) {
       </div>
 
       <p class="ntf-note muted">
-        You'll be dropped straight into a live <strong>{assistant || 'claude'}</strong> terminal —
+        You'll be dropped straight into a live <strong>{assistant || defaultAssistantLabel}</strong> terminal —
         type your first prompt there.
       </p>
+
+      {selectedAssistant?.trainingDisclosure && (
+        <p class="ntf-note ntf-disclosure" role="note">
+          ⚠️ Free {selectedAssistant.label} models may use your prompts and code to
+          improve the model — avoid sending confidential data. Add your own key in
+          Settings → Provider keys to switch providers.
+        </p>
+      )}
 
       {error && (
         <p class="ntf-error" role="alert">

--- a/charts/workspace/web/src/routes/tasks/TaskList.tsx
+++ b/charts/workspace/web/src/routes/tasks/TaskList.tsx
@@ -157,7 +157,7 @@ export function TaskList() {
             description={
               taskFilter.value
                 ? 'Try clearing the filter or searching for something else.'
-                : 'Create a task to run Claude Code in a tmux session.'
+                : 'Create a task to run a coding agent in a tmux session.'
             }
           />
         )

--- a/charts/workspace/web/src/routes/tasks/new-task.css
+++ b/charts/workspace/web/src/routes/tasks/new-task.css
@@ -57,6 +57,14 @@
 }
 .ntf-note strong { color: var(--accent); font-weight: 600; }
 
+/* Data-training disclosure for free Zen models (#395) — warmer than the plain
+   note so it reads as an advisory, not a neutral hint. */
+.ntf-disclosure {
+  background: color-mix(in srgb, var(--warning, #b8860b) 10%, var(--surface));
+  border-color: color-mix(in srgb, var(--warning, #b8860b) 35%, var(--border));
+  color: var(--text);
+}
+
 .ntf-error {
   margin: 0;
   padding: 10px 12px;

--- a/charts/workspace/web/src/store/hypervisor.test.ts
+++ b/charts/workspace/web/src/store/hypervisor.test.ts
@@ -39,6 +39,8 @@ import {
   selectedModel,
   selectedWorkdir,
   assistantModels,
+  assistantInfo,
+  assistantNeedsDisclosure,
   setSelectedAssistant,
   setActiveThreadModel,
   sameTranscript,
@@ -155,6 +157,31 @@ describe('model switcher (#308)', () => {
     setThreadModel.mockRejectedValue(new Error('boom'));
     await setActiveThreadModel('opus');
     expect(threads.value.find((t) => t.id === 'a')?.model).toBe('default');
+  });
+});
+
+describe('free-provider disclosure (#395)', () => {
+  beforeEach(() => {
+    config.value = cfg({
+      defaultAssistant: 'opencode-zen',
+      assistants: [
+        { id: 'claude', label: 'Claude Code', models: ['default', 'opus'] },
+        { id: 'opencode-zen', label: 'OpenCode Zen', models: [], free: true, trainingDisclosure: true },
+      ],
+    });
+  });
+
+  it('assistantInfo returns the config entry (with its flags) or undefined', () => {
+    expect(assistantInfo('opencode-zen')?.free).toBe(true);
+    expect(assistantInfo('claude')?.trainingDisclosure).toBeUndefined();
+    expect(assistantInfo('nope')).toBeUndefined();
+    expect(assistantInfo(null)).toBeUndefined();
+  });
+
+  it('assistantNeedsDisclosure is true only for a training-disclosure assistant', () => {
+    expect(assistantNeedsDisclosure('opencode-zen')).toBe(true);
+    expect(assistantNeedsDisclosure('claude')).toBe(false);
+    expect(assistantNeedsDisclosure(null)).toBe(false);
   });
 });
 

--- a/charts/workspace/web/src/store/hypervisor.ts
+++ b/charts/workspace/web/src/store/hypervisor.ts
@@ -94,6 +94,18 @@ export function assistantModels(assistantId: string | null | undefined): string[
   return a?.models ?? [];
 }
 
+/** The full config entry for an assistant id (or undefined). */
+export function assistantInfo(assistantId: string | null | undefined) {
+  if (!assistantId) return undefined;
+  return (config.value?.assistants ?? []).find((x) => x.id === assistantId);
+}
+
+/** True when the assistant is a free provider that may train on submitted data
+ *  (Zen free models, #395) — drives the in-chat disclosure note. */
+export function assistantNeedsDisclosure(assistantId: string | null | undefined): boolean {
+  return !!assistantInfo(assistantId)?.trainingDisclosure;
+}
+
 /** Pick the assistant a new chat will use, resetting the model to that
  *  assistant's default so the switcher never shows an off-list model. */
 export function setSelectedAssistant(assistantId: string): void {

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -27,6 +27,15 @@ This document describes all environment variables used by kube-coder components.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ANTHROPIC_API_KEY` | - | **Required for Claude.** Anthropic API key for Claude Code access. |
+| `KC_DEFAULT_ASSISTANT` | `claude` | **Workspace-wide default assistant.** Governs both the Hypervisor chat and the New Build / task-create picker, and sub-agent spawning. Empty/unset → `claude` (vanilla behaviour). Set to an enabled assistant id (e.g. `opencode-zen`) to provision a trial/demo workspace on a free assistant. If the chosen default isn't enabled the server logs a warning and falls back to claude. `hypervisor.defaultAssistant` (`HYPERVISOR_DEFAULT_ASSISTANT`) remains a back-compat override for the Hypervisor chat only. |
+
+#### OpenCode Zen Integration (free)
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENCODE_API_KEY` | - | OpenCode Zen API key ([opencode.ai/zen](https://opencode.ai/zen)). Lights up the **OpenCode Zen** assistant — a hosted gateway of free coding models (~100 req/day, no credit card). ⚠️ Zen's free models may use submitted data to improve the model; the dashboard surfaces this disclosure. |
+| `KC_OPENCODE_ZEN_MODEL` | `deepseek-v4-flash-free` | Zen free-model id (e.g. `big-pickle`, `mimo-v2.5-free`). |
+| `KC_OPENCODE_ZEN_MODELS` | - | Comma-separated override of the in-chat model switcher's Zen list (default first). |
+| `KC_OPENCODE_ZEN_BASE_URL` | `https://opencode.ai/zen/v1` | Zen gateway base URL (OpenAI chat/completions compatible). |
 
 #### OpenRouter Integration
 | Variable | Default | Description |

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -1165,6 +1165,11 @@ export interface Assistant {
   label?: string;
   default?: boolean;
   model?: string;
+  /** Zero-cost provider (e.g. opencode-zen, #395) — drives the "free" marker. */
+  free?: boolean;
+  /** Provider may train on submitted data (Zen free models) — drives the
+   *  data-training disclosure note near the picker. */
+  trainingDisclosure?: boolean;
 }
 
 export async function listAssistants(): Promise<Assistant[]> {

--- a/mobile/src/api/types.ts
+++ b/mobile/src/api/types.ts
@@ -287,6 +287,11 @@ export interface HypervisorAssistant {
   /** Selectable in-chat models (#308/#361), default first. Empty ⇒ no picker
    *  for this assistant (mirrors the web `assistantModels`). */
   models?: string[];
+  /** Zero-cost provider (e.g. opencode-zen, #395) — drives the "free" marker. */
+  free?: boolean;
+  /** Provider may train on submitted data (Zen free models) — drives the
+   *  data-training disclosure note. */
+  trainingDisclosure?: boolean;
 }
 
 export interface HypervisorConfig {

--- a/mobile/src/screens/NewTaskScreen.tsx
+++ b/mobile/src/screens/NewTaskScreen.tsx
@@ -1,4 +1,5 @@
-/** Create a new Claude task. */
+/** Create a new coding-agent task (assistant chosen in the picker; defaults to
+ *  the workspace default assistant). */
 import { useNavigation } from '@react-navigation/native';
 import { useHeaderHeight } from '@react-navigation/elements';
 import React, { useEffect, useState } from 'react';
@@ -48,6 +49,9 @@ export default function NewTaskScreen() {
       .catch(() => {/* keep the fallback list */});
   }, []);
 
+  const selected = assistants.find((a) => a.id === assistant);
+  const assistantName = selected?.label || 'the assistant';
+
   async function submit() {
     if (!prompt.trim()) return;
     setBusy(true);
@@ -80,7 +84,7 @@ export default function NewTaskScreen() {
           <TextInput
             value={prompt}
             onChangeText={setPrompt}
-            placeholder="Describe the task for Claude…"
+            placeholder={`Describe the task for ${assistantName}…`}
             placeholderTextColor={colors.textFaint}
             style={styles.prompt}
             multiline
@@ -104,10 +108,19 @@ export default function NewTaskScreen() {
                 onPress={() => setAssistant(a.id)}
                 style={[styles.chip, assistant === a.id && styles.chipActive]}
               >
-                <Text style={[styles.chipText, assistant === a.id && styles.chipTextActive]}>{a.label || a.id}</Text>
+                <Text style={[styles.chipText, assistant === a.id && styles.chipTextActive]}>
+                  {a.label || a.id}{a.free ? ' · free' : ''}
+                </Text>
               </Pressable>
             ))}
           </View>
+
+          {selected?.trainingDisclosure ? (
+            <Text style={styles.disclosure} accessibilityRole="text">
+              ⚠️ Free {selected.label} models may use your prompts and code to improve the
+              model — avoid confidential data. Add your own key in Settings → Provider keys.
+            </Text>
+          ) : null}
 
           {error ? (
             <Text style={styles.error} accessibilityRole="alert">
@@ -167,4 +180,10 @@ const styles = StyleSheet.create({
   chipText: { color: colors.textMuted, fontSize: font.size.sm, fontWeight: '500' },
   chipTextActive: { color: colors.accent, fontWeight: '700' },
   error: { color: colors.danger, fontSize: font.size.sm, marginTop: space.xl, lineHeight: 19 },
+  disclosure: {
+    color: colors.textMuted,
+    fontSize: font.size.sm,
+    marginTop: space.lg,
+    lineHeight: 19,
+  },
 });


### PR DESCRIPTION
## What & why

Every kube-coder workspace defaults to **Claude Code**, so a brand-new trial/demo user has to log into (and pay for) Claude before they can experience anything. This adds an **opt-in, per-workspace knob** that lets an operator provision a workspace which defaults to a **genuinely free assistant — OpenCode Zen** — across Hypervisor chat, New Build, and sub-agent spawning, with **no Claude login anywhere in onboarding**.

It is deliberately **not** a change to the global default: with the knob unset, vanilla deployments stay Claude-first, byte-for-byte. Closes #395.

## The partial knob that already existed (and why it wasn't enough)

`hypervisor.defaultAssistant` only governed the Hypervisor chat — the New Build / task-create path still hardcoded claude. `available_assistants()` always flagged `claude` as the sole `default:true`, and `resolve_assistant()` **silently reverted** to claude when the requested assistant wasn't enabled, so setting a default that lacked its key just quietly did nothing. There was also **no zero-credential assistant** to point it at.

## Changes

### Server (`server.py`)
- New `assistant.default` value → `KC_DEFAULT_ASSISTANT`, governing **both** the Hypervisor chat and the New Build / task-create picker. `hypervisor.defaultAssistant` is kept as a back-compat override for the Hypervisor chat only (empty ⇒ inherit the workspace default).
- `available_assistants()` no longer hardcodes claude as the default — it flags the configured default and sorts it first (`_apply_default_flag`). `resolve_assistant()` now falls back to the configured default (then claude) and **logs loudly** when a configured default isn't enabled, instead of silently reverting.
- New `opencode-zen` assistant, gated on `OPENCODE_API_KEY`, with the free-model catalogue wired into the in-chat model switcher and a `trainingDisclosure` flag.

### Chart
- `assistant.opencodeZen.{apiKey,model,sharedSecretName}` — a per-user key **or** a shared platform key (mirrors the existing `assistant.openrouter.sharedSecretName` mechanism), plumbed through `deployment.yaml` + `assistant-secret.yaml` (Secret key `opencode-api-key`).
- `KC_DEFAULT_ASSISTANT` is only emitted when opted in, so vanilla pods leave it unset and every consumer keeps its historical default.
- `start.sh` writes an explicit `opencode.json` provider stanza for Zen — unlike OpenRouter/DeepSeek it is **not** an auto-discovered provider — declaring the free models with `tool_call` enabled so tools actually advertise.

### Frontend (dashboard + mobile)
- Assistant pickers, onboarding copy, and the terminal note now read the configured default instead of hardcoding `claude`.
- Onboarding is assistant-aware: on a free-default workspace it **skips the Claude-connect step**, keeps the "add your own Anthropic/OpenRouter key later in Settings → Provider keys" upgrade path, and never forces the Claude-credential gate.
- The free-model **data-training disclosure** ("Zen free models may use your prompts/code to improve the model") is surfaced next to the picker on both surfaces, as the OpenCode Zen terms require.

### Orchestrator (`mcp_agent_orchestrator.py`)
- The duplicated assistant registry / command builder / spawn default are kept in sync: sub-agent spawning honours the workspace default when no assistant is specified; `opencode-zen` added; the pre-existing `codex` enum gap fixed.

## Backend flow

`assistant.default` → `KC_DEFAULT_ASSISTANT` (pod env) → `WORKSPACE_DEFAULT_ASSISTANT` in `server.py` → drives `available_assistants()` (`default:true` + ordering) and `resolve_assistant()` (task-create + Hypervisor). `GET /api/hypervisor/config` and `/api/claude/assistants` return the reworked list unchanged in shape, so the SPA and mobile pickers need no client-side selection logic — they already pick whichever entry carries `default:true`. For Zen, `OPENCODE_API_KEY` gates the dashboard option **and** signals `start.sh` to render the `opencode-zen` provider block, which `assistant_command()` / the orchestrator target via `opencode --model opencode-zen/<model>`.

## Testing

- **Server** (`tests/server_test.py`): the knob's default flagging/ordering, the warn-and-fall-back path when a configured default isn't enabled, Zen gating on `OPENCODE_API_KEY`, the Zen command, and the model list.
- **Orchestrator** (`tests/mcp_agent_orchestrator_test.py`): the Zen headless/interactive commands and `spawn_agent` honouring the workspace default (and vanilla still defaulting to `ante`).
- **Chart** (`tests/deployment_test.yaml`): `KC_DEFAULT_ASSISTANT` emission + Hypervisor inheritance, the `hypervisor.defaultAssistant` back-compat override, Zen env from a per-user key and from a shared secret, the per-user Secret key, and that vanilla emits none of it.
- **Frontend**: SPA + mobile typecheck, vitest (incl. new disclosure-helper tests), and a clean production build.
- **Live provider check**: verified the OpenCode Zen gateway end-to-end — key auth, that all wired free-model ids exist, and a real chat completion on the default `deepseek-v4-flash-free` model.

## Notes for reviewers
- Default Zen model is `deepseek-v4-flash-free` (a reasoning model, strong at coding), overridable via `KC_OPENCODE_ZEN_MODEL` / the in-chat switcher.
- Zen free models may be used for training — that's disclosed in the UI; the docs and values comments call it out too.
