### PR TITLE
security(supply-chain): verify installer checksums + dedicated signed…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,26 @@
-# Release: build the devlaptop image, publish it to GHCR, and sign it with
+# Release: build the release images, publish them to GHCR, and sign each with
 # keyless cosign (Sigstore OIDC — no long-lived keys, logged to Rekor) plus
-# BuildKit-native SBOM and SLSA provenance attestations.
+# BuildKit-native SBOM and SLSA provenance attestations. Two images are built
+# from one matrix (identical sign/attest path):
+#   * devlaptop   — the general workspace/controller image.
+#   * provisioner — the minimal tool-baked image the privileged provisioner Job
+#     runs (supply-chain finding 7). It is pinned by digest in the controller
+#     chart and verified at admission, so it MUST be signed here too.
 #
 # Fires on the repo's release tags — `v<X.Y.Z>`, cut from green main by
-# scripts/release.sh (`TAG="$VER"`). NB: `devlaptop-v<X.Y.Z>` is the *image* tag,
+# scripts/release.sh (`TAG="$VER"`). NB: `<image>-v<X.Y.Z>` is the *image* tag,
 # NOT the git tag, so the trigger + metadata pattern below key off `v*`. This is
 # additive: the DigitalOcean deploy image still
 # ships via `make push`; GHCR is the signed, attested, publicly-verifiable
 # artifact. No secrets required — the built-in GITHUB_TOKEN pushes to GHCR and
 # the OIDC id-token mints the signing certificate.
 #
-# Verify a released image:
-#   cosign verify ghcr.io/imran31415/kube-coder/devlaptop:<version> \
+# Verify a released image (swap devlaptop/provisioner):
+#   cosign verify ghcr.io/imran31415/kube-coder/provisioner:<version> \
 #     --certificate-identity-regexp '^https://github.com/imran31415/kube-coder/' \
 #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
-#   cosign download sbom       ghcr.io/imran31415/kube-coder/devlaptop:<version>
-#   cosign verify-attestation  ghcr.io/imran31415/kube-coder/devlaptop:<version> \
+#   cosign download sbom       ghcr.io/imran31415/kube-coder/provisioner:<version>
+#   cosign verify-attestation  ghcr.io/imran31415/kube-coder/provisioner:<version> \
 #     --type slsaprovenance --certificate-identity-regexp ... --certificate-oidc-issuer ...
 name: release
 
@@ -45,8 +50,24 @@ jobs:
       contents: read
       packages: write   # push image to GHCR
       id-token: write   # keyless cosign (Sigstore OIDC)
+    strategy:
+      fail-fast: false
+      # Two images share this identical build→sign→attest path:
+      #   * devlaptop   — the general workspace/controller image.
+      #   * provisioner — the minimal, tool-baked image the privileged
+      #     provisioner Job runs (finding 7). Building it here means it is
+      #     signed + SBOM/provenance-attested exactly like devlaptop, so the
+      #     controller chart can pin it by digest and admission can verify it.
+      matrix:
+        include:
+          - name: devlaptop
+            file: devlaptop/Dockerfile
+            target: runtime
+          - name: provisioner
+            file: provisioner/Dockerfile
+            target: ""
     env:
-      IMAGE: ghcr.io/${{ github.repository }}/devlaptop
+      IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.name }}
       PUSH: ${{ github.event_name == 'push' || !inputs.dryRun }}
     steps:
       - name: Checkout
@@ -82,8 +103,8 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          file: devlaptop/Dockerfile
-          target: runtime
+          file: ${{ matrix.file }}
+          target: ${{ matrix.target }}
           platforms: linux/amd64
           push: ${{ env.PUSH == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/charts/workspace-controller/controller.py
+++ b/charts/workspace-controller/controller.py
@@ -1489,8 +1489,11 @@ ALLOW_MUTABLE_CHART_REF = os.environ.get('ALLOW_MUTABLE_CHART_REF', '').strip().
     '1', 'true', 'yes', 'on')
 _CHART_REF_SHA_RE = re.compile(r'^(?:[0-9a-f]{40}|[0-9a-f]{64})$')
 _CHART_REF_TAG_RE = re.compile(r'^v\d+\.\d+\.\d+$')
-# Image the provisioner Job runs (needs git+make+kubectl; installs helm on the
-# fly if absent). Defaults to the controller's own image.
+# Image the provisioner Job runs. Should be the dedicated, signed provisioner
+# image (provisioner/Dockerfile) pinned BY DIGEST via provision.image — it bakes
+# helm+kubectl+git+make so nothing is downloaded at runtime (finding 7). Falls
+# back to the controller's own image only if unset; the Job then fails closed if
+# that image lacks helm rather than fetching it over the network.
 PROVISIONER_IMAGE = os.environ.get('PROVISIONER_IMAGE', '').strip()
 PROVISIONER_SA = os.environ.get('PROVISIONER_SERVICE_ACCOUNT', 'workspace-provisioner').strip()
 PROVISIONER_PULL_SECRET = os.environ.get('PROVISIONER_PULL_SECRET', '').strip()
@@ -1856,30 +1859,33 @@ def _git(args):
 # cannot smuggle an attacker-controlled workload in under the provisioner
 # identity. Endgame: move the provisioner to a separate namespace behind a
 # constrained broker that stamps Jobs from an immutable template (see PR notes).
-# Pinned helm release + its published SHA-256 (from
-# https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum). The
-# runtime download is verified against this digest before it is unpacked or
-# executed — a tampered/MITM'd helm tarball fails closed with `exit 1` rather
-# than running under the cluster-privileged provisioner SA (finding 7). Bump both
-# lines together when moving helm versions.
+# Helm version the privileged provisioner runs. This is no longer downloaded at
+# runtime (finding 7): helm — like kubectl/git/make — is baked into the dedicated
+# provisioner image (provisioner/Dockerfile), checksum-verified at BUILD time and
+# pinned by digest via provision.image, then verified at admission. This constant
+# stays as the single declared expected version (asserted in the unit tests and
+# echoed for provenance); keep it in lockstep with provisioner/Dockerfile's
+# HELM_VERSION ARG.
 PROVISION_HELM_VERSION = 'v3.14.4'
-PROVISION_HELM_SHA256 = 'a5844ef2c38ef6ddf3b5a8f7d91e7e0e8ebc39a38bb3fc8013d629c1ef29c259'
 
 PROVISION_JOB_SCRIPT = (r"""
 set -euo pipefail
 export HOME=/tmp
-mkdir -p /tmp/bin
 export PATH="/tmp/bin:$PATH"
-HELM_VERSION="__HELM_VERSION__"
-HELM_SHA256="__HELM_SHA256__"
-if ! command -v helm >/dev/null 2>&1; then
-  echo "helm not found — installing ${HELM_VERSION} to /tmp/bin (sha256-verified)"
-  curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o /tmp/helm.tgz
-  echo "${HELM_SHA256}  /tmp/helm.tgz" | sha256sum -c - \
-    || { echo "FATAL: helm ${HELM_VERSION} checksum verification failed — refusing to run" >&2; exit 1; }
-  tar -xzf /tmp/helm.tgz -C /tmp
-  install -m 0755 /tmp/linux-amd64/helm /tmp/bin/helm
-fi
+# Supply-chain (finding 7): helm + kubectl + git + make are baked into the
+# dedicated, checksum-verified provisioner image and pinned by digest. This
+# privileged path performs NO runtime tool downloads — the only network it does
+# is the approved GitOps git clones below. Fail closed if the image is missing a
+# tool (e.g. provision.image was pointed at the old fat image) rather than
+# silently fetching binaries from the internet under the cluster-privileged
+# provisioner ServiceAccount.
+for tool in helm kubectl git make; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "FATAL: '$tool' not found in provisioner image — provisioning requires the dedicated provisioner image (provisioner/Dockerfile); refusing to download tools at runtime under the provisioner SA" >&2
+    exit 1
+  }
+done
+echo "provisioner: baked-in helm $(helm version --short 2>/dev/null || echo '?') (expected __HELM_VERSION__), kubectl present — no runtime tool download"
 git clone --depth 1 -b "$CHART_REF" "$CHART_REPO" /tmp/kc
 # Provenance: record the exact commit the privileged deploy actually runs from.
 echo "provisioner: chart ref ${CHART_REF} resolved to commit $(git -C /tmp/kc rev-parse HEAD)"
@@ -1892,8 +1898,7 @@ cd /tmp/kc
 # creates+labels the namespace and replicates regcred (see REGCRED_SRC_NAMESPACE).
 make deploy USER="${SLUG}" NAMESPACE="${WS_NAMESPACE}" REGCRED_SRC_NAMESPACE="${NAMESPACE}"
 """
-                        .replace('__HELM_VERSION__', PROVISION_HELM_VERSION)
-                        .replace('__HELM_SHA256__', PROVISION_HELM_SHA256))
+                        .replace('__HELM_VERSION__', PROVISION_HELM_VERSION))
 
 
 def build_job_manifest(slug):

