### PR TITLE
feat(models): cross-assistant reasoning-effort selector (low/medium/h…

### DIFF
--- a/charts/workspace/harness.py
+++ b/charts/workspace/harness.py
@@ -426,15 +426,29 @@ def parse_xml_tool_calls(content: str):
 
 # ───────────────────────── HTTP to the LLM ─────────────────────────
 
+def pick_effort():
+    """Canonical reasoning effort for this run (#362), passed by the hypervisor
+    adapter as KC_EFFORT (already clamped to low/medium/high for this harness).
+    Empty when the user hasn't chosen one — we then omit the field so the model
+    keeps its own default."""
+    return (os.environ.get("KC_EFFORT") or "").strip().lower()
+
+
 def chat(messages, base_url, api_key, model):
-    body = json.dumps({
+    payload = {
         "model": model,
         "messages": messages,
         "tools": tools_schema(),
         "tool_choice": "auto",
         "stream": False,
         "temperature": 0.1,
-    }).encode()
+    }
+    # OpenAI-compatible reasoning control (#362). Ollama's /v1 endpoint and
+    # OpenAI-family models both honour `reasoning_effort`; harmless to omit.
+    effort = pick_effort()
+    if effort:
+        payload["reasoning_effort"] = effort
+    body = json.dumps(payload).encode()
     headers = {"Content-Type": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"

--- a/charts/workspace/hypervisor_session.py
+++ b/charts/workspace/hypervisor_session.py
@@ -216,6 +216,28 @@ def _expand_choices(partial: Dict[str, Any]) -> List[Dict[str, Any]]:
 # ───────────────────────────────────────────────────────────────────────────
 
 
+# ── Reasoning effort (#362) ─────────────────────────────────────────────────
+# Canonical 5-stop axis, ascending. Each assistant honours up to a native
+# ceiling; a higher pick clamps DOWN to that ceiling. Assistants absent from
+# EFFORT_CAP have no usable per-thread effort knob (nothing is injected).
+# NB: this cap table MUST mirror server.ClaudeTaskManager._EFFORT_CAP — a unit
+# test asserts the two stay in lockstep (they live in separate modules because
+# server imports this one, not vice-versa).
+EFFORT_LEVELS = ('low', 'medium', 'high', 'xhigh', 'max')
+EFFORT_CAP = {'claude': 'xhigh', 'codex': 'xhigh', 'kc-harness': 'high'}
+
+
+def native_effort(assistant: str, canonical: str) -> str:
+    """Map a per-thread canonical effort to the concrete level to hand
+    `assistant`'s CLI, clamped to its native ceiling. Returns '' when the
+    assistant has no knob or the level is unset/unknown (inject nothing)."""
+    lvl = (canonical or '').strip().lower()
+    cap = EFFORT_CAP.get(assistant, '')
+    if not cap or lvl not in EFFORT_LEVELS:
+        return ''
+    return cap if EFFORT_LEVELS.index(lvl) > EFFORT_LEVELS.index(cap) else lvl
+
+
 class Adapter:
     kind = 'base'
 
@@ -507,6 +529,13 @@ class ClaudeAdapter(Adapter):
         env = {k: v for k, v in os.environ.items()
                if k not in ('ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN')}
         env['HOME'] = WORKSPACE_HOME
+        # Reasoning effort (#362): the env var is the cleanest delivery — no argv
+        # change, and it wins over --effort/settings.json. Read fresh each turn so
+        # a mid-session switch takes effect. Claude Code tops at xhigh, so `max`
+        # arrives here already clamped by native_effort.
+        eff = native_effort('claude', ctx.get('effort'))
+        if eff:
+            env['CLAUDE_CODE_EFFORT_LEVEL'] = eff
         return {'argv': argv, 'cwd': ctx.get('workdir') or WORKSPACE_HOME, 'env': env}
 
     def parse(self, ctx, line):
@@ -598,6 +627,13 @@ class FallbackAdapter(Adapter):
         env = dict(os.environ)
         env.update({'TERM': 'dumb', 'NO_COLOR': '1', 'CI': '1',
                     'HOME': WORKSPACE_HOME})
+        # Reasoning effort (#362): kc-harness talks an OpenAI-compatible endpoint,
+        # so harness.py forwards KC_EFFORT as the request's `reasoning_effort`.
+        # Gated on the assistant — the fallback adapter also serves knob-less CLIs
+        # (librefang), which get nothing. native_effort clamps xhigh/max → high.
+        eff = native_effort(ctx.get('assistant', ''), ctx.get('effort'))
+        if eff:
+            env['KC_EFFORT'] = eff
         return {'argv': ['bash', '-lc', cli_cmd],
                 'cwd': ctx.get('workdir') or WORKSPACE_HOME,
                 'env': env, 'stdin': stdin + '\n', 'timeout': FALLBACK_TURN_TIMEOUT,
@@ -865,6 +901,12 @@ class CodexAdapter(_StructuredCliAdapter):
         model = (ctx.get('model') or os.environ.get('KC_CODEX_MODEL', '')).strip()
         if model:
             opts += ['--model', model]
+        # Reasoning effort (#362): codex takes it as a `-c` config override. The
+        # value is a fixed enum (low/medium/high/xhigh — `max` clamps to xhigh),
+        # so it's injection-safe. Read fresh each turn for mid-session switching.
+        eff = native_effort('codex', ctx.get('effort'))
+        if eff:
+            opts += ['-c', f'model_reasoning_effort="{eff}"']
         return opts
 
     def build(self, ctx, text, first):
@@ -1488,7 +1530,7 @@ class HypervisorSession:
     def create(cls, assistant: str, workdir: str, cli_cmd: str,
                preamble: str = '', title: str = '',
                model: str = '', persona: str = '',
-               project_id: str = '') -> 'HypervisorSession':
+               project_id: str = '', effort: str = '') -> 'HypervisorSession':
         os.makedirs(HYPERVISOR_DIR, exist_ok=True)
         thread_id = f'{int(time.time())}-{uuid.uuid4().hex[:8]}'
         self = cls(thread_id)
@@ -1517,6 +1559,9 @@ class HypervisorSession:
                 'cli_cmd': cli_cmd,
                 'preamble': preamble,
                 'model': model or '',
+                # Per-thread reasoning effort (#362), canonical level. Read fresh
+                # each turn by the adapter and mapped to its CLI's native knob.
+                'effort': effort or '',
             },
         }
         self._write_meta(meta)
