### PR TITLE
fix(provisioner): grant the provisioner SA RBAC for cilium.io CiliumNetworkPolicy

### DIFF
--- a/charts/workspace-controller/templates/provisioner-rbac.yaml
+++ b/charts/workspace-controller/templates/provisioner-rbac.yaml
@@ -74,6 +74,14 @@ rules:
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses", "networkpolicies"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# The per-workspace CiliumNetworkPolicy the chart renders (egress-deny hardening
+# #548/#550 — denies workspace egress to link-local + in-cluster CIDRs). It is a
+# cilium.io CRD, DISTINCT from the networking.k8s.io NetworkPolicy above, so
+# without its own rule `helm upgrade` of a new workspace fails with
+# `cannot get resource "ciliumnetworkpolicies" in API group "cilium.io"`.
+- apiGroups: ["cilium.io"]
+  resources: ["ciliumnetworkpolicies"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 # The oauth2-proxy PodDisruptionBudget the chart ships for its HA proxy pair.
 - apiGroups: ["policy"]
   resources: ["poddisruptionbudgets"]


### PR DESCRIPTION
Follow-up to #576 (which baked python3 into the provisioner image). This is the **second** provisioner gap the same real end-to-end provisioning run surfaced.

## Bug
The workspace chart renders a per-workspace **CiliumNetworkPolicy** (`ws-<user>-egress`, the egress-deny hardening from #548/#550), but the `workspace-provisioner` ClusterRole only granted `networking.k8s.io/networkpolicies` — not the `cilium.io` CRD. So `helm upgrade` of a new workspace fails under the provisioner SA:

```
Error: Unable to continue with install: could not get information about the resource
CiliumNetworkPolicy "ws-<user>-egress": ciliumnetworkpolicies.cilium.io is forbidden:
User "system:serviceaccount:coder:workspace-provisioner" cannot get resource
"ciliumnetworkpolicies" in API group "cilium.io"
```

Provisioning gets all the way through validate-user + base-infra install, then dies here.

## Fix
`charts/workspace-controller/templates/provisioner-rbac.yaml`: add a `get/list/watch/create/update/patch/delete` rule for `cilium.io/ciliumnetworkpolicies`, right beside the existing `networking.k8s.io` NetworkPolicy rule.

## Verification
Deployed the updated ClusterRole to the live controller and re-ran the exact provisioner Job (env-only, VAP-admitted). With #576's python3 fix + this RBAC rule, provisioning completed **end to end** — validate-user 8/8 → base-infra install → workspace `helm upgrade` including the CiliumNetworkPolicy → workspace up. `kubectl auth can-i create ciliumnetworkpolicies.cilium.io --as=system:serviceaccount:coder:workspace-provisioner` now returns `yes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)