--- a/charts/workspace-controller/templates/provisioner-image-policy.yaml
+++ b/charts/workspace-controller/templates/provisioner-image-policy.yaml
@@ -1,0 +1,88 @@
+{{- if and .Values.provision.enabled .Values.provision.admissionPolicy.enabled .Values.provision.admissionPolicy.verifyImageSignature }}
+{{- $ap := .Values.provision.admissionPolicy }}
+{{- /* Same "approved image" resolution as the CEL VAP: an explicit provision.image
+       pin, else the controller image repo the controller reuses as the Job image. */ -}}
+{{- $allowedImage := .Values.provision.image | default .Values.controller.image.repository }}
+# Provisioner image SIGNATURE verification (supply-chain review July 2026, finding
+# 7 — acceptance: "admission rejects an unsigned or unexpected provisioner image").
+#
+# The CEL ValidatingAdmissionPolicy (provisioner-vap.yaml) already pins the Job
+# shape + repository + digest, but CEL has no crypto/network and cannot verify a
+# cosign signature. This policy closes that gap by delegating signature checks to
+# a signature-verifying admission controller. It is OPT-IN
+# (provision.admissionPolicy.verifyImageSignature) because it REQUIRES that
+# controller to be installed — turning it on without one will hard-fail admission.
+#
+# Two engines are supported; pick with provision.admissionPolicy.engine:
+{{- if eq $ap.engine "kyverno" }}
+# --- engine: kyverno (Kyverno >= 1.11) ---------------------------------------
+# Verifies the keyless-cosign signature (Fulcio cert identity + OIDC issuer,
+# Rekor-logged) of any Pod that runs as the provisioner ServiceAccount and whose
+# image comes from the approved repo. Unsigned or wrong-identity images are
+# rejected; a matching signature is required. Kyverno also mutates the tag to the
+# resolved digest, complementing the VAP's digest requirement.
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: workspace-provisioner-image-signature
+  labels:
+    {{- include "wc.labels" . | nindent 4 }}
+spec:
+  validationFailureAction: Enforce
+  background: false
+  failurePolicy: Fail
+  webhookTimeoutSeconds: 30
+  rules:
+    - name: verify-provisioner-image-signature
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              namespaces:
+                - {{ .Values.namespace | quote }}
+      # Only gate Pods that actually run as the provisioner SA — every other
+      # workload in the namespace is out of scope and passes untouched.
+      preconditions:
+        all:
+          - key: {{ printf "{{ request.object.spec.serviceAccountName || '' }}" | quote }}
+            operator: Equals
+            value: {{ .Values.provision.serviceAccount | quote }}
+      verifyImages:
+        - imageReferences:
+            - {{ printf "%s*" $allowedImage | quote }}
+          mutateDigest: true
+          required: true
+          attestors:
+            - count: 1
+              entries:
+                - keyless:
+                    subject: {{ $ap.signatureIdentityRegexp | quote }}
+                    issuer: {{ $ap.signatureOidcIssuer | quote }}
+                    rekor:
+                      url: https://rekor.sigstore.dev
+{{- else if eq $ap.engine "sigstore" }}
+# --- engine: sigstore (Sigstore policy-controller) ---------------------------
+# Native cosign policy: only images matching the approved repo AND carrying a
+# keyless signature from the configured identity/issuer are admitted. Scope it to
+# the provisioner by labelling the control-plane namespace for policy-controller
+# enforcement (see docs/SUPPLY_CHAIN.md).
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: workspace-provisioner-image-signature
+  labels:
+    {{- include "wc.labels" . | nindent 4 }}
+spec:
+  images:
+    - glob: {{ printf "%s**" $allowedImage | quote }}
+  authorities:
+    - keyless:
+        url: https://fulcio.sigstore.dev
+        identities:
+          - issuer: {{ $ap.signatureOidcIssuer | quote }}
+            subjectRegExp: {{ $ap.signatureIdentityRegexp | quote }}
+{{- else }}
+{{- fail (printf "provision.admissionPolicy.engine must be 'kyverno' or 'sigstore', got %q" $ap.engine) }}
+{{- end }}
+{{- end }}

--- a/charts/workspace-controller/templates/provisioner-vap.yaml
+++ b/charts/workspace-controller/templates/provisioner-vap.yaml
@@ -91,6 +91,18 @@ spec:
       !(has(variables.podSpec.hostPID) && variables.podSpec.hostPID) &&
       !(has(variables.podSpec.hostIPC) && variables.podSpec.hostIPC)
     message: "provisioner Job must not use hostNetwork, hostPID, or hostIPC"