@@ -1733,6 +1778,20 @@ class HypervisorSession:
         self._write_meta(meta, touch=False)
         return self.summary(meta)
 
+    def set_effort(self, effort: str) -> Optional[Dict[str, Any]]:
+        """Switch the thread's reasoning effort (#362), twin of set_model. Stored
+        in the adapter ctx so the next turn's build() reads it; a running turn
+        already spawned keeps its effort. Left untouched (updated_at not bumped)
+        so a mid-session effort tweak doesn't reorder the chat list. Returns the
+        updated summary, or None if the thread is gone."""
+        meta = self.read_meta()
+        if meta is None:
+            return None
+        ctx = meta.setdefault('adapter', {})
+        ctx['effort'] = (effort or '').strip()
+        self._write_meta(meta, touch=False)
+        return self.summary(meta)
+
     def summary(self, meta: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         m = meta or self.read_meta() or {}
         return {
@@ -1742,6 +1801,9 @@ class HypervisorSession:
             # The per-thread model when the adapter honours one ('' otherwise),
             # so the switcher reflects a reopened thread's choice (#308).
             'model': (m.get('adapter') or {}).get('model') or '',
+            # Per-thread reasoning effort (#362), canonical level ('' when the
+            # assistant has no knob) — so a reopened thread reflects its choice.
+            'effort': (m.get('adapter') or {}).get('effort') or '',
             'status': self.status(),
             'created_at': m.get('created_at'),
             'updated_at': m.get('updated_at'),

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -1621,6 +1621,12 @@ class ClaudeTaskManager:
         # is the default.
         for a in out:
             a['models'] = ClaudeTaskManager.available_models(a['id'])
+            # Reasoning-effort axis (#362): the 5-stop list (empty → SPA hides
+            # the selector), the assistant's default, and its native ceiling so
+            # the UI can show an honest "runs <cap>" hint when a pick is clamped.
+            a['efforts'] = ClaudeTaskManager.available_efforts(a['id'])
+            a['effort'] = ClaudeTaskManager.default_effort(a['id'])
+            a['effortCap'] = ClaudeTaskManager.effort_cap(a['id'])
         return ClaudeTaskManager._apply_default_flag(out)
 
     @staticmethod
@@ -1727,6 +1733,104 @@ class ClaudeTaskManager:
         if requested and requested in models:
             return requested
         return models[0]
+
+    # ── Reasoning effort (#362) ──────────────────────────────────────────────
+    # A single canonical 5-stop axis surfaced identically for every assistant
+    # (stable labels), mapped per-assistant to each CLI's native knob. The
+    # concept replaces the deprecated raw thinking-token budget: current models
+    # expose `effort`, not a fixed token count.
+    _EFFORT_LEVELS = ('low', 'medium', 'high', 'xhigh', 'max')
+    _DEFAULT_EFFORT = 'high'
+
+    # assistant id → its native effort support, expressed as the TOP canonical
+    # level the assistant actually honours (its native set is [low..cap]). A pick
+    # above the cap clamps DOWN to it (resolve_native_effort). Assistants absent
+    # here have no usable per-thread effort knob and the selector stays hidden:
+    #   * opencode-*  — reasoningEffort is opencode.json-only (one shared file,
+    #                   racy per-turn) AND a silent no-op for Anthropic models
+    #                   over OpenRouter; no clean per-invocation override exists.
+    #   * ante        — no documented effort/reasoning surface (~/.ante/settings.json
+    #                   only carries mcp_servers).
+    #   * librefang / antigravity — no effort concept.
+    # Claude Code + Codex top out at native `xhigh` (raw APIs go to `max`, but the
+    # CLIs cap at xhigh), so `max` clamps to `xhigh`. kc-harness talks an
+    # OpenAI-compatible endpoint whose `reasoning_effort` tops at `high`, so both
+    # `xhigh` and `max` clamp to `high`.
+    _EFFORT_CAP = {
+        'claude': 'xhigh',
+        'codex': 'xhigh',
+        'kc-harness': 'high',
+    }
+
+    # assistant id → env var overriding its DEFAULT effort (helm
+    # assistant.<name>.effort → KC_*_EFFORT), mirroring _MODEL_LIST_ENV/KC_*_MODEL.
+    _EFFORT_DEFAULT_ENV = {
+        'claude': 'KC_CLAUDE_EFFORT',
+        'codex': 'KC_CODEX_EFFORT',
+        'kc-harness': 'KC_HARNESS_EFFORT',
+    }
+
+    @staticmethod
+    def _effort_supported(assistant):
+        return assistant in ClaudeTaskManager._EFFORT_CAP
+
+    @staticmethod
+    def effort_cap(assistant):
+        """Highest canonical level this assistant honours natively ('' when it
+        has no effort knob). Drives the SPA's 'runs <cap>' hint when a pick is
+        clamped."""
+        return ClaudeTaskManager._EFFORT_CAP.get(assistant, '')
+
+    @staticmethod
+    def available_efforts(assistant):
+        """Canonical levels to show for `assistant` — always the full 5-stop axis
+        (stable labels) when the assistant has ANY effort knob, else [] so the
+        SPA hides the selector (same pattern as assistants with no model list)."""
+        if not ClaudeTaskManager._effort_supported(assistant):
+            return []
+        return list(ClaudeTaskManager._EFFORT_LEVELS)
+
+    @staticmethod
+    def default_effort(assistant):
+        """The assistant's default canonical effort: an operator override
+        (KC_*_EFFORT, validated) else `high`. '' when the assistant has no knob."""
+        if not ClaudeTaskManager._effort_supported(assistant):
+            return ''
+        env_key = ClaudeTaskManager._EFFORT_DEFAULT_ENV.get(assistant)
+        override = (os.environ.get(env_key) or '').strip().lower() if env_key else ''
+        if override in ClaudeTaskManager._EFFORT_LEVELS:
+            return override
+        return ClaudeTaskManager._DEFAULT_EFFORT
+
+    @staticmethod
+    def resolve_effort(assistant, requested):
+        """Validate a requested CANONICAL effort against the 5-stop axis; fall
+        back to the assistant's default. Returns '' when the assistant has no
+        effort knob (selector hidden; webhooks/CLI callers are free-form so we
+        defend the boundary). Note this returns the canonical level as picked —
+        clamping to the assistant's native ceiling happens at injection time in
+        resolve_native_effort so the UI can still show the honest effective level."""
+        if not ClaudeTaskManager._effort_supported(assistant):
+            return ''
+        req = (requested or '').strip().lower()
+        if req in ClaudeTaskManager._EFFORT_LEVELS:
+            return req
+        return ClaudeTaskManager.default_effort(assistant)
+
+    @staticmethod
+    def resolve_native_effort(assistant, requested):
+        """The concrete level to hand the assistant's CLI: the resolved canonical
+        pick, clamped DOWN to the assistant's native ceiling (_EFFORT_CAP). E.g.
+        `max`→`xhigh` for claude/codex, `xhigh`/`max`→`high` for kc-harness.
+        Returns '' when the assistant has no effort knob (nothing injected)."""
+        level = ClaudeTaskManager.resolve_effort(assistant, requested)
+        if not level:
+            return ''
+        cap = ClaudeTaskManager._EFFORT_CAP.get(assistant, '')
+        levels = ClaudeTaskManager._EFFORT_LEVELS
+        if cap and levels.index(level) > levels.index(cap):
+            return cap
+        return level
 
     @staticmethod
     def resolve_assistant(requested):
@@ -8548,6 +8652,9 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         # Per-thread model choice (#308) — validated against the assistant's
         # allow-list; '' when the assistant offers no choice (adapter default).
         model = ClaudeTaskManager.resolve_model(assistant, data.get('model'))
+        # Per-thread reasoning effort (#362) — validated against the canonical
+        # 5-stop axis; '' when the assistant has no effort knob (selector hidden).
+        effort = ClaudeTaskManager.resolve_effort(assistant, data.get('effort'))
         # AI CTO persona (#465): a 'cto' thread swaps in CTO_PREAMBLE + the
         # project's markdown brief (injected on turn 1 via the adapter's
         # preamble path) and binds a project_id. Any other/absent persona is a
@@ -8596,7 +8703,7 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         try:
             session = HypervisorSession.create(
                 assistant=assistant, workdir=workdir, cli_cmd=cli_cmd,
-                preamble=preamble, title=message, model=model,
+                preamble=preamble, title=message, model=model, effort=effort,
                 persona=persona, project_id=project_id)
         except Exception as e:
             self.send_json({'error': f'failed to start chat: {e}'}, 500)
@@ -8754,6 +8861,32 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         model = ClaudeTaskManager.resolve_model(
             meta.get('assistant') or '', data.get('model'))
         summary = session.set_model(model)
+        if summary is None:
+            self.send_json({'error': 'not found'}, 404)
+            return
+        self.send_json({'thread': summary})
+
+    def handle_hypervisor_set_effort(self, thread_id):
+        """Switch a live thread's reasoning effort (#362). Takes effect on the
+        next turn — each adapter reads ctx['effort'] fresh at build and maps it
+        to its CLI's native knob. Validated against the thread's own assistant
+        (canonical 5-stop axis); an assistant with no effort knob resolves to ''
+        and the field is simply cleared."""
+        if not self.check_claude_auth():
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return
+        session = self._hv_session_or_404(thread_id)
+        if session is None:
+            return
+        try:
+            data = self.read_json_body()
+        except (json.JSONDecodeError, ValueError):
+            self.send_json({'error': 'Invalid JSON body'}, 400)
+            return
+        meta = session.read_meta() or {}
+        effort = ClaudeTaskManager.resolve_effort(
+            meta.get('assistant') or '', data.get('effort'))
+        summary = session.set_effort(effort)
         if summary is None:
             self.send_json({'error': 'not found'}, 404)
             return
@@ -12400,6 +12533,11 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
                 m = re.match(r'^/api/hypervisor/threads/([A-Za-z0-9_-]+)/model$', path)
                 if m:
                     self.handle_hypervisor_set_model(m.group(1))
+                    return
+                # /api/hypervisor/threads/{id}/effort — switch reasoning effort (#362)
+                m = re.match(r'^/api/hypervisor/threads/([A-Za-z0-9_-]+)/effort$', path)
+                if m:
+                    self.handle_hypervisor_set_effort(m.group(1))
                     return
                 # /api/skills/{name}/sync — cross-harness install (PR2).
                 # Stricter name charset than the GET route: only the

--- a/charts/workspace/templates/deployment.yaml
+++ b/charts/workspace/templates/deployment.yaml
@@ -154,6 +154,22 @@ spec:
         - name: KC_FALLBACK_PROVIDER_NAME
           value: {{ .Values.assistant.fallback.providerName | quote }}
         {{- end }}
+        {{- /* Reasoning-effort defaults (#362). Optional per-assistant curation
+               of the default effort level (low/medium/high/xhigh/max); blank =>
+               the built-in default (high). Only claude/codex/kc-harness have a
+               usable knob. Guarded so an absent value block never errors. */}}
+        {{- if (.Values.claude).effort }}
+        - name: KC_CLAUDE_EFFORT
+          value: {{ .Values.claude.effort | quote }}
+        {{- end }}
+        {{- if (.Values.assistant.codex).effort }}
+        - name: KC_CODEX_EFFORT
+          value: {{ .Values.assistant.codex.effort | quote }}
+        {{- end }}
+        {{- if (.Values.assistant.fallback).effort }}
+        - name: KC_HARNESS_EFFORT
+          value: {{ .Values.assistant.fallback.effort | quote }}
+        {{- end }}
         {{- /* Phase-2 semantic-memory embeddings (#90). Only emitted when a
                provider is configured; the key is referenced from a Secret. */}}
         {{- if ne (.Values.memory.embeddings.provider | default "none") "none" }}

--- a/charts/workspace/tests/deployment_test.yaml
+++ b/charts/workspace/tests/deployment_test.yaml
@@ -569,3 +569,49 @@ tests:
       - equal:
           path: spec.template.spec.containers[2].securityContext.runAsUser
           value: 0
+
+  # ── Reasoning-effort defaults (#362) ───────────────────────────────────────
+
+  - it: emits KC_*_EFFORT env only for assistants configured with a default effort
+    template: templates/deployment.yaml
+    set:
+      claude.effort: xhigh
+      assistant.codex.effort: high
+      assistant.fallback.effort: max
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_CLAUDE_EFFORT
+            value: "xhigh"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_CODEX_EFFORT
+            value: "high"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_HARNESS_EFFORT
+            value: "max"
+
+  - it: omits KC_*_EFFORT env when no default effort is configured
+    template: templates/deployment.yaml
+    asserts:
+      # any:true = subset match on each array element, so a name-only content
+      # actually detects the var regardless of its value.
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: KC_CLAUDE_EFFORT
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: KC_CODEX_EFFORT
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: KC_HARNESS_EFFORT

--- a/charts/workspace/tests/effort_test.py
+++ b/charts/workspace/tests/effort_test.py
@@ -1,0 +1,150 @@
+"""Unit tests for the cross-assistant reasoning-effort selector (#362).
+
+Covers the server-side registry (ClaudeTaskManager), the per-adapter native
+translation + injection (hypervisor_session), the per-thread persistence, and
+the cross-module cap-table lockstep.
+
+Run with:   python3 -m unittest tests.effort_test   (from charts/workspace/)
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+
+import hypervisor_session as hv  # noqa: E402
+import server  # noqa: E402
+
+CTM = server.ClaudeTaskManager
+
+
+class RegistryTests(unittest.TestCase):
+    def tearDown(self):
+        for k in ('KC_CLAUDE_EFFORT', 'KC_CODEX_EFFORT', 'KC_HARNESS_EFFORT'):
+            os.environ.pop(k, None)
+
+    def test_available_efforts_full_axis_for_supported(self):
+        for a in ('claude', 'codex', 'kc-harness'):
+            self.assertEqual(CTM.available_efforts(a),
+                             ['low', 'medium', 'high', 'xhigh', 'max'])
+
+    def test_available_efforts_empty_hides_selector(self):
+        for a in ('opencode-openrouter', 'opencode-deepseek', 'ante',
+                  'librefang', 'antigravity', 'unknown'):
+            self.assertEqual(CTM.available_efforts(a), [])
+
+    def test_default_effort_is_high(self):
+        self.assertEqual(CTM.default_effort('claude'), 'high')
+        self.assertEqual(CTM.default_effort('librefang'), '')
+
+    def test_default_effort_env_override_validated(self):
+        os.environ['KC_CODEX_EFFORT'] = 'xhigh'
+        self.assertEqual(CTM.default_effort('codex'), 'xhigh')
+        os.environ['KC_CODEX_EFFORT'] = 'BOGUS'
+        self.assertEqual(CTM.default_effort('codex'), 'high')  # invalid → default
+
+    def test_resolve_effort_validates_and_defaults(self):
+        self.assertEqual(CTM.resolve_effort('claude', 'xhigh'), 'xhigh')
+        self.assertEqual(CTM.resolve_effort('claude', 'MAX'), 'max')  # case-insensitive
+        self.assertEqual(CTM.resolve_effort('claude', 'nope'), 'high')
+        self.assertEqual(CTM.resolve_effort('claude', ''), 'high')
+        self.assertEqual(CTM.resolve_effort('librefang', 'max'), '')
+
+    def test_resolve_native_effort_clamps(self):
+        self.assertEqual(CTM.resolve_native_effort('claude', 'max'), 'xhigh')
+        self.assertEqual(CTM.resolve_native_effort('codex', 'max'), 'xhigh')
+        self.assertEqual(CTM.resolve_native_effort('kc-harness', 'xhigh'), 'high')
+        self.assertEqual(CTM.resolve_native_effort('kc-harness', 'max'), 'high')
+        self.assertEqual(CTM.resolve_native_effort('claude', 'medium'), 'medium')
+        self.assertEqual(CTM.resolve_native_effort('ante', 'high'), '')
+
+    def test_effort_cap(self):
+        self.assertEqual(CTM.effort_cap('claude'), 'xhigh')
+        self.assertEqual(CTM.effort_cap('kc-harness'), 'high')
+        self.assertEqual(CTM.effort_cap('ante'), '')
+
+
+class NativeClampTests(unittest.TestCase):
+    def test_native_effort_matches_server_for_valid_levels(self):
+        # For any concrete canonical level, the adapter-side clamp and the
+        # server-side native resolver must agree.
+        for a in ('claude', 'codex', 'kc-harness', 'ante', 'librefang'):
+            for lvl in hv.EFFORT_LEVELS:
+                self.assertEqual(hv.native_effort(a, lvl),
+                                 CTM.resolve_native_effort(a, lvl),
+                                 msg=f'{a}/{lvl}')
+
+    def test_native_effort_empty_for_unknown_or_blank(self):
+        self.assertEqual(hv.native_effort('claude', ''), '')
+        self.assertEqual(hv.native_effort('claude', 'bogus'), '')
+        self.assertEqual(hv.native_effort('librefang', 'high'), '')
+
+    def test_cap_table_lockstep(self):
+        # The two modules carry independent copies (server imports hv, not the
+        # reverse); they must never drift.
+        self.assertEqual(CTM._EFFORT_CAP, hv.EFFORT_CAP)
+        self.assertEqual(tuple(CTM._EFFORT_LEVELS), tuple(hv.EFFORT_LEVELS))
+
+
+class AdapterInjectionTests(unittest.TestCase):
+    def test_claude_sets_env_clamped(self):
+        spec = hv._adapter_for('claude').build({'effort': 'max', 'workdir': '/w'}, 'hi', True)
+        self.assertEqual(spec['env'].get('CLAUDE_CODE_EFFORT_LEVEL'), 'xhigh')
+
+    def test_claude_omits_env_when_unset(self):
+        spec = hv._adapter_for('claude').build({'workdir': '/w'}, 'hi', True)
+        self.assertNotIn('CLAUDE_CODE_EFFORT_LEVEL', spec['env'])
+
+    def test_codex_adds_config_flag(self):
+        opts = hv._adapter_for('codex')._opts({'effort': 'high'})
+        self.assertIn('-c', opts)
+        self.assertTrue(any('model_reasoning_effort="high"' in o for o in opts))
+
+    def test_codex_omits_flag_when_unset(self):
+        opts = hv._adapter_for('codex')._opts({})
+        self.assertFalse(any('model_reasoning_effort' in o for o in opts))
+
+    def test_harness_sets_env_clamped(self):
+        spec = hv._adapter_for('kc-harness').build(
+            {'assistant': 'kc-harness', 'effort': 'xhigh', 'cli_cmd': 'x'}, 'hi', True)
+        self.assertEqual(spec['env'].get('KC_EFFORT'), 'high')
+
+    def test_fallback_knobless_assistant_injects_nothing(self):
+        spec = hv._adapter_for('librefang').build(
+            {'assistant': 'librefang', 'effort': 'max', 'cli_cmd': 'x'}, 'hi', True)
+        self.assertNotIn('KC_EFFORT', spec['env'])
+
+
+class PerThreadPersistenceTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._orig = hv.HYPERVISOR_DIR
+        hv.HYPERVISOR_DIR = self._tmp.name
+
+    def tearDown(self):
+        hv.HYPERVISOR_DIR = self._orig
+
+    def test_create_stores_effort_and_summary_exposes_it(self):
+        s = hv.HypervisorSession.create(
+            assistant='claude', workdir='/w', cli_cmd='claude', effort='xhigh')
+        self.assertEqual(s.read_meta()['adapter']['effort'], 'xhigh')
+        self.assertEqual(s.summary()['effort'], 'xhigh')
+
+    def test_set_effort_updates_without_reordering(self):
+        s = hv.HypervisorSession.create(
+            assistant='claude', workdir='/w', cli_cmd='claude', effort='high')
+        before = s.read_meta()['updated_at']
+        summary = s.set_effort('low')
+        self.assertEqual(summary['effort'], 'low')
+        self.assertEqual(s.read_meta()['adapter']['effort'], 'low')
+        # touch=False: a mid-session effort tweak must not bump updated_at.
+        self.assertEqual(s.read_meta()['updated_at'], before)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/tests/harness_effort_test.py
+++ b/charts/workspace/tests/harness_effort_test.py
@@ -1,0 +1,69 @@
+"""Unit tests for kc-harness reasoning-effort forwarding (#362).
+
+kc-harness talks an OpenAI-compatible endpoint, so the hypervisor passes the
+per-thread effort as KC_EFFORT and harness.py forwards it as the request's
+`reasoning_effort` — omitted entirely when unset so the model keeps its default.
+
+Run with:   python3 -m unittest tests.harness_effort_test   (from charts/workspace/)
+"""
+
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+import harness  # noqa: E402
+
+
+class PickEffortTests(unittest.TestCase):
+    def tearDown(self):
+        os.environ.pop('KC_EFFORT', None)
+
+    def test_reads_and_normalizes_env(self):
+        os.environ['KC_EFFORT'] = ' High '
+        self.assertEqual(harness.pick_effort(), 'high')
+
+    def test_blank_when_unset(self):
+        os.environ.pop('KC_EFFORT', None)
+        self.assertEqual(harness.pick_effort(), '')
+
+
+class ChatBodyTests(unittest.TestCase):
+    """Capture the request body chat() builds without hitting the network."""
+
+    def tearDown(self):
+        os.environ.pop('KC_EFFORT', None)
+
+    def _capture_body(self):
+        captured = {}
+
+        class _Resp:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return b'{"choices":[]}'
+
+        def fake_urlopen(req, timeout=None):
+            captured['body'] = json.loads(req.data.decode())
+            return _Resp()
+
+        with mock.patch('urllib.request.urlopen', fake_urlopen):
+            harness.chat([{'role': 'user', 'content': 'hi'}],
+                         'http://x/v1', '', 'qwen')
+        return captured['body']
+
+    def test_includes_reasoning_effort_when_set(self):
+        os.environ['KC_EFFORT'] = 'high'
+        body = self._capture_body()
+        self.assertEqual(body.get('reasoning_effort'), 'high')
+
+    def test_omits_reasoning_effort_when_unset(self):
+        os.environ.pop('KC_EFFORT', None)
+        body = self._capture_body()
+        self.assertNotIn('reasoning_effort', body)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -309,6 +309,10 @@ browser:
 # If apiKey is set, it takes precedence over OAuth.
 claude:
   apiKey: ""
+  # Default reasoning effort for Claude in the Hypervisor chat (#362): one of
+  # low/medium/high/xhigh/max. Blank => the built-in default (high). Users can
+  # still switch per-thread in the chat. `max` clamps to Claude Code's xhigh.
+  effort: ""
 
 # Hypervisor — the workspace-aware chat tab. A clean chat interface layered
 # over the user's existing CLI agents (claude, ante, opencode, …) plus a
@@ -434,6 +438,15 @@ assistant:
     model: "anthropic/claude-sonnet-4"
     providerId: "kube-coder-fallback"     # OpenCode provider id (free-form)
     providerName: "Kube-Coder Fallback"
+    # Default reasoning effort for the kc-harness assistant (#362): forwarded as
+    # the OpenAI-compatible `reasoning_effort`. Blank => built-in default (high);
+    # xhigh/max clamp to high (the harness endpoint's ceiling).
+    effort: ""                            # KC_HARNESS_EFFORT
+  # Codex (OpenAI) — ChatGPT-OAuth terminal agent, pre-installed. No key here.
+  codex:
+    # Default reasoning effort (#362): codex model_reasoning_effort. Blank =>
+    # built-in default (high); max clamps to codex's xhigh ceiling.
+    effort: ""                            # KC_CODEX_EFFORT
 
 # Persistent memory subsystem. SQLite-backed at /home/dev/.claude-memory/memory.db,
 # exposed to the dashboard at /api/memory and to claude via the `memory` MCP server.

--- a/charts/workspace/web/src/api/hypervisor.ts
+++ b/charts/workspace/web/src/api/hypervisor.ts
@@ -17,6 +17,14 @@ export interface HypervisorAssistant {
   /** Selectable models for the in-chat model switcher (#308), default first.
    *  Empty/absent → the assistant offers no model choice (switcher hidden). */
   models?: string[];
+  /** Reasoning-effort axis (#362): the canonical 5-stop levels to show
+   *  (low/medium/high/xhigh/max). Empty/absent → no effort knob (selector
+   *  hidden). `effort` is the default level; `effortCap` is the highest level
+   *  the assistant honours natively — a pick above it is clamped, so the UI
+   *  can show an honest "runs <cap>" hint. */
+  efforts?: string[];
+  effort?: string;
+  effortCap?: string;
   /** Zero-cost provider (e.g. opencode-zen, #395) — drives the "free" marker. */
   free?: boolean;
   /** Provider may train on submitted data (Zen free models, #395) — drives the
@@ -55,6 +63,9 @@ export interface HypervisorThread {
   // The thread's selected model when its assistant offers a choice (#308);
   // '' when none. Reflected by the in-chat switcher when the thread is open.
   model?: string;
+  // The thread's reasoning effort when its assistant offers one (#362); '' when
+  // none. Reflected by the in-chat effort selector when the thread is open.
+  effort?: string;
   status: ThreadStatus;
   created_at: number | null;
   updated_at: number | null;
@@ -161,6 +172,8 @@ export const createThread = (opts: {
   assistant?: string;
   workdir?: string;
   model?: string;
+  // Reasoning effort (#362): canonical level, applied from turn 1.
+  effort?: string;
   // AI CTO (#465): persona 'cto' + the bound project id.
   persona?: string;
   project_id?: string;
@@ -197,6 +210,14 @@ export const setThreadModel = (id: string, model: string) =>
   apiPost<{ thread: HypervisorThread }>(
     `/api/hypervisor/threads/${encodeURIComponent(id)}/model`,
     { model },
+  ).then((r) => r.thread);
+
+/** Switch a live thread's reasoning effort (#362). Takes effect on the next
+ *  turn (each adapter reads it fresh at build). */
+export const setThreadEffort = (id: string, effort: string) =>
+  apiPost<{ thread: HypervisorThread }>(
+    `/api/hypervisor/threads/${encodeURIComponent(id)}/effort`,
+    { effort },
   ).then((r) => r.thread);
 
 export const stopThread = (id: string) =>

--- a/charts/workspace/web/src/routes/hypervisor/hypervisor.css
+++ b/charts/workspace/web/src/routes/hypervisor/hypervisor.css
@@ -497,6 +497,13 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
+/* Effort clamp hint (#362): shown when the picked level exceeds the assistant's
+   native ceiling, e.g. "→ xhigh" beside a `max` pick. */
+.hv-effort-hint {
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+  white-space: nowrap;
+}
 .hv-model-select {
   max-width: 130px;
   padding: 4px 7px;

--- a/charts/workspace/web/src/routes/hypervisor/index.tsx
+++ b/charts/workspace/web/src/routes/hypervisor/index.tsx
@@ -15,11 +15,16 @@ import {
   activeStatus,
   selectedAssistant,
   selectedModel,
+  selectedEffort,
   selectedWorkdir,
   assistantModels,
+  assistantEfforts,
+  assistantEffortDefault,
+  assistantEffortCap,
   assistantNeedsDisclosure,
   setSelectedAssistant,
   setActiveThreadModel,
+  setActiveThreadEffort,
   initHypervisor,
   openThread,
   newChat,
@@ -168,6 +173,19 @@ export function HypervisorRoute() {
   const currentModel = active
     ? activeThread?.model || models[0] || ''
     : selectedModel.value || models[0] || '';
+
+  // Effort selector (#362), twin of the model switcher. Same 5-stop list for
+  // every assistant that has a knob (empty → hidden); a pick above the
+  // assistant's native cap is honestly shown as "→ <cap>".
+  const efforts = assistantEfforts(effectiveAssistant);
+  const effortDefault = assistantEffortDefault(effectiveAssistant);
+  const currentEffort = active
+    ? activeThread?.effort || effortDefault || ''
+    : selectedEffort.value || effortDefault || '';
+  const effortCap = assistantEffortCap(effectiveAssistant);
+  const effortClamped =
+    !!effortCap &&
+    efforts.indexOf(currentEffort) > efforts.indexOf(effortCap);
 
   // Split into what you're working with now vs. older chats. Derived purely
   // from status + updated_at (see chatTabs.ts) — no server change needed.
@@ -591,6 +609,42 @@ export function HypervisorRoute() {
                     </option>
                   ))}
                 </select>
+              </label>
+            )}
+            {/* Reasoning-effort selector (#362). Same behaviour as the model
+                picker: sets the new-thread default with no thread open, switches
+                the open thread live (next turn). Shown only when the effective
+                assistant has an effort knob; a clamped pick shows "→ <cap>". */}
+            {efforts.length > 0 && (
+              <label
+                class="hv-model-picker"
+                title={
+                  effortClamped
+                    ? `Reasoning effort: ${currentEffort} — this assistant runs ${effortCap}`
+                    : `Reasoning effort: ${currentEffort}`
+                }
+              >
+                <span class="hv-model-label">Effort</span>
+                <select
+                  class="hv-model-select"
+                  value={currentEffort}
+                  disabled={status === 'running'}
+                  onChange={(e) =>
+                    void setActiveThreadEffort((e.target as HTMLSelectElement).value)
+                  }
+                  aria-label="Reasoning effort"
+                >
+                  {efforts.map((lv) => (
+                    <option key={lv} value={lv}>
+                      {lv}
+                    </option>
+                  ))}
+                </select>
+                {effortClamped && (
+                  <span class="hv-effort-hint mono" aria-label={`Runs ${effortCap}`}>
+                    → {effortCap}
+                  </span>
+                )}
               </label>
             )}
             {active && status && (

--- a/charts/workspace/web/src/store/hypervisor.effort.test.ts
+++ b/charts/workspace/web/src/store/hypervisor.effort.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import type { HypervisorThread, HypervisorConfig } from '../api/hypervisor';
+
+// Reasoning-effort selector store logic (#362) in isolation — no network.
+const { setThreadEffort, listThreads } = vi.hoisted(() => ({
+  setThreadEffort: vi.fn(),
+  listThreads: vi.fn(),
+}));
+
+vi.mock('../api/hypervisor', () => ({
+  setThreadEffort: (...a: unknown[]) => setThreadEffort(...a),
+  listThreads: (...a: unknown[]) => listThreads(...a),
+  // Unused-by-these-tests exports the store imports at module load.
+  renameThread: vi.fn(),
+  setThreadModel: vi.fn(),
+  createThread: vi.fn(),
+  getThread: vi.fn(),
+  getHypervisorConfig: vi.fn(),
+  sendThreadMessage: vi.fn(),
+  stopThread: vi.fn(),
+  deleteThread: vi.fn(),
+}));
+vi.mock('../api/tasks', () => ({ listTasks: vi.fn() }));
+vi.mock('./router', () => ({
+  navigate: vi.fn(),
+  currentPath: { value: '/hypervisor' },
+}));
+
+import {
+  threads,
+  config,
+  activeThreadId,
+  selectedEffort,
+  assistantEfforts,
+  assistantEffortDefault,
+  assistantEffortCap,
+  setSelectedAssistant,
+  setActiveThreadEffort,
+} from './hypervisor';
+
+function thread(over: Partial<HypervisorThread> = {}): HypervisorThread {
+  return { id: 'a', title: 't', assistant: 'claude', status: 'idle',
+    created_at: 1, updated_at: 1, ...over };
+}
+
+function cfg(): HypervisorConfig {
+  return {
+    enabled: true,
+    defaultAssistant: 'claude',
+    workdir: '/home/dev',
+    readOnly: false,
+    assistants: [
+      { id: 'claude', label: 'Claude Code', models: ['default'],
+        efforts: ['low', 'medium', 'high', 'xhigh', 'max'], effort: 'high', effortCap: 'xhigh' },
+      { id: 'kc-harness', label: 'Harness', models: [],
+        efforts: ['low', 'medium', 'high', 'xhigh', 'max'], effort: 'high', effortCap: 'high' },
+      { id: 'librefang', label: 'LibreFang', models: [], efforts: [] },
+    ],
+  };
+}
+
+beforeEach(() => {
+  setThreadEffort.mockReset();
+  listThreads.mockReset().mockResolvedValue([]);
+  config.value = cfg();
+  threads.value = [thread({ id: 'a' })];
+  activeThreadId.value = null;
+  selectedEffort.value = '';
+});
+
+describe('effort config helpers', () => {
+  it('exposes the 5-stop axis + cap for a supported assistant', () => {
+    expect(assistantEfforts('claude')).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+    expect(assistantEffortDefault('claude')).toBe('high');
+    expect(assistantEffortCap('claude')).toBe('xhigh');
+    expect(assistantEffortCap('kc-harness')).toBe('high');
+  });
+
+  it('reports no efforts for a knob-less assistant (selector hidden)', () => {
+    expect(assistantEfforts('librefang')).toEqual([]);
+    expect(assistantEffortDefault('librefang')).toBe('');
+    expect(assistantEffortCap('librefang')).toBe('');
+  });
+});
+
+describe('setSelectedAssistant resets effort to the assistant default', () => {
+  it('seeds the new assistant default', () => {
+    setSelectedAssistant('claude');
+    expect(selectedEffort.value).toBe('high');
+    setSelectedAssistant('librefang');
+    expect(selectedEffort.value).toBe(''); // hidden → no default
+  });
+});
+
+describe('setActiveThreadEffort', () => {
+  it('updates the new-chat default when no thread is open', async () => {
+    activeThreadId.value = null;
+    await setActiveThreadEffort('low');
+    expect(selectedEffort.value).toBe('low');
+    expect(setThreadEffort).not.toHaveBeenCalled();
+  });
+
+  it('switches the open thread server-side and the list reflects it', async () => {
+    activeThreadId.value = 'a';
+    setThreadEffort.mockResolvedValue(thread({ id: 'a', effort: 'xhigh' }));
+    // refreshThreads() re-reads from the server after the switch — return the
+    // updated thread so the post-refresh list carries the new effort.
+    listThreads.mockResolvedValue([thread({ id: 'a', effort: 'xhigh' })]);
+    await setActiveThreadEffort('xhigh');
+    expect(setThreadEffort).toHaveBeenCalledWith('a', 'xhigh');
+    expect(threads.value.find((t) => t.id === 'a')?.effort).toBe('xhigh');
+  });
+});

--- a/charts/workspace/web/src/store/hypervisor.ts
+++ b/charts/workspace/web/src/store/hypervisor.ts
@@ -11,6 +11,7 @@ import {
   restoreThread,
   renameThread,
   setThreadModel,
+  setThreadEffort,
   type HypervisorConfig,
   type HypervisorThread,
   type TranscriptSource,
@@ -80,6 +81,12 @@ export const selectedAssistant = signal<string>('');
  *  acts on that thread instead (setActiveThreadModel). */
 export const selectedModel = signal<string>('');
 
+/** The reasoning effort a NEW thread will use (#362) — the selected assistant's
+ *  default (its config `effort`) unless the user picks another. '' when the
+ *  assistant offers no effort choice. For an already-open thread the selector
+ *  acts on that thread instead (setActiveThreadEffort). */
+export const selectedEffort = signal<string>('');
+
 /** The folder a NEW thread starts in (#345) — seeded from config.workdir (the
  *  server's HYPERVISOR_WORKDIR) so the picker shows the real default. '' is
  *  passed as no workdir, letting the server default apply. A thread keeps the
@@ -100,6 +107,23 @@ export function assistantInfo(assistantId: string | null | undefined) {
   return (config.value?.assistants ?? []).find((x) => x.id === assistantId);
 }
 
+/** Selectable reasoning-effort levels for an assistant (#362), or [] when the
+ *  assistant has no effort knob (the selector stays hidden). */
+export function assistantEfforts(assistantId: string | null | undefined): string[] {
+  return assistantInfo(assistantId)?.efforts ?? [];
+}
+
+/** The assistant's default effort level ('' when it has no knob). */
+export function assistantEffortDefault(assistantId: string | null | undefined): string {
+  return assistantInfo(assistantId)?.effort ?? '';
+}
+
+/** The highest level the assistant honours natively ('' when unbounded/none) —
+ *  a pick above it is clamped, so the UI shows a "runs <cap>" hint. */
+export function assistantEffortCap(assistantId: string | null | undefined): string {
+  return assistantInfo(assistantId)?.effortCap ?? '';
+}
+
 /** True when the assistant is a free provider that may train on submitted data
  *  (Zen free models, #395) — drives the in-chat disclosure note. */
 export function assistantNeedsDisclosure(assistantId: string | null | undefined): boolean {
@@ -111,6 +135,9 @@ export function assistantNeedsDisclosure(assistantId: string | null | undefined)
 export function setSelectedAssistant(assistantId: string): void {
   selectedAssistant.value = assistantId;
   selectedModel.value = assistantModels(assistantId)[0] ?? '';
+  // Reset effort to the new assistant's default (#362) so the selector never
+  // shows a level the assistant doesn't offer.
+  selectedEffort.value = assistantEffortDefault(assistantId);
 }
 
 /** Live workspace "entities" surfaced as chips in the chat — currently the
@@ -140,6 +167,11 @@ export async function initHypervisor(): Promise<void> {
     // (and its per-assistant model lists) is loaded (#308).
     if (!selectedModel.value) {
       selectedModel.value = assistantModels(selectedAssistant.value)[0] ?? '';
+    }
+    // Seed the effort to the selected assistant's default now that the config
+    // (and its per-assistant effort lists) is loaded (#362).
+    if (!selectedEffort.value) {
+      selectedEffort.value = assistantEffortDefault(selectedAssistant.value);
     }
     if (!selectedWorkdir.value) {
       selectedWorkdir.value = cfg.workdir || '';
@@ -287,6 +319,7 @@ export async function sendMessage(text: string): Promise<void> {
         message: trimmed,
         assistant: selectedAssistant.value || undefined,
         model: selectedModel.value || undefined,
+        effort: selectedEffort.value || undefined,
         // A CTO thread omits the workdir so the server defaults it to the bound
         // project's first workdir; a plain chat sends the picker's folder. Sending
         // the picker's /home/dev default would defeat the server's project
@@ -373,6 +406,25 @@ export async function setActiveThreadModel(model: string): Promise<void> {
   threads.value = prev.map((t) => (t.id === id ? { ...t, model } : t));
   try {
     await setThreadModel(id, model);
+    await refreshThreads();
+  } catch {
+    threads.value = prev;
+  }
+}
+
+/** Switch the reasoning effort (#362), twin of setActiveThreadModel. With a
+ *  thread open, updates it server-side (takes effect next turn) and optimistically
+ *  patches the list; with no thread open, just updates the new-chat default. */
+export async function setActiveThreadEffort(effort: string): Promise<void> {
+  const id = activeThreadId.value;
+  if (!id) {
+    selectedEffort.value = effort;
+    return;
+  }
+  const prev = threads.value;
+  threads.value = prev.map((t) => (t.id === id ? { ...t, effort } : t));
+  try {
+    await setThreadEffort(id, effort);
     await refreshThreads();
   } catch {
     threads.value = prev;


### PR DESCRIPTION
…igh/xhigh/max)

Adds the effort control the review asked for: a stable 5-stop axis (low/medium/ high/xhigh/max, default high) that works across every assistant, not just Claude. Modeled as the direct twin of the existing model-picker machinery (#308/#361) — same registry -> per-thread param -> adapter-translation shape, just for effort instead of model.

Per-provider reality (surveyed before writing any code):
  - claude:      CLAUDE_CODE_EFFORT_LEVEL env; native ceiling xhigh, so `max`
                 clamps down to xhigh.
  - codex:       `-c model_reasoning_effort="..."`; same xhigh ceiling/clamp.
  - kc-harness:  forwarded as the OpenAI-compatible `reasoning_effort` field;
                 ceiling is high, so xhigh/max both clamp to high.
  - opencode-*:  hidden. reasoningEffort is config-file-only (one shared
                 opencode.json — a per-turn write would race) and is reported to
                 be a silent no-op for Anthropic models over OpenRouter anyway.
  - ante:        hidden. No effort/reasoning field in ~/.ante/settings.json.
  - librefang:   hidden. No effort concept at all.
Assistants with no real knob report an empty effort list and the selector simply
doesn't render for them, the same pattern already used for assistants with no
model list.

Backend flow: server.py's ClaudeTaskManager gets an effort registry mirroring the model one (_EFFORT_LEVELS, _EFFORT_CAP, available_efforts / default_effort / resolve_effort / resolve_native_effort) and a new PUT /threads/{id}/effort route, plus effort on thread creation. hypervisor_session.py carries a matching native_effort() clamp table (checked against the server's in a unit test so the two can't drift) and each adapter reads ctx['effort'] fresh every turn so a mid-session switch takes effect on the next turn, exactly like model switching. Helm gets optional assistant.*.effort -> KC_*_EFFORT defaults, guarded so an unset value never renders.

Frontend: an effort dropdown next to the existing model picker in the Hypervisor chat header, hidden when the assistant has no efforts list, with a small "-> xhigh" hint when a pick gets clamped so the control never silently lies about what level is actually running.

Testing: 22 new backend unit tests (registry validation/defaults, per-provider clamping, adapter injection incl. the "nothing injected" case for knob-less assistants, per-thread persistence, and a cross-module lockstep check between the server and hypervisor_session cap tables) plus 5 frontend store tests and 2 new helm-unittest cases for the KC_*_EFFORT env wiring. tsc and the SPA production build are clean; the pre-existing Windows-only subprocess-signal test failures in hypervisor_session_test are unrelated (same failures on a clean checkout with none of this branch's changes applied).