### PR TITLE
feat(metrics): add product metrics — chats, tokens, skills, memory re…

### DIFF
--- a/charts/workspace/hypervisor_session.py
+++ b/charts/workspace/hypervisor_session.py
@@ -538,6 +538,21 @@ class ClaudeAdapter(Adapter):
         if t == 'result':
             if o.get('session_id'):
                 ctx['claude_session_id'] = o['session_id']
+            # Product metrics (#363): the terminal `result` event carries the
+            # turn's authoritative cumulative token usage. Stash it on ctx so the
+            # runner's finalize can fold it into the thread's running total —
+            # this is the ONLY place token usage is exposed, and it's per-turn
+            # cumulative (not per-chunk), so no double counting. Any adapter may
+            # set ctx['_turn_usage'] = {'input': int, 'output': int}; only Claude
+            # reports it today, others simply contribute 0.
+            usage = o.get('usage')
+            if isinstance(usage, dict):
+                ctx['_turn_usage'] = {
+                    'input': (int(usage.get('input_tokens') or 0)
+                              + int(usage.get('cache_read_input_tokens') or 0)
+                              + int(usage.get('cache_creation_input_tokens') or 0)),
+                    'output': int(usage.get('output_tokens') or 0),
+                }
             if o.get('subtype') not in (None, 'success'):
                 raw = _stringify(o.get('result') or o.get('subtype'))
                 out.append({'role': 'system', 'type': 'error',
@@ -1442,6 +1457,19 @@ def _notify_turn_complete(thread_id: str) -> None:
             _log(f'turn observer error: {type(e).__name__}: {e}')
 
 
+# Product metrics (#363): a leading `/name` is the composer's convention for
+# invoking a skill / custom slash command (the `/` picker lists exactly these).
+# The `(?=\s|$)` boundary keeps a bare filesystem path like `/home/dev/x` from
+# being mistaken for a command.
+_SLASH_CMD_RE = re.compile(r'^/([a-z0-9][a-z0-9-]*)(?=\s|$)')
+
+
+def _slash_command_name(text: str) -> Optional[str]:
+    """The skill/slash-command name a user turn invokes, or None."""
+    m = _SLASH_CMD_RE.match((text or '').strip())
+    return m.group(1) if m else None
+
+
 class HypervisorSession:
     def __init__(self, thread_id: str):
         self.id = thread_id
@@ -1531,6 +1559,52 @@ class HypervisorSession:
         key = 'deleted_at' if only_deleted else 'updated_at'
         out.sort(key=lambda t: t.get(key) or 0, reverse=True)
         return out
+
+    @classmethod
+    def product_totals(cls) -> Dict[str, Any]:
+        """Aggregate per-thread product metrics (#363) across live (non-deleted)
+        threads: chat counts, token usage, and skill invocations. Reads only the
+        small thread.json metas — never the big events.jsonl — so it stays cheap
+        enough for every /metrics poll. Memory recalls live in the memory store,
+        not threads, and are joined in by the caller.
+
+        chats.active counts threads with a turn ACTUALLY running now (the live
+        _RUNNING registry, via is_turn_live), not meta['status'] which can stick
+        at 'running' after a crash. tokens.per_session_avg divides by the number
+        of threads that reported any usage, so adapters that report none don't
+        dilute the average."""
+        total = active = 0
+        tok_input = tok_output = token_sessions = 0
+        skills: Dict[str, int] = {}
+        if os.path.isdir(HYPERVISOR_DIR):
+            for tid in os.listdir(HYPERVISOR_DIR):
+                s = cls.get(tid)
+                if not s:
+                    continue
+                m = s.read_meta()
+                if not m or m.get('deleted_at') is not None:
+                    continue
+                total += 1
+                if cls.is_turn_live(tid):
+                    active += 1
+                prod = m.get('product') or {}
+                tok = prod.get('tokens') or {}
+                ti = int(tok.get('input', 0) or 0)
+                to = int(tok.get('output', 0) or 0)
+                if ti or to:
+                    tok_input += ti
+                    tok_output += to
+                    token_sessions += 1
+                for name, count in (prod.get('skills') or {}).items():
+                    skills[name] = skills.get(name, 0) + int(count or 0)
+        tok_total = tok_input + tok_output
+        per_session_avg = int(round(tok_total / token_sessions)) if token_sessions else 0
+        return {
+            'chats': {'total': total, 'active': active},
+            'tokens': {'total': tok_total, 'input': tok_input,
+                       'output': tok_output, 'per_session_avg': per_session_avg},
+            'skills': {'invocations_by_name': skills},
+        }
 
     def delete(self) -> None:
         """Soft-delete: stamp ``deleted_at`` so the thread drops out of the
@@ -1815,6 +1889,14 @@ class HypervisorSession:
                 and meta.get('title', 'New chat') in ('New chat', '')):
             meta['title'] = text[:80]
         self._append([{'role': 'user', 'type': 'message', 'text': text}])
+        # Product metrics (#363): count a slash-command turn as a skill
+        # invocation, keyed by name, in the thread's own metadata (folded into
+        # the write below — no extra I/O). Aggregated across threads by
+        # product_totals().
+        skill = _slash_command_name(text)
+        if skill:
+            skills = meta.setdefault('product', {}).setdefault('skills', {})
+            skills[skill] = int(skills.get(skill, 0)) + 1
         meta['status'] = 'running'
         self._write_meta(meta)
         with _RUNLOCK:
@@ -2062,6 +2144,18 @@ class HypervisorSession:
                 self._append([{'role': 'system', 'type': 'message',
                                'text': '⏹ Stopped by user.'}])
             m = self.read_meta() or meta
+            # Product metrics (#363): fold this turn's token usage into the
+            # thread's running total before persisting. The adapter stashes a
+            # per-turn cumulative {'input','output'} on ctx (Claude only, today);
+            # `turns` counts only turns that actually reported usage, so the
+            # per-session average isn't diluted by adapters that report none.
+            usage = ctx.pop('_turn_usage', None)
+            if isinstance(usage, dict):
+                prod = m.setdefault('product', {})
+                tok = prod.setdefault('tokens', {'input': 0, 'output': 0})
+                tok['input'] = int(tok.get('input', 0)) + int(usage.get('input', 0))
+                tok['output'] = int(tok.get('output', 0)) + int(usage.get('output', 0))
+                prod['turns'] = int(prod.get('turns', 0)) + 1
             m['adapter'] = ctx  # persist any session id the adapter captured
             m['status'] = 'idle'
             self._write_meta(m)

--- a/charts/workspace/memory/manager.py
+++ b/charts/workspace/memory/manager.py
@@ -422,6 +422,30 @@ class MemoryManager:
             ).fetchall()
         return [dict(r) for r in rows]
 
+    @classmethod
+    def recall_counts(cls, *, limit: int = 10) -> List[Dict[str, Any]]:
+        """Most-recalled memories (product metrics #363). Every memory carries a
+        maintained ``access_count`` bumped on each read (see log_ref), so this is
+        a cheap top-N query — no scanning of the (capped) ref-log. Returns
+        [{namespace, key, count, last_accessed_at}] ordered by recall count,
+        most-recent access as the tiebreak. Never raises — a metrics read must
+        not perturb the app."""
+        limit = max(1, min(int(limit), 100))
+        try:
+            with cls.store().conn() as c:
+                rows = c.execute(
+                    'SELECT namespace, key, access_count, last_accessed_at '
+                    '  FROM memories '
+                    ' WHERE deleted_at IS NULL AND access_count > 0 '
+                    ' ORDER BY access_count DESC, last_accessed_at DESC LIMIT ?',
+                    (limit,),
+                ).fetchall()
+            return [{'namespace': r['namespace'], 'key': r['key'],
+                     'count': int(r['access_count'] or 0),
+                     'last_accessed_at': r['last_accessed_at']} for r in rows]
+        except sqlite3.Error:
+            return []
+
     # ── Search (Phase 1: FTS + scoring) ───────────────────────────────────
 
     @classmethod

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -975,7 +975,54 @@ class MetricsCollector:
             'memory': memory,
             'disk': disk,
             'alerts': alerts,
-            'timestamp': time.time()
+            'timestamp': time.time(),
+            # Product-usage metrics (#363) — a SEPARATE section from the system
+            # cpu/memory/disk above. NB: this 'product.memory' is the knowledge
+            # store's recall counts, NOT RAM (which is the top-level 'memory').
+            'product': ProductMetricsCollector.get_product_metrics(),
+        }
+
+
+class ProductMetricsCollector:
+    """Product-usage metrics (#363): chat counts, token usage, skill
+    invocations, and memory-store recall counts — how the product is *used*,
+    as opposed to MetricsCollector's system health (CPU/RAM/disk).
+
+    Deliberately a separate collector/section so 'memory' (the knowledge store)
+    is never conflated with 'memory' (RAM). Every source is optional and
+    failure-isolated: a missing subsystem or a read error degrades that one
+    section to zeros/empty rather than failing the whole /metrics response."""
+
+    RECALL_TOP_N = 10
+
+    @staticmethod
+    def get_product_metrics():
+        # chats / tokens / skills are aggregated from the hypervisor thread
+        # metadata (cheap thread.json reads); memory recalls come from the
+        # memory store's maintained access counters.
+        chats = {'total': 0, 'active': 0}
+        tokens = {'total': 0, 'input': 0, 'output': 0, 'per_session_avg': 0}
+        skills = {'invocations_by_name': {}}
+        if HypervisorSession is not None:
+            try:
+                totals = HypervisorSession.product_totals()
+                chats = totals.get('chats', chats)
+                tokens = totals.get('tokens', tokens)
+                skills = totals.get('skills', skills)
+            except Exception as e:  # never let one section 500 the endpoint
+                chats = {**chats, 'error': str(e)}
+        memory = {'recall_count_by_key': []}
+        if MemoryManager is not None:
+            try:
+                memory = {'recall_count_by_key': MemoryManager.recall_counts(
+                    limit=ProductMetricsCollector.RECALL_TOP_N)}
+            except Exception as e:
+                memory = {'recall_count_by_key': [], 'error': str(e)}
+        return {
+            'chats': chats,
+            'tokens': tokens,
+            'skills': skills,
+            'memory': memory,
         }
 
 

--- a/charts/workspace/tests/hypervisor_session_test.py
+++ b/charts/workspace/tests/hypervisor_session_test.py
@@ -1602,5 +1602,97 @@ class WatcherRestartTest(WatcherTestBase):
         self.assertIn('[Hypervisor watcher fired]', delivered[0][1])
 
 
+class SlashCommandNameTest(unittest.TestCase):
+    """Product metrics (#363): only a leading `/name` (with a word boundary)
+    counts as a skill invocation — never a bare filesystem path."""
+
+    def test_detects_command(self):
+        self.assertEqual(hs._slash_command_name('/deploy the app'), 'deploy')
+        self.assertEqual(hs._slash_command_name('/kc-preflight'), 'kc-preflight')
+        self.assertEqual(hs._slash_command_name('  /graphify  '), 'graphify')
+
+    def test_rejects_non_commands(self):
+        for t in ('/home/dev/x', 'hello /deploy', '/', '', 'no slash', '/ leading space'):
+            self.assertIsNone(hs._slash_command_name(t), t)
+
+
+class ClaudeAdapterUsageCaptureTest(unittest.TestCase):
+    """The terminal `result` event's usage is stashed on ctx for the runner to
+    fold into the thread's token total (#363)."""
+
+    def test_result_usage_captured_on_ctx(self):
+        a = hs.ClaudeAdapter()
+        ctx = {}
+        line = json.dumps({'type': 'result', 'subtype': 'success',
+                           'usage': {'input_tokens': 10, 'output_tokens': 7,
+                                     'cache_read_input_tokens': 5,
+                                     'cache_creation_input_tokens': 2}})
+        a.parse(ctx, line)
+        self.assertEqual(ctx['_turn_usage'], {'input': 17, 'output': 7})
+
+    def test_result_without_usage_sets_nothing(self):
+        a = hs.ClaudeAdapter()
+        ctx = {}
+        a.parse(ctx, json.dumps({'type': 'result', 'subtype': 'success'}))
+        self.assertNotIn('_turn_usage', ctx)
+
+
+class ProductTotalsTest(unittest.TestCase):
+    """Aggregation over thread.json metas (#363)."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self._orig_dir = hs.HYPERVISOR_DIR
+        hs.HYPERVISOR_DIR = self.tmp
+        # No live turns by default.
+        self._running_patch = mock.patch.object(
+            hs.HypervisorSession, 'is_turn_live', staticmethod(lambda tid: False))
+        self._running_patch.start()
+
+    def tearDown(self):
+        self._running_patch.stop()
+        hs.HYPERVISOR_DIR = self._orig_dir
+
+    def _thread(self, tid, meta):
+        os.makedirs(os.path.join(self.tmp, tid))
+        with open(os.path.join(self.tmp, tid, 'thread.json'), 'w') as f:
+            json.dump(meta, f)
+
+    def test_empty_dir_is_all_zero(self):
+        t = hs.HypervisorSession.product_totals()
+        self.assertEqual(t['chats'], {'total': 0, 'active': 0})
+        self.assertEqual(t['tokens']['total'], 0)
+        self.assertEqual(t['tokens']['per_session_avg'], 0)
+        self.assertEqual(t['skills']['invocations_by_name'], {})
+
+    def test_aggregates_tokens_skills_and_excludes_deleted(self):
+        self._thread('t1', {'id': 't1', 'product': {
+            'tokens': {'input': 100, 'output': 50}, 'turns': 2,
+            'skills': {'deploy': 3, 'graphify': 1}}})
+        self._thread('t2', {'id': 't2', 'product': {
+            'tokens': {'input': 20, 'output': 30}, 'turns': 1,
+            'skills': {'deploy': 2}}})
+        self._thread('t3', {'id': 't3'})  # no product data
+        self._thread('t4', {'id': 't4', 'deleted_at': 123,
+                            'product': {'tokens': {'input': 999, 'output': 999}}})
+        t = hs.HypervisorSession.product_totals()
+        self.assertEqual(t['chats']['total'], 3)          # t4 excluded
+        self.assertEqual(t['tokens']['total'], 200)       # 150 + 50
+        # avg over the 2 threads that reported usage, not all 3.
+        self.assertEqual(t['tokens']['per_session_avg'], 100)
+        self.assertEqual(t['skills']['invocations_by_name'],
+                         {'deploy': 5, 'graphify': 1})
+
+    def test_active_counts_only_live_turns(self):
+        self._thread('t1', {'id': 't1'})
+        self._thread('t2', {'id': 't2'})
+        self._running_patch.stop()
+        with mock.patch.object(hs.HypervisorSession, 'is_turn_live',
+                               staticmethod(lambda tid: tid == 't2')):
+            t = hs.HypervisorSession.product_totals()
+        self._running_patch.start()  # keep tearDown symmetric
+        self.assertEqual(t['chats'], {'total': 2, 'active': 1})
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/charts/workspace/tests/memory_lifecycle_test.py
+++ b/charts/workspace/tests/memory_lifecycle_test.py
@@ -261,5 +261,51 @@ class ExportImportTests(LifecycleTestCase):
             MemoryManager.import_json({'memories': []}, mode='nope')
 
 
+# ───────────────────────────────────────────────────────────────────────────
+# Recall counts (product metrics #363)
+# ───────────────────────────────────────────────────────────────────────────
+
+class RecallCountsTests(LifecycleTestCase):
+    def setUp(self):
+        super().setUp()
+        MemoryManager.upsert(namespace='proj', key='alpha', value='a')
+        MemoryManager.upsert(namespace='proj', key='beta', value='b')
+        MemoryManager.upsert(namespace='proj', key='never', value='n')
+
+    def _recall(self, ns, key, n=1):
+        for _ in range(n):
+            MemoryManager.log_ref(namespace=ns, key=key, ref_kind='api',
+                                  ref_id='t', access_kind='read')
+
+    def test_ranks_by_access_count_desc(self):
+        self._recall('proj', 'alpha', 3)
+        self._recall('proj', 'beta', 1)
+        rc = MemoryManager.recall_counts(limit=10)
+        self.assertEqual(
+            [(r['namespace'], r['key'], r['count']) for r in rc],
+            [('proj', 'alpha', 3), ('proj', 'beta', 1)])
+
+    def test_excludes_never_recalled(self):
+        self._recall('proj', 'alpha', 1)
+        keys = {r['key'] for r in MemoryManager.recall_counts()}
+        self.assertIn('alpha', keys)
+        self.assertNotIn('never', keys)  # access_count == 0 is excluded
+
+    def test_excludes_soft_deleted(self):
+        self._recall('proj', 'alpha', 2)
+        MemoryManager.soft_delete(namespace='proj', key='alpha')
+        self.assertEqual(MemoryManager.recall_counts(), [])
+
+    def test_limit_caps_results(self):
+        self._recall('proj', 'alpha', 5)
+        self._recall('proj', 'beta', 4)
+        rc = MemoryManager.recall_counts(limit=1)
+        self.assertEqual(len(rc), 1)
+        self.assertEqual(rc[0]['key'], 'alpha')
+
+    def test_empty_when_no_recalls(self):
+        self.assertEqual(MemoryManager.recall_counts(), [])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/charts/workspace/tests/server_test.py
+++ b/charts/workspace/tests/server_test.py
@@ -2028,5 +2028,60 @@ class DetectUserTests(unittest.TestCase):
             self.assertEqual(server.CronManager.detect_user(), 'imran')
 
 
+class ProductMetricsCollectorTest(unittest.TestCase):
+    """Product metrics (#363): a section separate from the system cpu/mem/disk,
+    merging hypervisor-derived chats/tokens/skills with memory-store recalls.
+    Each source is failure-isolated so /metrics never 500s."""
+
+    def test_merges_hypervisor_and_memory_sources(self):
+        totals = {'chats': {'total': 2, 'active': 1},
+                  'tokens': {'total': 300, 'input': 200, 'output': 100,
+                             'per_session_avg': 150},
+                  'skills': {'invocations_by_name': {'deploy': 4}}}
+        recalls = [{'namespace': 'proj', 'key': 'alpha', 'count': 5,
+                    'last_accessed_at': 1}]
+        with mock.patch.object(server.HypervisorSession, 'product_totals',
+                               return_value=totals), \
+             mock.patch.object(server.MemoryManager, 'recall_counts',
+                               return_value=recalls):
+            p = server.ProductMetricsCollector.get_product_metrics()
+        self.assertEqual(p['chats'], totals['chats'])
+        self.assertEqual(p['tokens'], totals['tokens'])
+        self.assertEqual(p['skills'], totals['skills'])
+        self.assertEqual(p['memory'], {'recall_count_by_key': recalls})
+
+    def test_hypervisor_error_isolated_from_memory(self):
+        recalls = [{'namespace': 'p', 'key': 'k', 'count': 1,
+                    'last_accessed_at': 0}]
+        with mock.patch.object(server.HypervisorSession, 'product_totals',
+                               side_effect=RuntimeError('boom')), \
+             mock.patch.object(server.MemoryManager, 'recall_counts',
+                               return_value=recalls):
+            p = server.ProductMetricsCollector.get_product_metrics()
+        self.assertIn('error', p['chats'])          # degraded, flagged
+        self.assertEqual(p['chats']['total'], 0)
+        self.assertEqual(p['memory']['recall_count_by_key'], recalls)  # unaffected
+
+    def test_missing_subsystems_degrade_to_zero(self):
+        with mock.patch.object(server, 'HypervisorSession', None), \
+             mock.patch.object(server, 'MemoryManager', None):
+            p = server.ProductMetricsCollector.get_product_metrics()
+        self.assertEqual(p['chats'], {'total': 0, 'active': 0})
+        self.assertEqual(p['tokens']['total'], 0)
+        self.assertEqual(p['skills']['invocations_by_name'], {})
+        self.assertEqual(p['memory']['recall_count_by_key'], [])
+
+    def test_get_all_metrics_carries_separate_product_section(self):
+        with mock.patch.object(
+                server.ProductMetricsCollector, 'get_product_metrics',
+                return_value={'chats': {}, 'tokens': {}, 'skills': {},
+                              'memory': {}}):
+            m = server.MetricsCollector.get_all_metrics()
+        for k in ('cpu', 'memory', 'disk', 'alerts', 'product'):
+            self.assertIn(k, m)
+        # 'memory' (RAM) and 'product' (usage) stay distinct top-level keys.
+        self.assertIsNot(m['memory'], m['product'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/charts/workspace/web/src/api/metrics.ts
+++ b/charts/workspace/web/src/api/metrics.ts
@@ -36,12 +36,54 @@ export interface MetricsAlert {
   message: string;
 }
 
+/**
+ * Product-usage metrics (#363) — how the product is *used*, distinct from the
+ * system cpu/memory/disk above. NB: `ProductMetrics.memory` is the knowledge
+ * store's recall counts, NOT RAM (that's `SystemMetrics.memory`). All fields are
+ * optional/defaulted so an older pod that omits `product` degrades gracefully.
+ */
+export interface ChatMetrics {
+  total: number;
+  active: number;
+}
+
+export interface TokenMetrics {
+  total: number;
+  input: number;
+  output: number;
+  per_session_avg: number;
+}
+
+export interface SkillMetrics {
+  invocations_by_name: Record<string, number>;
+}
+
+export interface MemoryRecall {
+  namespace: string;
+  key: string;
+  count: number;
+  last_accessed_at?: number | null;
+}
+
+export interface ProductMemoryMetrics {
+  recall_count_by_key: MemoryRecall[];
+}
+
+export interface ProductMetrics {
+  chats: ChatMetrics;
+  tokens: TokenMetrics;
+  skills: SkillMetrics;
+  memory: ProductMemoryMetrics;
+}
+
 export interface SystemMetrics {
   cpu: CpuMetrics;
   memory: MemoryMetrics;
   disk: DiskMetrics;
   alerts: MetricsAlert[];
   timestamp: number;
+  // Present on pods running the #363 build; older pods omit it.
+  product?: ProductMetrics;
 }
 
 export interface HealthService {

--- a/charts/workspace/web/src/routes/settings/MetricsSection.test.tsx
+++ b/charts/workspace/web/src/routes/settings/MetricsSection.test.tsx
@@ -107,3 +107,71 @@ describe('MetricsSection', () => {
     expect(screen.getByText('No builds or chats are running right now.')).toBeInTheDocument();
   });
 });
+
+// Product usage card (#363).
+const PRODUCT = {
+  chats: { total: 14, active: 2 },
+  tokens: { total: 1284500, input: 900000, output: 384500, per_session_avg: 107042 },
+  skills: { invocations_by_name: { 'kc-preflight': 9, graphify: 6, worktree: 3 } },
+  memory: {
+    recall_count_by_key: [
+      { namespace: 'project.kube-coder', key: 'first-win-gap-map', count: 23 },
+      { namespace: 'user', key: 'pronouns', count: 11 },
+    ],
+  },
+};
+
+function sys(over: Record<string, unknown> = {}) {
+  return {
+    cpu: { usage_percent: 12, cores: 8 },
+    memory: { total_mb: 16000, used_mb: 6400, available_mb: 9600, percent: 40 },
+    disk: { total_gb: 100, used_gb: 38, available_gb: 62, percent: 38, path: '/home/dev' },
+    alerts: [],
+    timestamp: 0,
+    ...over,
+  };
+}
+
+describe('MetricsSection — Product usage card (#363)', () => {
+  beforeEach(() => {
+    apps = [];
+    tasks.value = [];
+    health.value = null;
+    serverMode.value = { readOnly: false, authed: true, authMode: 'basic', demoShowAll: false };
+  });
+
+  it('renders chats, top skills, and most-recalled memory', () => {
+    metrics.value = sys({ product: PRODUCT }) as never;
+    render(<MetricsSection />);
+    expect(screen.getByText('Product usage')).toBeInTheDocument();
+    expect(screen.getByText('14')).toBeInTheDocument();          // chats total
+    expect(screen.getByText(/2 active/)).toBeInTheDocument();
+    // Highest-count skill first, rendered with the slash prefix.
+    expect(screen.getByText('/kc-preflight')).toBeInTheDocument();
+    expect(screen.getByText('project.kube-coder/first-win-gap-map')).toBeInTheDocument();
+    // 'memory' here is explicitly the knowledge store, not RAM.
+    expect(document.body.innerHTML).toContain('knowledge store');
+  });
+
+  it('is absent when the pod omits product (backward compatible)', () => {
+    metrics.value = sys() as never;   // no product key
+    render(<MetricsSection />);
+    expect(screen.queryByText('Product usage')).not.toBeInTheDocument();
+    expect(screen.getByText('System metrics')).toBeInTheDocument();
+  });
+
+  it('shows empty states when product data is all zero/empty', () => {
+    metrics.value = sys({
+      product: {
+        chats: { total: 0, active: 0 },
+        tokens: { total: 0, input: 0, output: 0, per_session_avg: 0 },
+        skills: { invocations_by_name: {} },
+        memory: { recall_count_by_key: [] },
+      },
+    }) as never;
+    render(<MetricsSection />);
+    expect(screen.getByText('Product usage')).toBeInTheDocument();
+    expect(screen.getByText('No skill invocations yet.')).toBeInTheDocument();
+    expect(screen.getByText('No memory recalls yet.')).toBeInTheDocument();
+  });
+});

--- a/charts/workspace/web/src/routes/settings/MetricsSection.tsx
+++ b/charts/workspace/web/src/routes/settings/MetricsSection.tsx
@@ -186,6 +186,76 @@ function PortsBlock() {
   );
 }
 
+// Product-usage metrics (#363): chat/session counts, token usage, favourite
+// skills, and most-recalled memory. Renders nothing on an older pod whose
+// /metrics omits `product`, so the section degrades gracefully.
+function ProductUsageBlock() {
+  const p = metrics.value?.product;
+  if (!p) return null;
+  const num = (n: number) => (n ?? 0).toLocaleString();
+  const skills = Object.entries(p.skills?.invocations_by_name ?? {})
+    .sort((a, b) => b[1] - a[1]);
+  const recalls = p.memory?.recall_count_by_key ?? [];
+  const chats = p.chats ?? { total: 0, active: 0 };
+  const tokens = p.tokens ?? { total: 0, per_session_avg: 0, input: 0, output: 0 };
+  return (
+    <div class="metrics-running">
+      <div class="metrics-running-head">
+        <h3 class="metrics-running-title">Product usage</h3>
+        <InfoHint text="How this workspace is used: chat/session counts, token usage, which skills get invoked, and which memories get recalled most. Note: this 'memory' is the knowledge store — not RAM." />
+      </div>
+      <div class="product-stats">
+        <div class="product-stat">
+          <span class="product-stat-value mono">{num(chats.total)}</span>
+          <span class="product-stat-label muted">chats <span class="mono">({num(chats.active)} active)</span></span>
+        </div>
+        <div class="product-stat">
+          <span class="product-stat-value mono">{num(tokens.per_session_avg)}</span>
+          <span class="product-stat-label muted">avg tokens / session</span>
+        </div>
+        <div class="product-stat">
+          <span class="product-stat-value mono">{num(tokens.total)}</span>
+          <span class="product-stat-label muted">tokens total</span>
+        </div>
+      </div>
+      <div class="product-cols">
+        <div class="product-col">
+          <div class="product-col-head muted">Top skills</div>
+          {skills.length === 0 ? (
+            <div class="metrics-empty muted">No skill invocations yet.</div>
+          ) : (
+            <ul class="metrics-list">
+              {skills.slice(0, 8).map(([name, count]) => (
+                <li key={name} class="metrics-item">
+                  <span class="metrics-item-label mono" title={name}>/{name}</span>
+                  <Pill tone="neutral" mono>{num(count)}</Pill>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div class="product-col">
+          <div class="product-col-head muted">Most-recalled memory</div>
+          {recalls.length === 0 ? (
+            <div class="metrics-empty muted">No memory recalls yet.</div>
+          ) : (
+            <ul class="metrics-list">
+              {recalls.slice(0, 8).map((r) => (
+                <li key={`${r.namespace}/${r.key}`} class="metrics-item">
+                  <span class="metrics-item-label mono" title={`${r.namespace}/${r.key}`}>
+                    {r.namespace}/{r.key}
+                  </span>
+                  <Pill tone="neutral" mono>{num(r.count)}</Pill>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function MetricsSection() {
   useEffect(() => {
     startMetricsPolling(10000);
@@ -262,6 +332,8 @@ export function MetricsSection() {
           </div>
         </>
       )}
+
+      <ProductUsageBlock />
 
       <RunningTasksBlock />
       <PortsBlock />

--- a/charts/workspace/web/src/routes/settings/settings.css
+++ b/charts/workspace/web/src/routes/settings/settings.css
@@ -371,6 +371,36 @@
   min-width: 0;
 }
 .metrics-item-meta { font-size: 11px; flex: 0 0 auto; }
+
+/* Product usage (#363) — stat tiles + two side-by-side lists. */
+.product-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--size-2);
+  margin-bottom: var(--size-3);
+}
+.product-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  min-width: 0;
+}
+.product-stat-value { font-size: 20px; font-weight: 600; line-height: 1.15; }
+.product-stat-label { font-size: 11.5px; }
+.product-cols { display: grid; grid-template-columns: 1fr; gap: var(--size-3); }
+@media (min-width: 560px) {
+  .product-cols { grid-template-columns: 1fr 1fr; }
+}
+.product-col-head {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+}
 .metrics-item-actions {
   display: flex;
   align-items: center;

--- a/charts/workspace/web/src/store/metrics.test.ts
+++ b/charts/workspace/web/src/store/metrics.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SystemMetrics } from '../api/metrics';
+
+// Drive fetchMetrics from a per-test value; health is a constant stub.
+let metricsResult: () => SystemMetrics;
+vi.mock('../api/metrics', () => ({
+  fetchMetrics: () => Promise.resolve(metricsResult()),
+  fetchHealth: () =>
+    Promise.resolve({ status: 'healthy', services: {}, timestamp: 0 }),
+}));
+
+import { metrics, refreshMetrics } from './metrics';
+
+const SYSTEM: SystemMetrics = {
+  cpu: { usage_percent: 1, cores: 4 },
+  memory: { total_mb: 100, used_mb: 40, available_mb: 60, percent: 40 },
+  disk: { total_gb: 10, used_gb: 4, available_gb: 6, percent: 40, path: '/home/dev' },
+  alerts: [],
+  timestamp: 0,
+};
+
+describe('metrics store — product section (#363)', () => {
+  beforeEach(() => {
+    metrics.value = null;
+  });
+
+  it('carries the product usage section through to the signal', async () => {
+    metricsResult = () => ({
+      ...SYSTEM,
+      product: {
+        chats: { total: 3, active: 1 },
+        tokens: { total: 100, input: 60, output: 40, per_session_avg: 50 },
+        skills: { invocations_by_name: { deploy: 2, graphify: 1 } },
+        memory: {
+          recall_count_by_key: [
+            { namespace: 'proj', key: 'alpha', count: 5, last_accessed_at: 1 },
+          ],
+        },
+      },
+    });
+    await refreshMetrics();
+    const p = metrics.value?.product;
+    expect(p?.chats).toEqual({ total: 3, active: 1 });
+    expect(p?.tokens.per_session_avg).toBe(50);
+    expect(p?.skills.invocations_by_name.deploy).toBe(2);
+    expect(p?.memory.recall_count_by_key[0].key).toBe('alpha');
+  });
+
+  it('tolerates a pod whose /metrics omits product (backward compat)', async () => {
+    metricsResult = () => ({ ...SYSTEM });
+    await refreshMetrics();
+    expect(metrics.value).not.toBeNull();
+    // The system section still lands; product is simply absent.
+    expect(metrics.value?.product).toBeUndefined();
+    expect(metrics.value?.cpu.cores).toBe(4);
+  });
+});


### PR DESCRIPTION
…calls

The /metrics endpoint only reported system health (CPU/RAM/disk). This adds a separate product-usage section answering "how is the product being used":

  product.chats  = {total, active}
  product.tokens = {total, input, output, per_session_avg}
  product.skills = {invocations_by_name}
  product.memory = {recall_count_by_key}   # the knowledge store, NOT RAM

Kept as a distinct top-level `product` key so the existing system cpu/memory/disk payload is untouched — and so 'memory' (RAM) is never conflated with the memory store's recall counts.

Where each signal comes from:
  - chats:  aggregated from hypervisor thread metadata; active = threads with a turn actually running (the live registry, not a possibly-stale meta status).
  - tokens: the Claude adapter's terminal `result` event carries per-turn token usage — previously dropped. It's now folded into the thread's running total at turn end. Adapters that report no usage contribute 0.
  - skills: a leading `/name` in a user turn (the composer's slash-command convention) is counted per thread, keyed by name.
  - memory: each memory already maintains an access_count bumped on every recall, so this is a cheap top-N query (MemoryManager.recall_counts).

Counters are captured into thread.json at turn completion, so building the metric only reads the small per-thread metas — never the large events.jsonl — keeping /metrics cheap on every poll. Each source is failure-isolated: a missing subsystem or read error degrades that one section to zeros/empty rather than failing the whole response.

Frontend: new ProductMetrics types (product is optional, so an older pod that omits it degrades gracefully) and a "Product usage" card in the Settings metrics view showing chats, average tokens/session, top skills, and most-recalled memory.

Tests: recall ranking/exclusions, slash-command detection, token-usage capture, cross-thread aggregation (deleted-thread exclusion + average math), collector merge + failure isolation, plus a render test of the card (populated, empty, and product-absent states).