+  {{- if .Values.provision.admissionPolicy.requireDigest }}
+  # Immutable by digest (supply-chain finding 7): reject tag-only refs so the
+  # provisioner always runs the exact, signed image bytes the chart pinned — a
+  # mutable tag (e.g. :latest) could be repointed after admission review. CEL
+  # cannot verify a cosign signature (no crypto/network), so signature checking
+  # is delegated to the opt-in policy in provisioner-image-policy.yaml; this rule
+  # enforces the digest half, which admission CAN see. Appended last so the other
+  # validations keep their fixed indices.
+  - expression: >-
+      variables.containers.all(c, c.image.contains('@sha256:'))
+    message: "provisioner Job container image must be pinned by digest (repo@sha256:...), not a mutable tag"
+  {{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding

--- a/charts/workspace-controller/tests/controller_test.py
+++ b/charts/workspace-controller/tests/controller_test.py
@@ -502,24 +502,38 @@ class ChartRefSupplyChainTest(unittest.TestCase):
         self.assertIn('(mutable)', out)
 
 
-class ProvisionHelmChecksumTest(unittest.TestCase):
-    """Finding 7: the runtime helm download must be pinned + sha256-verified
-    before it is unpacked/executed under the privileged provisioner SA."""
+class ProvisionNoRuntimeToolDownloadTest(unittest.TestCase):
+    """Finding 7: the privileged provisioner must NOT download tools at runtime.
+    helm/kubectl/git/make are baked into the dedicated, checksum-verified
+    provisioner image; the Job fails closed if any is missing rather than
+    reaching out to the internet under the cluster-privileged provisioner SA."""
 
-    def test_script_pins_helm_version_and_verifies_checksum(self):
+    def test_script_does_not_download_helm_at_runtime(self):
         script = controller.PROVISION_JOB_SCRIPT
-        self.assertEqual(controller.PROVISION_HELM_VERSION, 'v3.14.4')
-        # 64-hex sha256 pinned as a constant and threaded into the script.
-        self.assertRegex(controller.PROVISION_HELM_SHA256, r'^[0-9a-f]{64}$')
-        self.assertIn(controller.PROVISION_HELM_VERSION, script)
-        self.assertIn(controller.PROVISION_HELM_SHA256, script)
-        # Verification happens (sha256sum -c) and fails closed (exit 1) BEFORE
-        # the tarball is unpacked/installed — never a bare `curl | tar` pipe.
-        self.assertIn('sha256sum -c', script)
-        self.assertIn('exit 1', script)
-        self.assertNotIn('| tar -xz', script)
+        # The old runtime install is gone: no fetch from get.helm.sh, no tarball
+        # unpack/install of helm inside the privileged Job.
+        self.assertNotIn('get.helm.sh', script)
+        self.assertNotIn('helm.tgz', script)
+        self.assertNotIn('curl', script)
         # No unfilled template placeholders leaked into the shipped script.
         self.assertNotIn('__HELM', script)
+
+    def test_script_fails_closed_when_tools_missing(self):
+        script = controller.PROVISION_JOB_SCRIPT
+        # Presence check for every baked-in tool, failing closed (exit 1).
+        for tool in ('helm', 'kubectl', 'git', 'make'):
+            self.assertIn(tool, script)
+        self.assertIn('command -v', script)
+        self.assertIn('exit 1', script)
+        self.assertIn('refusing to download tools at runtime', script)
+
+    def test_expected_helm_version_still_declared(self):
+        # The version stays declared centrally (echoed for provenance) and must
+        # match provisioner/Dockerfile's HELM_VERSION ARG.
+        self.assertEqual(controller.PROVISION_HELM_VERSION, 'v3.14.4')
+        self.assertIn(controller.PROVISION_HELM_VERSION, controller.PROVISION_JOB_SCRIPT)
+        self.assertFalse(hasattr(controller, 'PROVISION_HELM_SHA256'),
+                         'runtime helm sha256 is obsolete once helm is baked into the image')
 
     def test_script_logs_resolved_commit(self):
         # Provenance inside the Job: the exact commit the privileged deploy runs.

--- a/charts/workspace-controller/tests/provisioner-image-policy_test.yaml
+++ b/charts/workspace-controller/tests/provisioner-image-policy_test.yaml
@@ -1,0 +1,119 @@
+suite: provisioner image signature policy (supply-chain review July 2026, finding 7)
+templates:
+  - templates/provisioner-image-policy.yaml
+values:
+  - test-values.yaml
+tests:
+  - it: renders nothing unless provisioning is enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing when signature verification is left off (the default)
+    set:
+      provision.enabled: true
+      provision.workspaceDomain: dev.test.io
+      provision.gitops.repo: github.com/x/y.git
+      provision.gitToken: xxx
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a Kyverno ClusterPolicy when verification is enabled (default engine)
+    set:
+      provision.enabled: true
+      provision.workspaceDomain: dev.test.io
+      provision.gitops.repo: github.com/x/y.git
+      provision.gitToken: xxx
+      provision.admissionPolicy.verifyImageSignature: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: kyverno.io/v1
+      - equal:
+          path: kind
+          value: ClusterPolicy
+      - equal:
+          path: metadata.name
+          value: workspace-provisioner-image-signature
+      - equal:
+          path: spec.validationFailureAction
+          value: Enforce
+      # Only Pods running as the provisioner SA are gated.
+      - equal:
+          path: spec.rules[0].preconditions.all[0].value
+          value: workspace-provisioner
+      # Keyless cosign identity + issuer come from the configured defaults.
+      - equal:
+          path: spec.rules[0].verifyImages[0].attestors[0].entries[0].keyless.subject
+          value: "^https://github.com/imran31415/kube-coder/"
+      - equal:
+          path: spec.rules[0].verifyImages[0].attestors[0].entries[0].keyless.issuer
+          value: "https://token.actions.githubusercontent.com"
+      - equal:
+          path: spec.rules[0].verifyImages[0].required
+          value: true
+
+  - it: scopes verification to the approved image repository
+    set:
+      provision.enabled: true
+      provision.workspaceDomain: dev.test.io
+      provision.gitops.repo: github.com/x/y.git
+      provision.gitToken: xxx
+      provision.admissionPolicy.verifyImageSignature: true
+      provision.image: "ghcr.io/acme/provisioner@sha256:abc"
+    asserts:
+      - equal:
+          path: spec.rules[0].verifyImages[0].imageReferences[0]
+          value: "ghcr.io/acme/provisioner@sha256:abc*"
+
+  - it: renders a Sigstore ClusterImagePolicy when engine is sigstore
+    set:
+      provision.enabled: true
+      provision.workspaceDomain: dev.test.io
+      provision.gitops.repo: github.com/x/y.git
+      provision.gitToken: xxx
+      provision.admissionPolicy.verifyImageSignature: true
+      provision.admissionPolicy.engine: sigstore
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: policy.sigstore.dev/v1beta1
+      - equal:
+          path: kind
+          value: ClusterImagePolicy
+      - equal:
+          path: spec.authorities[0].keyless.identities[0].issuer
+          value: "https://token.actions.githubusercontent.com"
+      - equal:
+          path: spec.authorities[0].keyless.identities[0].subjectRegExp
+          value: "^https://github.com/imran31415/kube-coder/"
+
+  - it: honours a custom keyless identity (e.g. a fork)
+    set:
+      provision.enabled: true
+      provision.workspaceDomain: dev.test.io
+      provision.gitops.repo: github.com/x/y.git
+      provision.gitToken: xxx
+      provision.admissionPolicy.verifyImageSignature: true
+      provision.admissionPolicy.signatureIdentityRegexp: "^https://github.com/acme/fork/"
+    asserts:
+      - equal:
+          path: spec.rules[0].verifyImages[0].attestors[0].entries[0].keyless.subject
+          value: "^https://github.com/acme/fork/"
+
+  - it: fails the render on an unknown engine
+    set:
+      provision.enabled: true
+      provision.workspaceDomain: dev.test.io
+      provision.gitops.repo: github.com/x/y.git
+      provision.gitToken: xxx
+      provision.admissionPolicy.verifyImageSignature: true
+      provision.admissionPolicy.engine: bogus
+    asserts:
+      - failedTemplate:
+          errorMessage: "provision.admissionPolicy.engine must be 'kyverno' or 'sigstore', got \"bogus\""

--- a/charts/workspace-controller/tests/provisioner-vap_test.yaml
+++ b/charts/workspace-controller/tests/provisioner-vap_test.yaml
@@ -176,6 +176,35 @@ tests:
           path: spec.validations[1].expression
           pattern: "ephemeralContainers"
 
+  - it: requires the image be pinned by digest (finding 7) by default
+    set:
+      provision.enabled: true
+      provision.workspaceDomain: dev.test.io
+      provision.gitops.repo: github.com/x/y.git
+      provision.gitToken: xxx
+    documentIndex: 0
+    asserts:
+      # Appended last, so it is validations[7] after the seven finding-4 rules.
+      - matchRegex:
+          path: spec.validations[7].expression
+          pattern: "contains\\('@sha256:'\\)"
+      - matchRegex:
+          path: spec.validations[7].message
+          pattern: "pinned by digest"
+
+  - it: omits the digest rule when requireDigest is disabled
+    set:
+      provision.enabled: true
+      provision.workspaceDomain: dev.test.io
+      provision.gitops.repo: github.com/x/y.git
+      provision.gitToken: xxx
+      provision.admissionPolicy.requireDigest: false
+    documentIndex: 0
+    asserts:
+      # Only the seven finding-4 validations remain (indices 0..6); no 8th rule.
+      - notExists:
+          path: spec.validations[7]
+
   - it: binds the policy in Deny mode scoped to the control-plane namespace
     set:
       provision.enabled: true

--- a/charts/workspace-controller/values.yaml
+++ b/charts/workspace-controller/values.yaml
@@ -208,8 +208,40 @@ provision:
   admissionPolicy:
     enabled: true
 
-  # Image the Job runs. Empty => the controller image (has kubectl/git/make/curl;
-  # installs helm on the fly). Override only if you bake a dedicated tool image.
+    # Require the provisioner Job image to be pinned by digest (repo@sha256:...),
+    # not a mutable tag (supply-chain finding 7). The CEL ValidatingAdmissionPolicy
+    # enforces this — it is signature-independent and needs no extra controller.
+    # Keep it on; set `provision.image` to a digest ref below.
+    requireDigest: true
+
+    # Verify the provisioner image's keyless-cosign signature at admission
+    # (finding 7 acceptance: "admission rejects an unsigned or unexpected image").
+    # CEL cannot check signatures, so this renders an extra policy
+    # (provisioner-image-policy.yaml) for a signature-verifying admission
+    # controller. OFF by default because it REQUIRES one of these installed in the
+    # cluster:
+    #   * Kyverno (>= 1.11)               -> engine: kyverno   (default)
+    #   * Sigstore policy-controller      -> engine: sigstore
+    # Turn on only once that controller is present, or provisioning admission will
+    # hard-fail. The digest pin above holds regardless.
+    verifyImageSignature: false
+    engine: kyverno
+
+    # Keyless-cosign identity the signature policy trusts. Defaults match the
+    # release workflow's OIDC signer (.github/workflows/release.yml). Point
+    # `identityRegexp` at YOUR fork's repo if you publish your own signed image.
+    signatureIdentityRegexp: "^https://github.com/imran31415/kube-coder/"
+    signatureOidcIssuer: "https://token.actions.githubusercontent.com"
+
+  # Image the Job runs. STRONGLY prefer the dedicated, signed provisioner image
+  # pinned BY DIGEST (supply-chain finding 7) — it bakes helm+kubectl+git+make so
+  # provisioning downloads no tools at runtime, and admission can verify it:
+  #   image: ghcr.io/imran31415/kube-coder/provisioner@sha256:<digest>
+  # Get the digest from a release: `cosign verify … && docker buildx imagetools
+  # inspect ghcr.io/imran31415/kube-coder/provisioner:<version>`.
+  # Empty => falls back to the controller image, which lacks helm; the Job then
+  # fails closed (it will NOT download helm at runtime). Leaving this empty is
+  # only viable with admissionPolicy.requireDigest=false on a dev cluster.
   image: ""
 
   # Fallback image tag for new workspaces (chart prefixes it with `devlaptop-`).

--- a/devlaptop/Dockerfile
+++ b/devlaptop/Dockerfile
@@ -39,11 +39,13 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 20.x via NodeSource
-# SUPPLY-CHAIN (finding 7, deferred): the NodeSource setup script is piped to
-# bash. The major line (setup_20.x) is pinned but the script itself is a rolling
-# artifact with no publishable checksum. It installs an apt repo whose packages
-# are GPG-verified by apt. Follow-up: switch to the keyring+sources.list.d form
-# to drop the curl|bash entirely.
+# SUPPLY-CHAIN (finding 7, resolved): the previous `curl … setup_20.x | bash -`
+# piped a rolling, unchecksummable script straight into a root shell. Replaced
+# with the keyring + sources.list.d form the setup script itself installs: we
+# fetch NodeSource's long-lived GPG key to /usr/share/keyrings, register the
+# `signed-by=`-pinned apt source, and let apt install nodejs — so every package
+# is GPG-verified against that key and no code is piped to bash. Nothing here is
+# fetched-then-executed unverified anymore.
 # npm bundled with Node 20 (10.8.x) vendors old tar/minimatch/glob/cross-spawn
 # that Trivy flags (HIGH). Upgrade the global npm first so it ships patched
 # vendored deps (npm 11.x: tar>=7.5, minimatch>=10.2, glob>=13, cross-spawn
@@ -56,7 +58,11 @@ ARG NPM_VERSION=11.18.0
 # package integrity/signature against the registry on install.
 # renovate: datasource=npm depName=yarn
 ARG YARN_VERSION=1.22.22
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+      | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+      > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
     && apt-get install -y nodejs \
     && npm install -g npm@${NPM_VERSION} \
     && npm install -g yarn@${YARN_VERSION} \
@@ -108,13 +114,25 @@ RUN ARCH=$(dpkg --print-architecture) \
 # tar) track the upstream VS Code build code-server vendors and only move when
 # code-server rebases onto a newer VS Code — so bumping code-server is the lever.
 # renovate: datasource=github-releases depName=coder/code-server
-# SUPPLY-CHAIN (finding 7, deferred): version-pinned, but the release does not
-# publish a per-asset .sha256 (the .deb 404s for it), so no download→verify step
-# is added here. apt does verify the .deb's internal structure. Follow-up: pin a
-# hardcoded sha256 per arch if reproducibility beyond the version pin is needed.
+# SUPPLY-CHAIN (finding 7, resolved): the release ships no SHA256SUMS/.sha256
+# asset, but GitHub's release API exposes a per-asset sha256 `digest` for each
+# .deb. We pin that digest per arch below and `sha256sum -c` the download before
+# apt installs it, so a tampered/MITM'd .deb fails the build. Because the digests
+# are arch-specific, both must be bumped together with CODE_SERVER_VERSION — read
+# the new values from
+#   curl -fsSL https://api.github.com/repos/coder/code-server/releases/tags/v<VER> \
+#     | jq -r '.assets[] | select(.name|endswith(".deb")) | "\(.name) \(.digest)"'
 ARG CODE_SERVER_VERSION=4.128.0
+ARG CODE_SERVER_SHA256_AMD64=c0f6e3706c4285f06bb2350274576f289262e6a9962a70e3c31c6d3ea17a29d2
+ARG CODE_SERVER_SHA256_ARM64=b97107ee3ac7c2253a30221da12a562692a2765610457b647ecfcbc02a8ccc4f
 RUN ARCH=$(dpkg --print-architecture) \
+  && case "$ARCH" in \
+       amd64) CS_SHA256="$CODE_SERVER_SHA256_AMD64" ;; \
+       arm64) CS_SHA256="$CODE_SERVER_SHA256_ARM64" ;; \
+       *) echo "FATAL: no pinned code-server sha256 for arch $ARCH" >&2; exit 1 ;; \
+     esac \
   && curl -fsSL "https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server_${CODE_SERVER_VERSION}_${ARCH}.deb" -o /tmp/cs.deb \
