### PR TITLE
fix(walkie-talkie): stop phantom THINKING… and cross-thread bleed (#474)

### DIFF
--- a/charts/workspace/adapters/internal.py
+++ b/charts/workspace/adapters/internal.py
@@ -69,7 +69,8 @@ class LoopbackAdapter:
         item = self.transcript.add(
             'out', msg.text, wire=wire, quick_replies=list(msg.quick_replies),
             kind=kind, meta={'provider': self.wire_provider.name,
-                             'seq': msg.seq})
+                             'seq': msg.seq,
+                             'thread_id': msg.thread_id})
         if self.publish is not None:
             try:
                 self.publish('gateway.preview', {'seq': item['seq']})

--- a/charts/workspace/gateway.py
+++ b/charts/workspace/gateway.py
@@ -132,6 +132,11 @@ class OutboundMessage:
     template: Optional[str] = None  # logical template name for out-of-window
     template_args: Dict[str, Any] = field(default_factory=dict)
     seq: int = 0                    # per-conversation monotonic outbound sequence
+    # Hypervisor thread this reply belongs to, '' when there isn't one (system
+    # notices — not-linked, expired token, workspace list, …). The internal
+    # loopback preview (#474) uses this to scope the Walkie-Talkie view to the
+    # live conversation and never bleed a stale/foreign thread's reply into it.
+    thread_id: str = ''
 
 
 @dataclass
@@ -1004,7 +1009,7 @@ class ConversationGateway:
             self._send(adapter, identity, 'Could not deliver your message.')
             return InboundResult(status=500, action='error', thread_id=thread_id)
         if self.send_ack:
-            self._send(adapter, identity, self.ACK_TEXT)
+            self._send(adapter, identity, self.ACK_TEXT, thread_id=thread_id)
         return InboundResult(status=200, action='dispatched', thread_id=thread_id)
 
     # ── turn completion (the single hook) ─────────────────────────────────────
@@ -1073,7 +1078,7 @@ class ConversationGateway:
             key = f'{thread_id}:{since}:final:{i}'
             if not self.sequencer.dedupe(identity, key):
                 continue
-            self._send(adapter, identity, chunk, quick_replies=quick)
+            self._send(adapter, identity, chunk, quick_replies=quick, thread_id=thread_id)
 
     def _deliver_template(self, adapter, identity, thread_id, since) -> None:
         # The provider id comes from the live adapter (issue #328 gives every
@@ -1093,6 +1098,7 @@ class ConversationGateway:
             template='task_complete',
             template_args={'title': 'your task'},
             seq=self.sequencer.next(identity),
+            thread_id=thread_id,
         )
         try:
             adapter.outbound(msg)
@@ -1117,11 +1123,13 @@ class ConversationGateway:
             else 'No workspaces linked.'
 
     def _send(self, adapter: ChannelAdapter, identity: str, text: str,
-              quick_replies: Optional[List[str]] = None) -> DeliveryResult:
+              quick_replies: Optional[List[str]] = None,
+              thread_id: str = '') -> DeliveryResult:
         msg = OutboundMessage(
             channel_identity=identity, text=text,
             quick_replies=quick_replies or [],
             seq=self.sequencer.next(identity),
+            thread_id=thread_id,
         )
         try:
             result = adapter.outbound(msg)
@@ -1268,6 +1276,21 @@ class PreviewTranscript:
     def cursor(self) -> int:
         with self._lock:
             return self._seq
+
+    def set_meta(self, seq: int, patch: Dict[str, Any]) -> bool:
+        """Merge `patch` into the meta dict of the entry with this seq. Used to
+        back-fill the inbound user bubble's thread_id once dispatch resolves it
+        — the bubble is added BEFORE dispatch so it appears instantly, but the
+        thread (possibly a brand-new one, on a `new chat`) isn't known until
+        `handle_inbound` returns (#474). Returns False if the entry aged out of
+        the bounded deque (harmless — the caller's rendering degrades to
+        showing it as an always-visible untagged notice)."""
+        with self._lock:
+            for item in self._items:
+                if item['seq'] == seq:
+                    item['meta'] = {**item['meta'], **patch}
+                    return True
+            return False
 
     def clear(self) -> None:
         with self._lock:

--- a/charts/workspace/hypervisor_session.py
+++ b/charts/workspace/hypervisor_session.py
@@ -1620,6 +1620,19 @@ class HypervisorSession:
         m = self.read_meta() or {}
         return m.get('status', 'idle')
 
