### PR TITLE
fix(provisioner): unbreak workspace provisioning — bake python3 + grant cilium RBAC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,19 @@ jobs:
           test "${entrypoint}" = '["/usr/local/bin/provision.sh"]'
           docker run --rm --entrypoint /bin/bash kube-coder-provisioner:ci-test \
             -c 'test -x /usr/local/bin/provision.sh && bash -n /usr/local/bin/provision.sh && test -s /etc/provisioner/helm-version'
+          # Every tool the `make deploy` path shells out to must be baked in — the
+          # Job runs in THIS image, not the controller image. A missing one (e.g.
+          # python3, used by ensure-workspace-namespace.sh to reshape the regcred
+          # Secret and derive the self-serve HMAC) otherwise only surfaces on a
+          # live provisioning run as `<tool>: command not found`. Guard it here.
+          docker run --rm --entrypoint /bin/bash kube-coder-provisioner:ci-test -c '
+            set -euo pipefail
+            for t in helm kubectl git make bash python3; do
+              command -v "$t" >/dev/null || { echo "provisioner image missing required tool: $t" >&2; exit 1; }
+            done
+            # the exact stdlib modules the provisioner scripts import
+            python3 -c "import json, hashlib, hmac, os, sys"
+            echo "provisioner runtime tools OK: helm kubectl git make bash python3(+json/hashlib/hmac)"'
 
   security-scan:
     name: Security Scanning

--- a/provisioner/Dockerfile
+++ b/provisioner/Dockerfile
@@ -39,10 +39,15 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Base OS packages: apt GPG-verifies every one. `apt-get upgrade` picks up base
 # CVE fixes on rebuild (mirrors devlaptop). git+make+bash+coreutils are what
-# `make deploy` and the provisioner scripts shell out to; curl+ca-certificates
+# `make deploy` and the provisioner scripts shell out to; python3 is a RUNTIME
+# dep too — scripts/ensure-workspace-namespace.sh uses it to strip server-managed
+# metadata off the copied regcred Secret and to derive the self-serve token HMAC
+# (json/hashlib/hmac, stdlib only). Before #422 the Job ran under the controller
+# image, which has python3; the dedicated provisioner image must ship it itself
+# or `make deploy` fails with `python3: command not found`. curl+ca-certificates
 # are only used at BUILD time to fetch the verified helm/kubectl tarballs below.
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-    ca-certificates curl git make bash coreutils \
+    ca-certificates curl git make bash coreutils python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Helm — baked in, checksum-verified. The published per-release .sha256sum


### PR DESCRIPTION
Two provisioner gaps that both break real end-to-end provisioning on the #571/#422 dedicated-image path. Neither is caught by rendering/CI tests alone — both were found by an actual provisioning run (`alejandronbachi`), which now completes end to end.

## 1. `python3` missing from the provisioner image
#571 moved the privileged `make deploy` off the controller image (which has python3) onto the minimal provisioner image, which baked helm/kubectl/git/make but **not python3**. `scripts/ensure-workspace-namespace.sh` needs it (stdlib json/hashlib/hmac) to reshape the copied `regcred` Secret and derive the self-serve-token HMAC → `python3: command not found`.

- `provisioner/Dockerfile`: add `python3`, documented as a runtime dep.
- `ci.yml`: extend the provisioner-image smoke test to assert every deploy-path tool (`helm kubectl git make bash python3`) is present and the stdlib modules import — so a missing runtime tool fails CI, not a live provision.

## 2. provisioner SA can't manage `cilium.io/CiliumNetworkPolicy`
The workspace chart renders a per-workspace CiliumNetworkPolicy (egress-deny #548/#550), but the `workspace-provisioner` ClusterRole only covered `networking.k8s.io/networkpolicies`. So `helm upgrade` of a new workspace failed:
`cannot get resource "ciliumnetworkpolicies" in API group "cilium.io"`.

- `provisioner-rbac.yaml`: add a get/list/watch/create/update/patch/delete rule for `cilium.io/ciliumnetworkpolicies`, next to the existing NetworkPolicy rule.

## Verification
Both fixes deployed to the live controller and a full provisioner-Job run completed end to end: validate-user 8/8 → base-infra install → workspace `helm upgrade` (incl. the CiliumNetworkPolicy) → workspace up. The provisioner-image build + new CI assertion pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)