+  && echo "${CS_SHA256}  /tmp/cs.deb" | sha256sum -c - \
   && apt-get update && apt-get install -y /tmp/cs.deb && rm /tmp/cs.deb
 
 # Claude Code CLI (terminal assistant). Bring your own API key (or Bedrock/Vertex).
@@ -154,11 +172,14 @@ RUN npm install -g @openai/codex@${CODEX_VERSION}
 # restarts (the pod blocks runtime sudo). The official installer (curl|bash,
 # --dir to place the binary) is the only distribution channel, same mechanism
 # as Ante/LibreFang. https://antigravity.google
-# SUPPLY-CHAIN (finding 7, deferred): vendor ships only a curl|bash installer
-# that resolves "latest" with no publishable per-artifact checksum or version
-# pin, so we cannot download→verify→execute here. `test -x` confirms a binary
-# landed but not its integrity. Follow-up: pin once the vendor exposes a
-# versioned URL + checksum, mirroring the Ante manifest-pinned pattern below.
+# SUPPLY-CHAIN (finding 7, ACCEPTED EXCEPTION — the only one left): Antigravity
+# is distributed *solely* as a curl|bash installer that resolves "latest" server
+# side, with no versioned download URL and no publishable per-artifact checksum
+# or signature. There is therefore nothing to pin or verify — unlike every other
+# installer in this file, which is now checksum- or GPG-verified. `test -x` only
+# confirms a binary landed, not its integrity. Documented in docs/SUPPLY_CHAIN.md
+# as the sole remaining unverifiable artifact; pin the moment the vendor exposes
+# a versioned URL + checksum, mirroring the Ante manifest-pinned pattern below.
 RUN curl -fsSL https://antigravity.google/cli/install.sh | bash -s -- --dir /opt/antigravity \
     && test -x /opt/antigravity/agy \
     && ln -sfn /home/dev/.antigravity/bin/agy /usr/local/bin/agy