+    @staticmethod
+    def is_turn_live(thread_id: str) -> bool:
+        """True only when a turn is ACTUALLY running right now, per the live
+        in-process _RUNNING registry — never trusts meta['status'], which can
+        get stuck at 'running' forever after a crash mid-turn (#462), because
+        nothing reconciles it outside of server startup. Mirrors the same
+        signal WatcherManager._default_deliver already relies on, for the
+        identical reason (see its docstring below). Consumers that must not
+        be pinned indefinitely by a stale thread.json — e.g. the Walkie-Talkie
+        preview's busy flag (#474) — should call this instead of status()."""
+        with _RUNLOCK:
+            return bool(_RUNNING.get(thread_id))
+
     def set_title(self, title: str) -> Optional[Dict[str, Any]]:
         """Rename the chat. Marks the title as user-set (`title_custom`) so the
         first-message auto-title in send() never clobbers a manual rename.

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -9400,8 +9400,11 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         thread_id = binding.get('default_thread_id') if binding else None
         busy = False
         if thread_id and _HYPERVISOR_AVAILABLE:
-            s = HypervisorSession.get(thread_id)
-            busy = bool(s and s.status() == 'running')
+            # Live in-process signal only (#474) — never trust thread.json's
+            # persisted status, which can be stuck at 'running' forever after a
+            # mid-turn crash (#462) and would otherwise pin the Walkie-Talkie
+            # orb on THINKING… indefinitely.
+            busy = HypervisorSession.is_turn_live(thread_id)
         return thread_id, busy
 
     def handle_gateway_internal_inbound(self):
@@ -9427,11 +9430,16 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             return
         # Record the user's own bubble + the inbound "wire" (the provider webhook
         # shape WhatsApp would POST) so the UI can show both sides of the wire.
-        preview.transcript.add('in', display, kind='message', wire={
+        # Added BEFORE dispatch so it appears instantly, but the thread it
+        # belongs to isn't known yet (a `new chat` mints a brand-new one inside
+        # handle_inbound) — back-fill it from the result below (#474).
+        item = preview.transcript.add('in', display, kind='message', wire={
             'inbound': {'from': INTERNAL_IDENTITY, 'text': text, 'button': button}})
         raw = RawRequest(method='POST', form={
             'from': INTERNAL_IDENTITY, 'text': text, 'button': button})
         result = gw.handle_inbound(loop, raw)
+        if result.thread_id:
+            preview.transcript.set_meta(item['seq'], {'thread_id': result.thread_id})
         self.send_json({'ok': True, 'action': result.action,
                         'cursor': preview.transcript.cursor()})
 

--- a/charts/workspace/tests/gateway_preview_test.py
+++ b/charts/workspace/tests/gateway_preview_test.py
@@ -59,6 +59,29 @@ class PreviewTranscriptTest(unittest.TestCase):
         item = t.add('in', 'b')
         self.assertGreater(item['seq'], 1)
 
+    # ── thread tagging (issue #474) ────────────────────────────────────────
+
+    def test_meta_round_trips_thread_id(self):
+        t = gw.PreviewTranscript()
+        item = t.add('in', 'x', meta={'thread_id': 't1'})
+        self.assertEqual(item['meta']['thread_id'], 't1')
+        self.assertEqual(t.since(0)[0]['meta']['thread_id'], 't1')
+
+    def test_set_meta_patches_existing_entry(self):
+        # Mirrors the real back-fill: the inbound bubble is added BEFORE
+        # dispatch (so it appears instantly), and its thread isn't known
+        # until dispatch resolves it — possibly a brand-new thread on a
+        # rotation.
+        t = gw.PreviewTranscript()
+        item = t.add('in', 'x')
+        self.assertEqual(item['meta'], {})
+        self.assertTrue(t.set_meta(item['seq'], {'thread_id': 't1'}))
+        self.assertEqual(t.since(0)[0]['meta']['thread_id'], 't1')
+
+    def test_set_meta_unknown_seq_returns_false(self):
+        t = gw.PreviewTranscript()
+        self.assertFalse(t.set_meta(999, {'thread_id': 't1'}))
+
 
 class GatewayPreviewProbeTest(unittest.TestCase):
     def test_probe_only_forces_internal_identity_when_simulating(self):
@@ -110,6 +133,20 @@ class LoopbackAdapterTest(unittest.TestCase):
         item = self.t.since(0)[-1]
         self.assertEqual(item['kind'], 'template')
         self.assertEqual(item['wire']['payloads'][0]['type'], 'template')
+
+    def test_outbound_records_thread_id(self):
+        self.a.outbound(gw.OutboundMessage(
+            channel_identity='internal:local', text='hi', thread_id='t1'))
+        item = self.t.since(0)[-1]
+        self.assertEqual(item['meta']['thread_id'], 't1')
+
+    def test_outbound_thread_id_defaults_empty(self):
+        # Genuinely thread-less system replies (not-linked, workspace list, …)
+        # stay untagged — the client treats an empty thread_id as "always
+        # visible", not "belongs to nothing".
+        self.a.outbound(gw.OutboundMessage(channel_identity='internal:local', text='hi'))
+        item = self.t.since(0)[-1]
+        self.assertEqual(item['meta']['thread_id'], '')
 
 
 class LoopbackIntegrationTest(unittest.TestCase):
@@ -178,6 +215,49 @@ class LoopbackIntegrationTest(unittest.TestCase):
     def test_unknown_before_link_gets_not_linked(self):
         res = self._inbound('hi there')
         self.assertEqual(res.action, 'not_linked')
+
+    def test_two_threads_get_independently_tagged_replies(self):
+        """Each turn's reply is tagged with the thread that actually produced
+        it, not whatever the binding's CURRENT default happens to be — this
+        is the exact backend contract the Walkie-Talkie client's per-thread
+        scoping relies on to never bleed a foreign/rotated conversation into
+        the live view (issue #474). This harness drives the CORE gateway
+        directly (bypassing the HTTP handler that writes the 'in' bubble —
+        see test_inbound_backfills_the_post_rotation_thread_id for that half),
+        so only the 'out' replies are checked here."""
+        self._link()
+        res1 = self._inbound('first turn')
+        self.assertEqual(res1.action, 'dispatched')
+        thread_a = res1.thread_id
+        self.assertIsNotNone(thread_a)
+        self.assertTrue(_wait(lambda: any(
+            m['direction'] == 'out' and m['text'] == 'first turn'
+            for m in self.preview.transcript.since(0))),
+            'first turn never echoed back')
+
+        # Force the NEXT inbound to start a brand-new thread — exactly what a
+        # genuine rotation (new chat / the old thread vanishing out from
+        # under the binding) produces from the gateway's point of view: the
+        # binding no longer points at thread_a.
+        self.reg.set_default_thread(gw.INTERNAL_IDENTITY, 'default', None)
+        res2 = self._inbound('second turn')
+        self.assertEqual(res2.action, 'dispatched')
+        thread_b = res2.thread_id
+        self.assertIsNotNone(thread_b)
+        self.assertNotEqual(thread_a, thread_b)
+        self.assertTrue(_wait(lambda: any(
+            m['direction'] == 'out' and m['text'] == 'second turn'
+            for m in self.preview.transcript.since(0))),
+            'second turn never echoed back')
+
+        entries = self.preview.transcript.since(0)
+        out_a = next(m for m in entries if m['direction'] == 'out' and m['text'] == 'first turn')
+        out_b = next(m for m in entries if m['direction'] == 'out' and m['text'] == 'second turn')
+        self.assertEqual(out_a['meta'].get('thread_id'), thread_a)
+        self.assertEqual(out_b['meta'].get('thread_id'), thread_b)
+        # Late-delivery bleed check: thread_a's reply is NEVER attributed to
+        # thread_b, even though thread_b is now the live/default thread.
+        self.assertNotEqual(out_a['meta'].get('thread_id'), thread_b)
 
 
 class PreviewRouteTest(unittest.TestCase):
@@ -264,6 +344,54 @@ class PreviewRouteTest(unittest.TestCase):
         self.assertFalse(self.reg.is_linked(gw.INTERNAL_IDENTITY))
         self.assertEqual(self.preview.transcript.since(0), [])
 
+    def test_inbound_backfills_the_post_rotation_thread_id(self):
+        """The user's own bubble is written BEFORE dispatch (so it appears
+        instantly) but must end up tagged with whatever thread dispatch
+        actually resolved — including a brand-new one minted mid-request
+        (issue #474)."""
+        rotating = _RotatingClient()
+        self.gateway.client_factory = lambda b: rotating
+        self.reg.bind(gw.INTERNAL_IDENTITY, 'internal', workspace='default',
+                     workspace_host='h', token='tok')
+        h = self._handler()
+        h.read_json_body.return_value = {'text': 'ping'}
+        server.BrowserHandler.handle_gateway_internal_inbound(h)
+        obj = self.last()[0]
+        self.assertTrue(obj['ok'])
+        entries = self.preview.transcript.since(0)
+        in_entry = next(m for m in entries if m['text'] == 'ping')
+        self.assertEqual(in_entry['meta'].get('thread_id'), 'rot-1')
+
+    def test_busy_ignores_stale_running_status_with_no_live_turn(self):
+        """A crash mid-turn can leave thread.json stuck at 'running' forever
+        (#462) — _gw_internal_status must not trust it, or the Walkie-Talkie
+        orb would be pinned on THINKING… indefinitely (#474)."""
+        import hypervisor_session as hs_mod
+        tmp = tempfile.mkdtemp()
+        orig_dir = hs_mod.HYPERVISOR_DIR
+        hs_mod.HYPERVISOR_DIR = tmp
+        try:
+            session = hs_mod.HypervisorSession.create(
+                assistant='echo', workdir=tmp, cli_cmd='cat')
+            meta = session.read_meta()
+            meta['status'] = 'running'
+            session._write_meta(meta)
+            # Confirm the OLD/naive signal really would say "running" — the
+            # bug this guards against.
+            self.assertEqual(session.status(), 'running')
+
+            self.reg.bind(gw.INTERNAL_IDENTITY, 'internal', workspace='default',
+                         workspace_host='h', token='tok',
+                         default_thread_id=session.id)
+            h = self._handler()
+            h.path = '/api/gateway/internal/transcript?since=0'
+            server.BrowserHandler.handle_gateway_internal_transcript(h)
+            obj = self.last()[0]
+            self.assertEqual(obj['thread_id'], session.id)
+            self.assertFalse(obj['busy'])
+        finally:
+            hs_mod.HYPERVISOR_DIR = orig_dir
+
 
 class _NoopClient:
     def create_thread(self):
@@ -280,6 +408,23 @@ class _NoopClient:
         return True
     def exists(self, tid):
         return True
+
+
+class _RotatingClient(_NoopClient):
+    """Like _NoopClient, but create_thread() mints a fresh id each call and
+    exists() only recognizes ids this client actually minted — lets a route
+    test express real thread rotation, which the constant-id _NoopClient
+    cannot (issue #474)."""
+    def __init__(self):
+        self._minted = set()
+        self._n = 0
+    def create_thread(self):
+        self._n += 1
+        tid = f'rot-{self._n}'
+        self._minted.add(tid)
+        return tid
+    def exists(self, tid):
+        return tid in self._minted
 
 
 if __name__ == '__main__':

--- a/charts/workspace/tests/hypervisor_session_test.py
+++ b/charts/workspace/tests/hypervisor_session_test.py
@@ -465,6 +465,52 @@ class ReconcileStaleRunningTest(unittest.TestCase):
         self.assertEqual(s.read_meta()['updated_at'], before)
 
 
+class IsTurnLiveTest(unittest.TestCase):
+    """is_turn_live() must key busy-ness off the live in-process _RUNNING
+    registry, never meta['status'] — the same stale-'running' state #462
+    leaves behind forever, and which would otherwise pin any consumer
+    (e.g. the Walkie-Talkie preview's busy flag, #474) on THINKING…
+    indefinitely."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._orig = hs.HYPERVISOR_DIR
+        hs.HYPERVISOR_DIR = self.tmp
+
+    def tearDown(self):
+        hs.HYPERVISOR_DIR = self._orig
+
+    def test_false_when_status_stuck_running_but_not_actually_running(self):
+        s = hs.HypervisorSession.create(
+            assistant='claude', workdir='/home/dev', cli_cmd='claude')
+        meta = s.read_meta()
+        meta['status'] = 'running'
+        s._write_meta(meta)
+        # The OLD/naive signal really would say "running" — confirms this is
+        # exercising the exact bug being guarded against.
+        self.assertEqual(s.status(), 'running')
+        self.assertFalse(hs.HypervisorSession.is_turn_live(s.id))
+
+    def test_true_when_actually_running(self):
+        s = hs.HypervisorSession.create(
+            assistant='claude', workdir='/home/dev', cli_cmd='claude')
+        with hs._RUNLOCK:
+            hs._RUNNING[s.id] = True
+        try:
+            self.assertTrue(hs.HypervisorSession.is_turn_live(s.id))
+        finally:
+            with hs._RUNLOCK:
+                hs._RUNNING.pop(s.id, None)
+
+    def test_false_when_thread_does_not_exist(self):
+        self.assertFalse(hs.HypervisorSession.is_turn_live('no-such-thread'))
+
+    def test_false_when_idle(self):
+        s = hs.HypervisorSession.create(
+            assistant='claude', workdir='/home/dev', cli_cmd='claude')
+        self.assertFalse(hs.HypervisorSession.is_turn_live(s.id))
+
+
 class FallbackAdapterTest(unittest.TestCase):
     def test_strips_ansi_and_emits_message(self):
         a = hs.FallbackAdapter()

--- a/charts/workspace/web/src/routes/hypervisor/WalkieTalkie.busy.test.tsx
+++ b/charts/workspace/web/src/routes/hypervisor/WalkieTalkie.busy.test.tsx
@@ -1,0 +1,324 @@
+import { render, waitFor } from '@testing-library/preact';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import type { PreviewMessage, PreviewState } from '../../api/gatewayPreview';
+
+// Turn ownership + thread scoping (issue #474): the orb must only show
+// THINKING… for a turn THIS surface sent — never for activity elsewhere on
+// the bound thread (Hypervisor chat, WhatsApp, a stuck/crashed session) —
+// and the live card/narration must only ever reflect the CURRENT thread,
+// never bleed in a foreign or since-rotated conversation.
+
+let stateNow: PreviewState;
+let pushEvent: ((ev: { type: string }) => void) | null = null;
+const sendPreviewMock = vi.fn(() => Promise.resolve({ ok: true, action: 'sent', cursor: 0 }));
+
+vi.mock('../../api/gatewayPreview', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../api/gatewayPreview')>()),
+  fetchPreview: vi.fn(() => Promise.resolve(stateNow)),
+  sendPreview: (...args: unknown[]) => sendPreviewMock(...(args as [])),
+  previewControl: vi.fn(() => Promise.resolve({ ok: true, linked: true })),
+}));
+vi.mock('../../api/events', () => ({
+  subscribeEvents: vi.fn((handler: (ev: { type: string }) => void) => {
+    pushEvent = handler;
+    return () => {
+      pushEvent = null;
+    };
+  }),
+}));
+
+import { WalkieTalkie, messageThreadId, inLiveThread } from './WalkieTalkie';
+import { setSpeakReplies } from './voice';
+
+// Minimal SpeechRecognition stand-in — same shape as WalkieTalkie.stop.test.tsx.
+interface FakeRec {
+  lang: string;
+  interimResults: boolean;
+  continuous: boolean;
+  onresult: ((e: unknown) => void) | null;
+  onerror: ((e: { error: string }) => void) | null;
+  onend: (() => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+let lastRec: FakeRec | null = null;
+
+class FakeRecognition implements FakeRec {
+  lang = '';
+  interimResults = false;
+  continuous = false;
+  onresult: ((e: unknown) => void) | null = null;
+  onerror: ((e: { error: string }) => void) | null = null;
+  onend: (() => void) | null = null;
+  start() {
+    lastRec = this;
+  }
+  stop() {
+    this.onend?.();
+  }
+  abort() {
+    this.onend?.();
+  }
+}
+
+function msg(partial: Partial<PreviewMessage> & { seq: number }): PreviewMessage {
+  return {
+    ts: 0,
+    direction: 'in',
+    kind: 'message',
+    text: '',
+    quick_replies: [],
+    wire: null,
+    meta: {},
+    ...partial,
+  };
+}
+
+function makeState(messages: PreviewMessage[]): PreviewState {
+  return {
+    available: true,
+    messages,
+    cursor: messages.length ? messages[messages.length - 1].seq : 0,
+    linked: true,
+    simulate_out_of_window: false,
+    provider: 'internal',
+    identity: 'internal:local',
+    busy: false,
+    thread_id: 't-test',
+  };
+}
+
+const win = window as unknown as Record<string, unknown>;
+
+describe('WalkieTalkie turn ownership + thread scoping (issue #474)', () => {
+  beforeEach(() => {
+    lastRec = null;
+    sendPreviewMock.mockClear();
+    stateNow = makeState([]);
+    win.SpeechRecognition = FakeRecognition;
+    win.SpeechSynthesisUtterance = class {
+      text: string;
+      constructor(text: string) {
+        this.text = text;
+      }
+    };
+    win.speechSynthesis = { speaking: false, pending: false, speak: vi.fn(), cancel: vi.fn() };
+  });
+  afterEach(() => {
+    setSpeakReplies(false);
+    delete win.SpeechRecognition;
+    delete win.speechSynthesis;
+    delete win.SpeechSynthesisUtterance;
+  });
+
+  async function findOrb(container: Element): Promise<HTMLButtonElement> {
+    return waitFor(() => {
+      const el = container.querySelector('button.wt-orb') as HTMLButtonElement;
+      expect(el).not.toBeNull();
+      expect(el.disabled).toBe(false);
+      return el;
+    });
+  }
+
+  function phaseOf(container: Element): string | null {
+    return container.querySelector('.wt')!.getAttribute('data-phase');
+  }
+
+  function chipLabel(container: Element): string | null {
+    return container.querySelector('.wt-chip-label')?.textContent ?? null;
+  }
+
+  it('never shows THINKING… on mount when the server reports busy but this surface sent nothing', async () => {
+    stateNow = { ...makeState([]), busy: true };
+    const { container } = render(<WalkieTalkie />);
+    await waitFor(() => {
+      expect(phaseOf(container)).toBe('idle');
+    });
+    expect(chipLabel(container)).not.toBe('THINKING…');
+    expect(chipLabel(container)).toBe('LINKED');
+  });
+
+  it('activity on the bound thread from elsewhere does not spin the orb', async () => {
+    stateNow = makeState([]);
+    const { container } = render(<WalkieTalkie />);
+    await findOrb(container);
+    expect(phaseOf(container)).toBe('idle');
+
+    // Some other surface (Hypervisor chat / WhatsApp / a stuck session) makes
+    // the bound thread busy — this client never sent anything.
+    stateNow = { ...makeState([]), busy: true };
+    pushEvent?.({ type: 'gateway.preview' });
+
+    // Give the effect a tick, then assert it never moved off idle.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(phaseOf(container)).toBe('idle');
+  });
+
+  it('shows THINKING… for a turn this surface sent, and settles once its reply lands', async () => {
+    const { container } = render(<WalkieTalkie />);
+    const orb = await findOrb(container);
+
+    orb.click(); // idle -> listening
+    lastRec!.onresult?.({
+      resultIndex: 0,
+      results: [{ isFinal: true, 0: { transcript: 'what is running' }, length: 1 }],
+    });
+    lastRec!.stop(); // -> onend -> captured -> sendVoice()
+
+    await waitFor(() => {
+      expect(sendPreviewMock).toHaveBeenCalledWith('what is running');
+    });
+    // dispatch('sent') moves sending -> thinking as soon as the send resolves.
+    await waitFor(() => expect(phaseOf(container)).toBe('thinking'));
+
+    // Server confirms busy while we own the turn — stays thinking.
+    stateNow = {
+      ...makeState([msg({ seq: 1, direction: 'in', text: 'what is running' })]),
+      busy: true,
+    };
+    pushEvent?.({ type: 'gateway.preview' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(phaseOf(container)).toBe('thinking');
+
+    // The reply lands — settles to idle.
+    stateNow = makeState([
+      msg({ seq: 1, direction: 'in', text: 'what is running' }),
+      msg({ seq: 2, direction: 'out', text: 'Nothing is running.' }),
+    ]);
+    pushEvent?.({ type: 'gateway.preview' });
+    await waitFor(() => expect(phaseOf(container)).toBe('idle'));
+  });
+
+  it('does not re-enter THINKING… when busy resurfaces after our own turn already resolved (watermark is consumed, not sticky)', async () => {
+    const { container } = render(<WalkieTalkie />);
+    const orb = await findOrb(container);
+
+    orb.click();
+    lastRec!.onresult?.({
+      resultIndex: 0,
+      results: [{ isFinal: true, 0: { transcript: 'ping' }, length: 1 }],
+    });
+    lastRec!.stop();
+    await waitFor(() => expect(sendPreviewMock).toHaveBeenCalled());
+
+    stateNow = makeState([
+      msg({ seq: 1, direction: 'in', text: 'ping' }),
+      msg({ seq: 2, direction: 'out', text: 'pong' }),
+    ]);
+    pushEvent?.({ type: 'gateway.preview' });
+    await waitFor(() => expect(phaseOf(container)).toBe('idle'));
+
+    // Someone/something else makes the thread busy again, with a NEW message
+    // this client never sent — proves the update below is a change, not the
+    // stale idle from before.
+    stateNow = {
+      ...makeState([
+        msg({ seq: 1, direction: 'in', text: 'ping' }),
+        msg({ seq: 2, direction: 'out', text: 'pong' }),
+        msg({ seq: 3, direction: 'in', text: 'someone else typed this' }),
+      ]),
+      busy: true,
+    };
+    pushEvent?.({ type: 'gateway.preview' });
+    await waitFor(() => {
+      expect(container.querySelector('.wt-you')?.textContent).toContain('someone else typed this');
+    });
+    expect(phaseOf(container)).toBe('idle');
+  });
+
+  it('defensively settles a turn that never resolves (max-thinking watchdog)', async () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = render(<WalkieTalkie />);
+      const orb = await findOrb(container);
+      orb.click();
+      lastRec!.onresult?.({
+        resultIndex: 0,
+        results: [{ isFinal: true, 0: { transcript: 'never answered' }, length: 1 }],
+      });
+      lastRec!.stop();
+      await vi.waitFor(() => expect(sendPreviewMock).toHaveBeenCalled());
+      await vi.waitFor(() => expect(phaseOf(container)).toBe('thinking'));
+
+      await vi.advanceTimersByTimeAsync(120_001);
+      expect(phaseOf(container)).toBe('idle');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('scopes the live card + "you" bubble to the current thread and segments History with a divider', async () => {
+    stateNow = {
+      ...makeState([
+        msg({ seq: 1, direction: 'in', text: 'first turn', meta: { thread_id: 'thread-a' } }),
+        msg({ seq: 2, direction: 'out', text: 'first reply', meta: { thread_id: 'thread-a' } }),
+        msg({ seq: 3, direction: 'in', text: 'second turn', meta: { thread_id: 'thread-b' } }),
+        msg({ seq: 4, direction: 'out', text: 'second reply', meta: { thread_id: 'thread-b' } }),
+      ]),
+      thread_id: 'thread-b',
+    };
+    const { container } = render(<WalkieTalkie />);
+
+    await waitFor(() => {
+      expect(container.querySelector('.wt-card-text')?.textContent).toBe('second reply');
+    });
+    // thread-a's reply never bleeds into the live card.
+    expect(container.querySelector('.wt-card-text')?.textContent).not.toBe('first reply');
+    expect(container.querySelector('.wt-you')?.textContent).toContain('second turn');
+
+    const toggle = container.querySelector('.wt-history-toggle') as HTMLButtonElement;
+    expect(toggle).not.toBeNull();
+    toggle.click();
+
+    await waitFor(() => {
+      expect(container.querySelector('.wt-thread-divider')).not.toBeNull();
+    });
+    expect(container.textContent).toContain('first turn');
+  });
+
+  it('a foreign thread reply does not get narrated aloud', async () => {
+    setSpeakReplies(true);
+    stateNow = {
+      ...makeState([msg({ seq: 1, direction: 'in', text: 'hi', meta: { thread_id: 'thread-a' } })]),
+      thread_id: 'thread-a',
+    };
+    const { container } = render(<WalkieTalkie />);
+    await findOrb(container);
+
+    // A reply lands for a DIFFERENT thread than the one live on screen.
+    stateNow = {
+      ...makeState([
+        msg({ seq: 1, direction: 'in', text: 'hi', meta: { thread_id: 'thread-a' } }),
+        msg({ seq: 2, direction: 'out', text: 'foreign reply', meta: { thread_id: 'thread-b' } }),
+      ]),
+      thread_id: 'thread-a',
+    };
+    pushEvent?.({ type: 'gateway.preview' });
+
+    // Give the narration effect a tick — it must never have spoken/entered
+    // 'speaking' for a thread that isn't live.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(phaseOf(container)).not.toBe('speaking');
+    expect(container.querySelector('.wt-card-text')?.textContent ?? '').not.toBe('foreign reply');
+  });
+});
+
+describe('messageThreadId / inLiveThread (issue #474)', () => {
+  it('reads a real thread id out of meta, or null when absent/blank', () => {
+    expect(messageThreadId(msg({ seq: 1, meta: { thread_id: 't1' } }))).toBe('t1');
+    expect(messageThreadId(msg({ seq: 2, meta: {} }))).toBeNull();
+    expect(messageThreadId(msg({ seq: 3, meta: { thread_id: '' } }))).toBeNull();
+    expect(messageThreadId(msg({ seq: 4, meta: { thread_id: 42 } }))).toBeNull();
+  });
+
+  it('an untagged message is always in the live thread; a tagged one only matches its own', () => {
+    const untagged = msg({ seq: 1, meta: {} });
+    const tagged = msg({ seq: 2, meta: { thread_id: 't1' } });
+    expect(inLiveThread(untagged, 't1')).toBe(true);
+    expect(inLiveThread(untagged, null)).toBe(true);
+    expect(inLiveThread(tagged, 't1')).toBe(true);
+    expect(inLiveThread(tagged, 't2')).toBe(false);
+    expect(inLiveThread(tagged, null)).toBe(false);
+  });
+});

--- a/charts/workspace/web/src/routes/hypervisor/WalkieTalkie.tsx
+++ b/charts/workspace/web/src/routes/hypervisor/WalkieTalkie.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { isErrorResponse } from '../../api/client';
 import { subscribeEvents } from '../../api/events';
@@ -67,6 +68,29 @@ interface AudioTap {
   raf: number;
 }
 
+/** Thread this transcript entry belongs to, or null when it's an untagged
+ *  system notice (not-linked, expired token, workspace list, "nothing is
+ *  running", …) that should always render regardless of which thread is
+ *  currently live — those aren't conversational content tied to one chat. */
+export function messageThreadId(m: PreviewMessage): string | null {
+  const t = m.meta?.thread_id;
+  return typeof t === 'string' && t ? t : null;
+}
+
+/** True when `m` belongs to the live thread, or carries no thread at all
+ *  (untagged notices are always visible). Scopes the live card + narration
+ *  to the current conversation so a foreign or since-rotated thread's reply
+ *  never bleeds in or gets spoken aloud (issue #474). */
+export function inLiveThread(m: PreviewMessage, liveThreadId: string | null): boolean {
+  const t = messageThreadId(m);
+  return t === null || t === liveThreadId;
+}
+
+// Defensive settle (#474): even a turn THIS surface started can't pin the
+// orb on THINKING… forever — if nothing ever resolves it, give up rather
+// than trust the server's busy flag indefinitely.
+const MAX_THINKING_MS = 120_000;
+
 export function WalkieTalkie() {
   const [state, setState] = useState<PreviewState | null>(null);
   const [draft, setDraft] = useState('');
@@ -110,6 +134,19 @@ export function WalkieTalkie() {
   // Newest outbound seq already narrated; null until the first snapshot lands
   // (history is never narrated — only messages that arrive while watching).
   const narratedSeq = useRef<number | null>(null);
+  // Turn ownership (#474): set the moment THIS surface sends a message,
+  // cleared once its answer lands (or the watchdog below fires). The gateway
+  // busy flag only drives the orb into THINKING… while this is set — never
+  // on its own — so activity elsewhere on the bound thread (Hypervisor chat,
+  // WhatsApp, cron, a stuck session) can never spin the orb for a query the
+  // user never asked here.
+  const pendingTurn = useRef<{ sinceCursor: number } | null>(null);
+  const busyWatchdog = useRef<number | null>(null);
+  // The thread this surface is currently showing. undefined until the first
+  // snapshot; tracked so a rotation (new chat / silent re-bind) can reset the
+  // narration + turn-ownership bookkeeping instead of bleeding into the new
+  // conversation.
+  const liveThreadRef = useRef<string | null | undefined>(undefined);
 
   const speakOn = speakReplies.value;
   const handsFreeOn = handsFree.value;
@@ -158,11 +195,27 @@ export function WalkieTalkie() {
     }
   }, [state?.linked, state?.available]);
 
+  // Reset narration + turn-ownership bookkeeping whenever the LIVE thread
+  // changes (new chat / a silent re-bind because the old thread vanished,
+  // #474). Without this, an old thread's still-arriving reply keeps the
+  // narration watermark advancing and a pending turn can be "answered" by a
+  // conversation that isn't even the one on screen anymore.
+  useEffect(() => {
+    const tid = state?.thread_id ?? null;
+    if (liveThreadRef.current === tid) return;
+    liveThreadRef.current = tid;
+    narratedSeq.current = null;
+    pendingTurn.current = null;
+    clearBusyWatchdog();
+    if (phaseRef.current === 'thinking') dispatch('quiet');
+  }, [state?.thread_id]);
+
   // ── narration: speak replies that arrive while watching ───────────────────
   useEffect(() => {
     if (!state) return;
+    const liveId = state.thread_id;
     const outs = state.messages.filter(
-      (m) => m.direction === 'out' && m.kind !== 'notice',
+      (m) => m.direction === 'out' && m.kind !== 'notice' && inLiveThread(m, liveId),
     );
     if (narratedSeq.current === null) {
       // First snapshot — everything on screen is history.
@@ -182,12 +235,30 @@ export function WalkieTalkie() {
     watchSpeech();
   }, [state?.cursor, speakOn]);
 
-  // Mirror the gateway busy flag into the phase machine, and settle `thinking`
-  // back to idle once the turn is over and nothing is being narrated. (Runs
-  // after the narration effect, so a just-queued reply keeps the floor.)
+  // Mirror the gateway busy flag into the phase machine — but ONLY while this
+  // surface owns the turn currently in flight (#474). Server `busy` is
+  // confirmation, never the trigger: activity elsewhere on the bound thread
+  // (Hypervisor chat, WhatsApp, cron, a stuck/crashed session) can no longer
+  // spin the orb, and the chip/orb label are both derived from `phase` below
+  // so they can't disagree with each other either. Runs after the narration
+  // effect, so a just-queued reply keeps the floor.
   useEffect(() => {
     if (!state) return;
-    if (state.busy) {
+    // Resolve our own pending turn the moment its answer lands, regardless of
+    // what `state.busy` currently says — this consumes the "I sent
+    // something" watermark so a later, unrelated busy can't re-trigger it.
+    if (pendingTurn.current) {
+      const watermark = pendingTurn.current.sinceCursor;
+      const answered = state.messages.some(
+        (m) => m.direction === 'out' && m.kind !== 'notice' && m.seq > watermark,
+      );
+      if (answered) {
+        pendingTurn.current = null;
+        clearBusyWatchdog();
+      }
+    }
+    const owned = pendingTurn.current !== null;
+    if (state.busy && owned) {
       dispatch('busy');
       return;
     }
@@ -205,6 +276,23 @@ export function WalkieTalkie() {
     } catch {
       return false;
     }
+  }
+
+  function clearBusyWatchdog() {
+    if (busyWatchdog.current !== null) {
+      clearTimeout(busyWatchdog.current);
+      busyWatchdog.current = null;
+    }
+  }
+
+  /** Arm the defensive-settle timer for a turn this surface just sent. */
+  function armBusyWatchdog() {
+    clearBusyWatchdog();
+    busyWatchdog.current = window.setTimeout(() => {
+      pendingTurn.current = null;
+      busyWatchdog.current = null;
+      if (phaseRef.current === 'thinking') dispatch('quiet');
+    }, MAX_THINKING_MS);
   }
 
   /** Poll the TTS engine until it goes quiet, then settle the phase. */
@@ -460,11 +548,17 @@ export function WalkieTalkie() {
 
   async function sendVoice(text: string) {
     try {
-      await sendPreview(text);
+      const res = await sendPreview(text);
+      // Own this turn (#474) — the busy-mirror effect only shows THINKING…
+      // while we're waiting on OUR OWN reply, using this as the watermark.
+      pendingTurn.current = { sinceCursor: res.cursor };
+      armBusyWatchdog();
       dispatch('sent');
       await refresh();
     } catch {
       setVoiceHint('Send failed — check the gateway and try again');
+      pendingTurn.current = null;
+      clearBusyWatchdog();
       dispatch('cancel');
     }
   }
@@ -476,9 +570,16 @@ export function WalkieTalkie() {
     stopSpeaking();
     setBusySend(true);
     try {
-      await sendPreview(button ? '' : text, button);
+      const res = await sendPreview(button ? '' : text, button);
+      // Own this turn (#474) — see sendVoice above for why.
+      pendingTurn.current = { sinceCursor: res.cursor };
+      armBusyWatchdog();
       if (!button) setDraft('');
       await refresh();
+    } catch (err) {
+      pendingTurn.current = null;
+      clearBusyWatchdog();
+      throw err;
     } finally {
       setBusySend(false);
     }
@@ -503,6 +604,8 @@ export function WalkieTalkie() {
     setVoiceHint('');
     dispatch('cancel');
     narratedSeq.current = null;
+    pendingTurn.current = null;
+    clearBusyWatchdog();
     await previewControl('reset');
     await refresh();
   }
@@ -519,6 +622,7 @@ export function WalkieTalkie() {
       stopSpeaking();
       closeTap();
       if (speechTimer.current) clearInterval(speechTimer.current);
+      clearBusyWatchdog();
     },
     [],
   );
@@ -537,26 +641,39 @@ export function WalkieTalkie() {
 
   // ── derived view state ────────────────────────────────────────────────────
   const linked = !!state?.linked;
-  const busy = !!state?.busy;
-  const signal = !state?.available ? 'off' : busy ? 'busy' : linked ? 'live' : 'down';
+  // THINKING… is derived from `phase`, not straight from state.busy (#474) —
+  // phase is already gated on turn ownership above, so the chip and the orb
+  // (whose own label also comes from `phase` via orbCopy below) can never
+  // disagree about whether this surface is actually waiting on something.
+  const thinking = phase === 'thinking';
+  const signal = !state?.available ? 'off' : thinking ? 'busy' : linked ? 'live' : 'down';
   const signalLabel = !state?.available
     ? 'OFFLINE'
-    : busy
+    : thinking
       ? 'THINKING…'
       : linked
         ? 'LINKED'
         : 'NOT LINKED';
 
+  // Thread scoping (#474): the live card/lastIn/"you" bubble only ever show
+  // the CURRENT conversation — untagged system notices (not-linked, workspace
+  // list, …) still always show. The History panel keeps every prior
+  // conversation (segmented by a divider below) so nothing is lost, it's just
+  // never mixed into the live exchange.
+  const liveThreadId = state?.thread_id ?? null;
   const messages = state?.messages ?? [];
-  const conversational = messages.filter((m) => m.kind !== 'notice');
-  const lastOutIdx = conversational.reduce(
+  const allConversational = messages.filter((m) => m.kind !== 'notice');
+  const liveConversational = allConversational.filter((m) => inLiveThread(m, liveThreadId));
+  const lastOutIdx = liveConversational.reduce(
     (acc, m, i) => (m.direction === 'out' ? i : acc),
     -1,
   );
-  const card: PreviewMessage | null = lastOutIdx >= 0 ? conversational[lastOutIdx] : null;
+  const card: PreviewMessage | null = lastOutIdx >= 0 ? liveConversational[lastOutIdx] : null;
   // The user's line this reply answers — the newest inbound before/after the card.
-  const lastIn = [...conversational].reverse().find((m) => m.direction === 'in') ?? null;
-  const history = conversational.slice(0, Math.max(lastOutIdx, 0));
+  const lastIn = [...liveConversational].reverse().find((m) => m.direction === 'in') ?? null;
+  // Everything before the live card, across every thread — the divider below
+  // marks where one conversation ends and the next begins.
+  const history = card ? allConversational.filter((m) => m.seq < card.seq) : allConversational;
   const youOpen = lastIn !== null && youOpenSeq === lastIn.seq;
   const copy = orbCopy(phase, {
     available: !!state?.available,
@@ -687,19 +804,33 @@ export function WalkieTalkie() {
         )}
         {showHistory && (
           <div class="wt-history" ref={historyRef}>
-            {history.map((m) => (
-              <div
-                key={m.seq}
-                class={`wt-msg wt-msg-${m.direction} ${m.kind === 'template' ? 'wt-msg-template' : ''}`}
-              >
-                <div class="wt-bubble">
-                  {m.kind === 'template' && (
-                    <span class="wt-tag">TEMPLATE · out-of-window</span>
+            {history.map((m, i) => {
+              // A divider marks where one conversation ends and the next
+              // begins (#474) — only drawn between two REAL, differing
+              // threads; an untagged system notice never breaks the run.
+              const tid = messageThreadId(m);
+              const prevTid = i > 0 ? messageThreadId(history[i - 1]) : null;
+              const showDivider = tid !== null && prevTid !== null && tid !== prevTid;
+              return (
+                <Fragment key={m.seq}>
+                  {showDivider && (
+                    <div class="wt-thread-divider" role="separator">
+                      <span>New conversation</span>
+                    </div>
                   )}
-                  <div class="wt-bubble-text">{m.text}</div>
-                </div>
-              </div>
-            ))}
+                  <div
+                    class={`wt-msg wt-msg-${m.direction} ${m.kind === 'template' ? 'wt-msg-template' : ''}`}
+                  >
+                    <div class="wt-bubble">
+                      {m.kind === 'template' && (
+                        <span class="wt-tag">TEMPLATE · out-of-window</span>
+                      )}
+                      <div class="wt-bubble-text">{m.text}</div>
+                    </div>
+                  </div>
+                </Fragment>
+              );
+            })}
           </div>
         )}
 

--- a/charts/workspace/web/src/routes/hypervisor/walkie.css
+++ b/charts/workspace/web/src/routes/hypervisor/walkie.css
@@ -229,6 +229,27 @@
   border-radius: var(--radius);
 }
 
+/* Marks a thread boundary in the History panel (#474) — a full-width row
+   between two conversations, distinct from either side's bubble alignment. */
+.wt-thread-divider {
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  gap: var(--size-2);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.wt-thread-divider::before,
+.wt-thread-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
 .wt-msg {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What & why

The Walkie-Talkie surface has two related state bugs, both stemming from the same design gap: it mirrors global server state (the gateway's `busy` flag, the preview transcript) without tying it to a turn this surface actually started.

1. **Phantom "THINKING…"** — the orb enters the thinking phase (and the status chip reads `THINKING…`) on load or mid-session even though the user never sent a query from this surface. Any activity on the bound Hypervisor thread — a turn from the regular chat tab, a WhatsApp message on the same identity, a cron/queued turn, or a stale/crashed session (`thread.json` stuck at `"running"`, #462) — lit up the orb.
2. **Conversation bleed** — the preview transcript is a single global, thread-agnostic log. When the underlying Hypervisor thread rotates (a new chat, a WhatsApp turn on the same identity), the on-screen conversation and the live thread/busy state drift apart, so old exchanges mix in with the current one.

Closes #474.

## Root cause (confirmed against current source)

- `server.py`'s `_gw_internal_status` derived `busy` purely from `HypervisorSession.status() == 'running'` — global to the bound thread, with no notion of who owns it, and trusting a persisted status flag that a mid-turn crash can leave stuck at `"running"` forever.
- `WalkieTalkie.tsx` trusted that flag unconditionally (`if (state.busy) dispatch('busy')`) — and separately, the status chip read `THINKING…` straight off `state.busy`, bypassing the phase machine entirely, so fixing only the dispatch would have left the chip lying.
- `gateway.py`'s `PreviewTranscript` held one `deque` for the whole workspace. The `meta` field existed on every entry but nothing populated it with a thread id, and nothing rescoped or segmented the transcript when the thread rotated.

## Fix

### Backend — tag every transcript entry with its thread, harden the busy check
- `OutboundMessage` / `_send` / `LoopbackAdapter.outbound` now carry a `thread_id`, using the transcript's existing (previously unused) `meta` field — no client schema break.
- The inbound user bubble is written *before* dispatch (so it renders instantly) and back-filled with the resolved thread once dispatch returns — covers a message that mints a brand-new thread.
- New `HypervisorSession.is_turn_live()` keys busy-ness off the live in-process `_RUNNING` registry instead of `thread.json`'s persisted status — the exact same pattern `WatcherManager._default_deliver` already uses, and for the identical documented reason (a crash mid-turn leaves a stale `"running"` with nothing to reconcile it outside of server restart). `_gw_internal_status` now uses it, so a stuck session can no longer pin the orb indefinitely.

### Frontend — own the turn, scope the conversation
- `WalkieTalkie.tsx` tracks a `pendingTurn` watermark set only when *this surface* sends (both the voice and typed/quick-reply paths), cleared once a matching reply lands, or by a defensive watchdog if nothing ever resolves it. The gateway's `busy` flag is now confirmation of an owned turn, never the trigger by itself.
- The status chip and the orb's own label are both now derived from the same `phase` value, so they can never disagree about whether the surface is actually thinking.
- The live response card, the "you said" bubble, and narration are scoped to `state.thread_id` (untagged system notices — not-linked, workspace list, … — still always render). The History panel keeps every prior conversation but segments them with a "New conversation" divider instead of running them together.

## Backend flow

`gateway.py`'s `_send`/`_deliver_final`/`_deliver_template` thread a `thread_id` into every `OutboundMessage` they build → `LoopbackAdapter.outbound` writes it into the transcript entry's `meta` → `server.py`'s inbound handler back-fills the user's own bubble with the same id once dispatch resolves it. On the read side, `_gw_internal_status` now asks `HypervisorSession.is_turn_live()` (live in-process registry) instead of the persisted `status()` field. The client reads `state.thread_id` + each entry's `meta.thread_id` to scope the live view and segment History — no new endpoints, no schema break.

## Testing

- **`gateway_preview_test.py`**: thread-tag round-tripping on `PreviewTranscript`, `LoopbackAdapter` recording `thread_id`, a full integration test proving two separately-dispatched turns get independently tagged replies (and that a late reply from an old thread is never attributed to whichever thread is live now), a route-level test for the inbound back-fill across a rotation (using a new `_RotatingClient` since the existing `_NoopClient` returns a constant thread id), and a route-level regression for the stale-busy fix.
- **`hypervisor_session_test.py`**: `is_turn_live()` against a hand-crafted stuck `"running"` `thread.json` (the exact #462 state), a genuinely live turn, an idle thread, and a nonexistent thread id.
- **`WalkieTalkie.busy.test.tsx`** (new): mount-with-busy stays idle, activity from elsewhere doesn't spin the orb, an owned turn shows thinking and settles once its reply lands, a later unrelated busy doesn't re-trigger it (the watermark is consumed, not sticky), the watchdog defensively settles a turn that never resolves, cross-thread scoping of the live card/"you" bubble + History segmentation with the divider, and that a foreign thread's reply is never narrated aloud. Plus direct unit coverage of the exported `messageThreadId`/`inLiveThread` helpers.
- Full local CI mirror (helm lint/template/unittest, `server.py` full suite, dashboard SPA typecheck + build + vitest, shell syntax) is green.

## Acceptance criteria

- [x] Opening the Walkie tab with no prior action shows idle, never `THINKING…`.
- [x] Activity on the bound thread from another surface does not put the orb into thinking.
- [x] Sending a query shows thinking until its reply lands, then settles to idle.
- [x] After a new chat / thread rotation, the transcript reflects only the current conversation in the live view (older ones segmented in History); busy/thread_id/transcript stay consistent.
- [x] An interrupted/stuck `running` session cannot pin the orb on `THINKING…` indefinitely.

## Out of scope (flagged, not fixed here)
- Fixing bug #462 itself (the stale `thread.json`) beyond making the Walkie-Talkie surface immune to it.
- Adding an explicit "new chat"/unlink control action to the preview API — today rotation is only reachable by typing `new chat` as a message. Worth a follow-up.
- Reworking `reset` so it stops orphaning a still-running thread when it revokes the identity.