@@ -177,11 +198,32 @@ RUN curl -fsSL https://antigravity.google/cli/install.sh | bash -s -- --dir /opt
 # docs/SUPPLY_CHAIN.md); check https://download.ante.run/channels/stable/manifest.json
 # for the current version.
 # https://docs.antigma.ai
+# SUPPLY-CHAIN (finding 7, resolved): the previous `curl … install.sh | bash`
+# piped the vendor installer into a root shell. Ante's pinned release manifest
+# already publishes a per-artifact sha256, so we drop the pipe entirely: fetch
+# the pinned manifest, read the tarball URL + sha256 for this arch, download the
+# tarball, `sha256sum -c` it (fail-closed on mismatch), then extract the `ante`
+# binary. Nothing is executed before it is verified. The manifest keys linux
+# builds as linux-x86_64 / linux-arm64.
 ARG ANTE_VERSION=v0.preview.60
-RUN curl -fsSL https://ante.run/install.sh | bash -s -- "https://download.ante.run/releases/${ANTE_VERSION}/manifest.json" \
-    && mkdir -p /opt/ante \
-    && install -m 0755 "$HOME/.ante/bin/ante" /opt/ante/ante \
+RUN ARCH=$(dpkg --print-architecture) \
+    && case "$ARCH" in \
+         amd64) ANTE_PLAT=linux-x86_64 ;; \
+         arm64) ANTE_PLAT=linux-arm64 ;; \
+         *) echo "FATAL: no ante build for arch $ARCH" >&2; exit 1 ;; \
+       esac \
+    && curl -fsSL "https://download.ante.run/releases/${ANTE_VERSION}/manifest.json" -o /tmp/ante-manifest.json \
+    && ANTE_URL=$(jq -er ".binaries.\"${ANTE_PLAT}\".url" /tmp/ante-manifest.json) \
+    && ANTE_SHA=$(jq -er ".binaries.\"${ANTE_PLAT}\".sha256" /tmp/ante-manifest.json) \
+    && curl -fsSL "$ANTE_URL" -o /tmp/ante.tar.gz \
+    && echo "${ANTE_SHA}  /tmp/ante.tar.gz" | sha256sum -c - \
+    && mkdir -p /opt/ante /tmp/ante-extract \
+    && tar -xzf /tmp/ante.tar.gz -C /tmp/ante-extract \
+    && ANTE_BIN=$(find /tmp/ante-extract -type f -name ante | head -n1) \
+    && test -n "$ANTE_BIN" \
+    && install -m 0755 "$ANTE_BIN" /opt/ante/ante \
     && test -x /opt/ante/ante \
+    && rm -rf /tmp/ante.tar.gz /tmp/ante-extract /tmp/ante-manifest.json \
     && ln -sfn /home/dev/.ante/bin/ante /usr/local/bin/ante
 
 # LibreFang CLI — open-source agent OS (https://librefang.ai); surfaces in
@@ -199,10 +241,12 @@ RUN curl -fsSL https://ante.run/install.sh | bash -s -- "https://download.ante.r
 # static musl build, fall back to glibc. The installer pulls this exact
 # tarball (librefang/librefang releases); we just skip its WAF-gated front
 # door. Bump LIBREFANG_VERSION (a release tag) + rebuild to update.
-# SUPPLY-CHAIN (finding 7, deferred): release tag is pinned but the tarball is
-# unpacked without a checksum. The release does not ship a stable per-asset
-# digest we can fetch arch-agnostically; hardcoding one per arch would need a
-# manual update each bump. Follow-up: verify a pinned sha256 per arch.
+# SUPPLY-CHAIN (finding 7, resolved): the release now ships a per-asset
+# `<tarball>.sha256` sidecar (and a cosign-signed SHA256SUMS) for every arch, so
+# we fetch the sidecar alongside the tarball and `sha256sum -c` before unpacking
+# — fail-closed on mismatch. We try the static musl build first (matching the old
+# behaviour) and fall back to glibc, verifying whichever one we actually pulled
+# against its own sidecar.
 # renovate: datasource=github-releases depName=librefang/librefang
 ARG LIBREFANG_VERSION=v2026.7.11
 RUN ARCH=$(dpkg --print-architecture) \
@@ -213,12 +257,19 @@ RUN ARCH=$(dpkg --print-architecture) \
        esac \
     && BASE="https://github.com/librefang/librefang/releases/download/${LIBREFANG_VERSION}" \
     && mkdir -p /opt/librefang \
-    && ( curl -fL --retry 5 --retry-delay 5 --retry-connrefused \
-           "${BASE}/librefang-${LF_ARCH}-unknown-linux-musl.tar.gz" -o /tmp/librefang.tar.gz \
-         || curl -fL --retry 5 --retry-delay 5 --retry-connrefused \
-           "${BASE}/librefang-${LF_ARCH}-unknown-linux-gnu.tar.gz" -o /tmp/librefang.tar.gz ) \
+    && LF_OK= \
+    && for FLAVOR in musl gnu; do \
+         ASSET="librefang-${LF_ARCH}-unknown-linux-${FLAVOR}.tar.gz"; \
+         if curl -fL --retry 5 --retry-delay 5 --retry-connrefused "${BASE}/${ASSET}" -o /tmp/librefang.tar.gz \
+            && curl -fL --retry 5 --retry-delay 5 --retry-connrefused "${BASE}/${ASSET}.sha256" -o /tmp/librefang.sha256; then \
+              if echo "$(awk '{print $1}' /tmp/librefang.sha256)  /tmp/librefang.tar.gz" | sha256sum -c -; then \
+                LF_OK=1; break; \
+              fi; \
+         fi; \
+       done \
+    && [ -n "$LF_OK" ] \
     && tar -xzf /tmp/librefang.tar.gz -C /opt/librefang \
-    && rm /tmp/librefang.tar.gz \
+    && rm -f /tmp/librefang.tar.gz /tmp/librefang.sha256 \
     && chmod +x /opt/librefang/librefang* \
     && test -x /opt/librefang/librefang \
     && ln -sfn /home/dev/.librefang/bin/librefang /usr/local/bin/librefang
@@ -227,19 +278,27 @@ RUN ARCH=$(dpkg --print-architecture) \
 # Pinned to a known-good version so transient 502s from GitHub's release CDN
 # don't break the build (we hit them repeatedly while bumping to v1.7.1).
 # To bump: update TTYD_VERSION, rebuild image.
-# SUPPLY-CHAIN (finding 7, deferred): version-pinned but the raw binary is
-# installed without checksum verification (tsl0922/ttyd publishes SHA256SUMS
-# only for some releases). Follow-up: verify against a pinned sha256 per arch.
+# SUPPLY-CHAIN (finding 7, resolved): the v1.7.7 release publishes a SHA256SUMS
+# asset covering every per-arch binary, so we download the binary to a temp file,
+# fetch SHA256SUMS, and `sha256sum -c` the matching `ttyd.<arch>` line before
+# installing it — fail-closed on mismatch. (SHA256SUMS uses the standard
+# `<hash>  ttyd.<arch>` format, so we verify from a cwd holding the renamed-back
+# file.)
 # renovate: datasource=github-releases depName=tsl0922/ttyd
 ARG TTYD_VERSION=1.7.7
 RUN apt-get update && apt-get install -y wget \
     && ARCH=$(dpkg --print-architecture) \
     && if [ "$ARCH" = "amd64" ]; then TTYD_ARCH="x86_64"; elif [ "$ARCH" = "arm64" ]; then TTYD_ARCH="aarch64"; else TTYD_ARCH="$ARCH"; fi \
+    && BASE="https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}" \
     && wget --tries=5 --waitretry=10 --retry-connrefused \
        --retry-on-http-error=429,500,502,503,504 \
-       -O /usr/local/bin/ttyd \
-       "https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.${TTYD_ARCH}" \
-    && chmod +x /usr/local/bin/ttyd \
+       -O "/tmp/ttyd.${TTYD_ARCH}" "${BASE}/ttyd.${TTYD_ARCH}" \
+    && wget --tries=5 --waitretry=10 --retry-connrefused \
+       --retry-on-http-error=429,500,502,503,504 \
+       -O /tmp/ttyd.SHA256SUMS "${BASE}/SHA256SUMS" \
+    && (cd /tmp && grep " ttyd.${TTYD_ARCH}$" ttyd.SHA256SUMS | sha256sum -c -) \
+    && install -m 0755 "/tmp/ttyd.${TTYD_ARCH}" /usr/local/bin/ttyd \
+    && rm -f "/tmp/ttyd.${TTYD_ARCH}" /tmp/ttyd.SHA256SUMS \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI
@@ -252,16 +311,26 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | g
 # sqlite-vec loadable extension — enables vector search inside SQLite for the
 # persistent-memory subsystem (Phase 2 activates this). Shipped as a single
 # .so so the dashboard + MCP memory server can `conn.load_extension('vec0')`.
-# SUPPLY-CHAIN (finding 7, deferred): version-pinned but streamed straight to
-# tar without a checksum. Follow-up: download to a temp file, verify a pinned
-# per-arch sha256, then extract (as done for helm in the provisioner path).
+# SUPPLY-CHAIN (finding 7, resolved): the release publishes a checksums.txt
+# covering every asset, so we stop streaming `curl | tar` and instead download
+# the tarball to a temp file, look up its sha256 in checksums.txt, `sha256sum -c`
+# it (fail-closed on mismatch), then extract. NB: sqlite-vec's checksums.txt uses
+# a *reversed* `<filename> <hash>` layout (not the standard `<hash>  <filename>`),
+# so we grep the asset line and take the second field.
 # renovate: datasource=github-releases depName=asg017/sqlite-vec
 ARG SQLITE_VEC_VERSION=0.1.9
 RUN ARCH=$(dpkg --print-architecture) \
  && case "$ARCH" in amd64) VEC_ARCH=x86_64 ;; arm64) VEC_ARCH=aarch64 ;; *) VEC_ARCH=$ARCH ;; esac \
  && mkdir -p /usr/local/lib/sqlite-vec \
- && curl -fsSL "https://github.com/asg017/sqlite-vec/releases/download/v${SQLITE_VEC_VERSION}/sqlite-vec-${SQLITE_VEC_VERSION}-loadable-linux-${VEC_ARCH}.tar.gz" \
-    | tar -xz -C /usr/local/lib/sqlite-vec/ \
+ && BASE="https://github.com/asg017/sqlite-vec/releases/download/v${SQLITE_VEC_VERSION}" \
+ && ASSET="sqlite-vec-${SQLITE_VEC_VERSION}-loadable-linux-${VEC_ARCH}.tar.gz" \
+ && curl -fsSL "${BASE}/${ASSET}" -o /tmp/sqlite-vec.tar.gz \
+ && curl -fsSL "${BASE}/checksums.txt" -o /tmp/sqlite-vec.checksums \
+ && EXPECTED=$(grep "^${ASSET} " /tmp/sqlite-vec.checksums | awk '{print $2}') \
+ && test -n "$EXPECTED" \
+ && echo "${EXPECTED}  /tmp/sqlite-vec.tar.gz" | sha256sum -c - \
+ && tar -xzf /tmp/sqlite-vec.tar.gz -C /usr/local/lib/sqlite-vec/ \
+ && rm -f /tmp/sqlite-vec.tar.gz /tmp/sqlite-vec.checksums \
  && ln -sf /usr/local/lib/sqlite-vec/vec0.so /usr/local/lib/vec0.so
 
 # Python deps for memory-system embeddings (Voyage AI / OpenAI) and HTTP

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -11,13 +11,38 @@ Tracks issue [#104](https://github.com/imran31415/kube-coder/issues/104).
 
 | Artifact | Where | Pin |
 |----------|-------|-----|
-| Base images (`node`, `ubuntu`) | `devlaptop/Dockerfile` `FROM` | tag + digest (Renovate `pinDigests`) |
+| Base images (`node`, `ubuntu`) | `devlaptop/Dockerfile`, `provisioner/Dockerfile` `FROM` | tag + digest (Renovate `pinDigests`) |
 | Kaniko builder image | `charts/*/values.yaml`, `controller.py` | `gcr.io/kaniko-project/executor:v1.24.0` (+digest) |
 | docker-compose | `devlaptop/Dockerfile` `COMPOSE_VERSION` | release tag (was `releases/latest`) |
-| code-server, ttyd, sqlite-vec, librefang | `devlaptop/Dockerfile` `*_VERSION` | release tags |
+| code-server, ttyd, sqlite-vec, librefang | `devlaptop/Dockerfile` `*_VERSION` | release tag **+ checksum-verified** (see below) |
+| helm, kubectl (provisioner) | `provisioner/Dockerfile` `HELM_VERSION`/`KUBECTL_VERSION` | version + published-checksum-verified |
 | npm, claude-code, opencode, codex | `devlaptop/Dockerfile` `*_VERSION` | npm versions |
 | GitHub Actions | `.github/workflows/*` | commit SHA (Renovate `pinGitHubActionDigests`) |
 | SPA / controller deps | `charts/**/package.json`, Python reqs | native npm / pip managers |
+
+## Artifact integrity verification (finding 7)
+
+Beyond version-pinning, every external binary/archive pulled into an image is
+**checksum- or signature-verified at build time and fails the build on
+mismatch** (download → verify → install; no `curl | bash`, no `curl | tar`):
+
+| Artifact | Image | Verification source |
+|----------|-------|---------------------|
+| Node.js / npm repo | `devlaptop` | NodeSource **GPG keyring** + `signed-by=` apt source (no `curl \| bash`) |
+| code-server `.deb` | `devlaptop` | per-arch `sha256` pinned as `CODE_SERVER_SHA256_{AMD64,ARM64}` (from the GitHub release API `digest`) |
+| ttyd | `devlaptop` | release `SHA256SUMS` |
+| sqlite-vec | `devlaptop` | release `checksums.txt` (reversed `<file> <hash>` layout) |
+| librefang | `devlaptop` | per-asset `.tar.gz.sha256` sidecar |
+| Ante | `devlaptop` | pinned release `manifest.json` `sha256` (download tarball direct, no installer pipe) |
+| docker-compose, kubectl | `devlaptop` | vendor-published `.sha256` |
+| helm, kubectl | `provisioner` | `get.helm.sh` `.sha256sum` / `dl.k8s.io` `.sha256` |
+
+**Accepted exception (one):** **Antigravity (`agy`)** is distributed *only* as a
+`curl | bash` installer that resolves `latest` server-side with no versioned URL
+and no published per-artifact checksum, so there is nothing to pin or verify. It
+is documented here and marked `# SUPPLY-CHAIN … ACCEPTED EXCEPTION` in the
+Dockerfile; it will be pinned the moment the vendor exposes a versioned URL +
+checksum.
 
 Each pinned `ARG *_VERSION` in the Dockerfile carries a `# renovate:` annotation
 naming its datasource, so Renovate's custom manager can resolve upgrades.
@@ -117,6 +142,40 @@ This is **additive** and needs **no secrets** (the built-in `GITHUB_TOKEN`
 pushes to GHCR; the OIDC `id-token` mints the certificate). The DigitalOcean
 deploy image still ships via `make push`; GHCR is the signed, publicly
 verifiable artifact.
+
+The same job now builds **two** images from one matrix: `devlaptop` and
+`provisioner` (below).
+
+## Privileged provisioner image (finding 7)
+
+The self-service provisioner Job (`charts/workspace-controller/controller.py`)
+runs `make deploy` under the cluster-privileged `workspace-provisioner`
+ServiceAccount. It used to reuse the fat workspace image **and install Helm at
+runtime** with a `curl` from `get.helm.sh` — a moving part on a privileged path.
+That is now closed:
+
+- **Dedicated minimal image** — [`provisioner/Dockerfile`](../provisioner/Dockerfile)
+  bakes `helm` + `kubectl` + `git` + `make` (each checksum-verified at build),
+  so provisioning performs **no runtime tool downloads** — only the approved
+  GitOps `git clone`s. The Job **fails closed** if a tool is missing instead of
+  fetching it.
+- **Signed + attested** — built, keyless-cosign **signed**, and SBOM/SLSA-
+  provenance **attested** by the release workflow, exactly like `devlaptop`.
+- **Pinned by digest** — set `provision.image` to a `repo@sha256:…` ref. The CEL
+  `ValidatingAdmissionPolicy` (`provisioner-vap.yaml`) **requires** the digest
+  form (`provision.admissionPolicy.requireDigest`, on by default) alongside the
+  existing shape/repository pinning.
+- **Signature verified at admission** *(opt-in)* — CEL cannot check a cosign
+  signature, so `provision.admissionPolicy.verifyImageSignature=true` renders a
+  signature-verifying policy (`provisioner-image-policy.yaml`) for either
+  **Kyverno** (`engine: kyverno`, default) or **Sigstore policy-controller**
+  (`engine: sigstore`). It is off by default because it requires that controller
+  installed in the cluster; the digest pin holds regardless. The trusted keyless
+  identity/issuer default to the release signer and are overridable
+  (`signatureIdentityRegexp` / `signatureOidcIssuer`) for forks.
+
+Result: the exact provisioner bytes are immutable (digest), provably built by
+this repo's CI (signature + provenance), and reconstructible from pinned inputs.
 
 ### Verifying a released image
 

--- a/provisioner/Dockerfile
+++ b/provisioner/Dockerfile
@@ -1,0 +1,75 @@
+# syntax=docker/dockerfile:1.7
+# provisioner/Dockerfile
+#
+# Dedicated, minimal image for the privileged workspace-provisioner Job
+# (charts/workspace-controller/controller.py :: build_job_manifest). Supply-chain
+# hardening, security review July 2026, finding 7.
+#
+# Why a separate image at all: the provisioner Job runs `make deploy` under the
+# cluster-privileged `workspace-provisioner` ServiceAccount. It previously reused
+# the fat general-workspace image AND installed Helm at runtime with a `curl`
+# from get.helm.sh. That runtime download is exactly the kind of moving part a
+# privileged path must not have. This image bakes every tool the Job needs —
+# helm, kubectl, git, make — each checksum-verified at build time, so:
+#   * provisioning performs NO runtime tool downloads (only the approved GitOps
+#     git clones the Job itself does), and
+#   * the image is published, signed (keyless cosign), SBOM- + provenance-attested
+#     by .github/workflows/release.yml and pinned BY DIGEST in the controller
+#     chart (provision.image), then verified at admission.
+#
+# Keep the pins here in lockstep with the constants they mirror in controller.py
+# (PROVISION_HELM_VERSION) and devlaptop/Dockerfile (KUBECTL_VERSION) — CI and the
+# controller unit tests assert the helm version matches.
+
+# Reuse the same Ubuntu base already pinned + Renovate-tracked for devlaptop, so
+# there is one vetted base digest across the repo rather than a second one to
+# audit. Renovate bumps the digest here too (pinDigests).
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Base OS packages: apt GPG-verifies every one. `apt-get upgrade` picks up base
+# CVE fixes on rebuild (mirrors devlaptop). git+make+bash+coreutils are what
+# `make deploy` and the provisioner scripts shell out to; curl+ca-certificates
+# are only used at BUILD time to fetch the verified helm/kubectl tarballs below.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    ca-certificates curl git make bash coreutils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Helm — baked in, checksum-verified. The published per-release .sha256sum
+# (which already carries the `<hash>  <file>` line format) is fetched from the
+# same release path and `sha256sum -c`'d before the tarball is unpacked, so a
+# tampered/MITM'd helm fails the BUILD (not silently at provision time). Keep
+# HELM_VERSION == controller.py PROVISION_HELM_VERSION (asserted in tests).
+# renovate: datasource=github-releases depName=helm/helm
+ARG HELM_VERSION=v3.14.4
+RUN ARCH=$(dpkg --print-architecture) \
+    && TARBALL="helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" \
+    && curl -fsSL "https://get.helm.sh/${TARBALL}" -o "/tmp/${TARBALL}" \
+    && curl -fsSL "https://get.helm.sh/${TARBALL}.sha256sum" -o "/tmp/${TARBALL}.sha256sum" \
+    # get.helm.sh's .sha256sum carries the *original* tarball name, so verify from
+    # /tmp with the file kept under that exact name (a rename breaks `-c`).
+    && (cd /tmp && sha256sum -c "${TARBALL}.sha256sum") \
+    && tar -xzf "/tmp/${TARBALL}" -C /tmp \
+    && install -m 0755 "/tmp/linux-${ARCH}/helm" /usr/local/bin/helm \
+    && rm -rf "/tmp/${TARBALL}" "/tmp/${TARBALL}.sha256sum" "/tmp/linux-${ARCH}" \
+    && helm version --short
+
+# kubectl — same pinned version + published-checksum pattern as devlaptop.
+# renovate: datasource=github-releases depName=kubernetes/kubernetes
+ARG KUBECTL_VERSION=v1.31.4
+RUN ARCH=$(dpkg --print-architecture) \
+    && curl -fsSLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" \
+    && curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256" -o kubectl.sha256 \
+    && echo "$(cat kubectl.sha256)  kubectl" | sha256sum -c - \
+    && install -m 0755 kubectl /usr/local/bin/kubectl \
+    && rm -f kubectl kubectl.sha256 \
+    && kubectl version --client=true --output=yaml >/dev/null
+
+# Run as a non-root user. The Job exports HOME=/tmp and clones/deploys entirely
+# under /tmp (1777), so an unprivileged uid is sufficient — and it keeps this
+# image inside the provisioner ValidatingAdmissionPolicy's non-root expectation.
+RUN useradd -u 65532 -m -s /usr/sbin/nologin provisioner
+USER 65532
+ENV HOME=/tmp
+WORKDIR /tmp

--- a/renovate.json
+++ b/renovate.json
@@ -17,8 +17,8 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Pinned CLI/tool versions declared as ARG *_VERSION in the devlaptop image, annotated with a `# renovate:` datasource hint on the preceding line.",
-      "managerFilePatterns": ["devlaptop/Dockerfile"],
+      "description": "Pinned CLI/tool versions declared as ARG *_VERSION in the devlaptop and provisioner images, annotated with a `# renovate:` datasource hint on the preceding line.",
+      "managerFilePatterns": ["devlaptop/Dockerfile", "provisioner/Dockerfile"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( versioning=(?<versioning>\\S+))?\\nARG \\S+=(?<currentValue>\\S+)"
       ]
@@ -40,8 +40,8 @@
   ],
   "packageRules": [
     {
-      "description": "Group the devlaptop image CLI/tool bumps into one weekly PR.",
-      "matchFileNames": ["devlaptop/Dockerfile"],
+      "description": "Group the devlaptop + provisioner image CLI/tool bumps into one weekly PR.",
+      "matchFileNames": ["devlaptop/Dockerfile", "provisioner/Dockerfile"],
       "groupName": "devlaptop CLI tools"
     },
     {


### PR DESCRIPTION
… provisioner image

Follow-up to security-review finding 7 (after #420), closing the two remaining supply-chain gaps.

Gap 1 — installer integrity in devlaptop/Dockerfile. Every artifact that was version-pinned but not checksum-verified now does download -> verify -> install and fails the build on mismatch:
  - NodeSource: replaced `curl | bash` with the GPG keyring + signed-by apt source (apt now verifies every package; no piping to a root shell).
  - code-server: verify the .deb against a per-arch pinned sha256.
  - ttyd: verify against the release SHA256SUMS.
  - sqlite-vec: verify against checksums.txt (handles its reversed layout); no more `curl | tar`.
  - librefang: verify against the per-asset .sha256 sidecar before unpacking.
  - Ante: verify the tarball against the pinned manifest.json sha256; drops the `curl | bash` installer entirely. Antigravity (agy) is documented as the sole accepted exception — it ships only a curl|bash installer resolving "latest" with no versioned URL or checksum.

Gap 2 — the privileged provisioner path.
  - New provisioner/Dockerfile: a minimal image with helm+kubectl+git+make baked in and checksum-verified at build time, so provisioning performs no runtime tool downloads. controller.py stops installing helm at runtime and fails closed if a tool is missing instead of reaching out to the network under the cluster-privileged provisioner ServiceAccount.
  - release.yml builds the provisioner image alongside devlaptop from one matrix, so it is keyless-cosign signed + SBOM/provenance attested identically.
  - The provisioner ValidatingAdmissionPolicy now requires the image be pinned by digest (repo@sha256:), on by default via admissionPolicy.requireDigest.
  - New opt-in provisioner-image-policy.yaml verifies the image signature at admission via Kyverno (default) or Sigstore policy-controller, gated behind admissionPolicy.verifyImageSignature with a configurable keyless identity.

Also: extend the Renovate custom manager + grouping to track provisioner/Dockerfile pins, and document all of the above in docs/SUPPLY_CHAIN.md.

Tests: controller unit tests updated to assert no runtime helm download and fail-closed tool checks; new helm-unittest suites cover the digest requirement and both signature engines. Verified locally by building the provisioner image (tools present, runs non-root) and confirming a bad checksum fails the build.