### PR TITLE
feat(memory): scope injection by namespace and summarize long entries…

### DIFF
--- a/charts/workspace/memory/manager.py
+++ b/charts/workspace/memory/manager.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Iterable, List, Optional
 
 from . import store as _store
 from .store import MemoryStore, DB_PATH
+from .summarize import summarize as _summarize
 
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -69,6 +70,36 @@ def _require(cond: bool, msg: str) -> None:
         raise ValidationError(msg)
 
 
+# ── Namespace scoping (#359) ────────────────────────────────────────────────
+# Injection used to retrieve from the whole workspace DB, so a `project.foo`
+# memory could surface inside a `project.bar` chat whenever it out-scored the
+# local ones — the token-inefficiency this fixes. A *scope* is a namespace root:
+# it matches the root itself plus everything nested under it, anchored on the
+# '.' separator so `project.foo` matches `project.foo` and `project.foo.goals`
+# but NOT `project.foobar`.
+_LIKE_ESCAPE = '\\'
+
+
+def _like_escape(s: str) -> str:
+    """Escape LIKE metacharacters. Namespaces admit `_` and `%` is possible via
+    the API surface; unescaped, `project.foo_bar` would also match
+    `project.fooXbar`. Paired with an explicit ESCAPE clause in the SQL."""
+    return (s.replace(_LIKE_ESCAPE, _LIKE_ESCAPE * 2)
+             .replace('%', _LIKE_ESCAPE + '%')
+             .replace('_', _LIKE_ESCAPE + '_'))
+
+
+def _ns_scope_clause(scope: str, col: str = 'namespace'):
+    """(sql_clause, params) restricting `col` to a namespace scope root, or
+    (None, []) when no scope is given (global retrieval — the default, so
+    unscoped callers keep today's behaviour exactly)."""
+    scope = (scope or '').strip()
+    if not scope:
+        return None, []
+    return (f'({col} = ? OR {col} LIKE ? ESCAPE ?)',
+            [scope, _like_escape(scope) + '.%', _LIKE_ESCAPE])
+
+
 def _validate_ns_key(namespace: str, key: str) -> None:
     _require(isinstance(namespace, str) and _NS_KEY_RE.match(namespace),
              'namespace must match [a-zA-Z0-9._-]{1,128}')
@@ -113,6 +144,22 @@ def _row_to_dict(row: sqlite3.Row) -> Dict[str, Any]:
     if 'tags' in d and isinstance(d['tags'], str):
         d['tags_list'] = [t for t in (s.strip() for s in d['tags'].split(',')) if t]
     return d
+
+
+def _row_summary(row: Any) -> Optional[str]:
+    """The derived summary on a row, or None. Tolerates rows read before the
+    v3 migration added the column (#359) — sqlite3.Row raises on unknown keys."""
+    try:
+        return row['summary']
+    except (IndexError, KeyError):
+        return None
+
+
+def injection_text(entry: Dict[str, Any]) -> str:
+    """The text to inject for a memory: its write-time summary when one exists,
+    else the full value (#359). Short memories have no summary and are injected
+    verbatim — only long ones were ever the problem."""
+    return (entry.get('summary') or entry.get('value') or '').strip()
 
 
 def _normalize_tags(tags: Optional[str]) -> str:
@@ -172,6 +219,13 @@ class MemoryManager:
         confidence = _clamp01(confidence, name='confidence')
         tags = _normalize_tags(tags)
         now = time.time()
+        # Write-time summarization (#359): condense long values ONCE here so
+        # injection has something short to show, instead of hard-cutting the
+        # value mid-sentence on every prompt. `value` itself is stored
+        # untouched — this is a derived column. Best-effort by construction:
+        # summarize() swallows failures and returns None, and NULL simply means
+        # readers fall back to the full value.
+        summary = _summarize(value)
 
         with cls.store().tx() as c:
             existing = c.execute(
@@ -182,11 +236,11 @@ class MemoryManager:
             if existing is None:
                 cur = c.execute(
                     'INSERT INTO memories ('
-                    '  namespace, key, value, kind, tags, importance, confidence,'
-                    '  source, created_at, updated_at, version, expires_at'
-                    ') VALUES (?,?,?,?,?,?,?,?,?,?,?,?)',
-                    (namespace, key, value, kind, tags, importance, confidence,
-                     source or '', now, now, 1, expires_at),
+                    '  namespace, key, value, summary, kind, tags, importance,'
+                    '  confidence, source, created_at, updated_at, version, expires_at'
+                    ') VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)',
+                    (namespace, key, value, summary, kind, tags, importance,
+                     confidence, source or '', now, now, 1, expires_at),
                 )
                 mem_id = cur.lastrowid
                 version = 1
@@ -194,13 +248,15 @@ class MemoryManager:
             else:
                 mem_id = existing['id']
                 version = int(existing['version']) + 1
+                # summary is recomputed from the new value every time, so it can
+                # never go stale relative to the text it describes.
                 c.execute(
                     'UPDATE memories SET'
-                    '  value=?, kind=?, tags=?, importance=?, confidence=?,'
+                    '  value=?, summary=?, kind=?, tags=?, importance=?, confidence=?,'
                     '  source=?, updated_at=?, version=?, expires_at=?,'
                     '  deleted_at=NULL'
                     ' WHERE id=?',
-                    (value, kind, tags, importance, confidence,
+                    (value, summary, kind, tags, importance, confidence,
                      source or '', now, version, expires_at, mem_id),
                 )
                 op = 'update'
@@ -268,13 +324,17 @@ class MemoryManager:
             new_conf = confidence if confidence is not None else row['confidence']
             new_exp = expires_at if expires_at is not None else row['expires_at']
             version = int(row['version']) + 1
+            # Recompute the derived summary whenever the value changes (#359);
+            # leave it untouched on metadata-only edits so we don't churn it.
+            new_summary = (_summarize(new_value) if value is not None
+                           else _row_summary(row))
 
             c.execute(
                 'UPDATE memories SET'
-                '  value=?, kind=?, tags=?, importance=?, confidence=?,'
+                '  value=?, summary=?, kind=?, tags=?, importance=?, confidence=?,'
                 '  source=?, updated_at=?, version=?, expires_at=?'
                 ' WHERE id=?',
-                (new_value, new_kind, new_tags, new_imp, new_conf,
+                (new_value, new_summary, new_kind, new_tags, new_imp, new_conf,
                  source or row['source'], now, version, new_exp, row['id']),
             )
             c.execute(
@@ -358,11 +418,13 @@ class MemoryManager:
         q: Optional[str] = None,
         limit: int = 500,
         include_deleted: bool = False,
+        namespace_scope: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         limit = max(1, min(int(limit), 100000))
         if q:
             return cls.search(q=q, namespaces=[namespace] if namespace else None,
-                              kinds=[kind] if kind else None, limit=limit)
+                              kinds=[kind] if kind else None, limit=limit,
+                              namespace_scope=namespace_scope)
         clauses = []
         params: List[Any] = []
         if not include_deleted:
@@ -372,6 +434,10 @@ class MemoryManager:
         if namespace:
             clauses.append('namespace=?')
             params.append(namespace)
+        scope_clause, scope_params = _ns_scope_clause(namespace_scope)
+        if scope_clause:
+            clauses.append(scope_clause)
+            params.extend(scope_params)
         if kind:
             clauses.append('kind=?')
             params.append(kind)
@@ -455,6 +521,7 @@ class MemoryManager:
         q: str,
         kinds: Optional[Iterable[str]] = None,
         namespaces: Optional[Iterable[str]] = None,
+        namespace_scope: Optional[str] = None,
         limit: int = 25,
     ) -> List[Dict[str, Any]]:
         """Hybrid keyword + semantic search.
@@ -465,6 +532,12 @@ class MemoryManager:
         fusion (RRF). When any of those is missing the method degrades to the
         Phase-1 FTS-only ranking with identical output — so behavior is
         unchanged on deployments without embeddings configured.
+
+        `namespaces` is an exact-match allow-list; `namespace_scope` (#359) is a
+        namespace ROOT that also matches everything nested under it. Both are
+        applied on every retrieval path — FTS, the LIKE degradation, and the
+        vector-only hits loaded by _fetch_by_ids — so a high-scoring
+        out-of-scope memory can never be fused back in.
         """
         limit = max(1, min(int(limit), 200))
         if not q or not q.strip():
@@ -477,12 +550,16 @@ class MemoryManager:
         namespaces = [n for n in (namespaces or []) if n]
         if namespaces:
             clauses.append('m.namespace IN (' + ','.join('?' * len(namespaces)) + ')')
+        scope_clause, scope_params = _ns_scope_clause(namespace_scope, 'm.namespace')
+        if scope_clause:
+            clauses.append(scope_clause)
         if kinds:
             clauses.append('m.kind IN (' + ','.join('?' * len(kinds)) + ')')
         where = ' AND '.join(clauses)
 
-        # Param order matches the SQL: MATCH ?, expires-at-now, namespaces, kinds, LIMIT.
-        params: List[Any] = [fts_q, now, *namespaces, *kinds, limit * 4]
+        # Param order matches the SQL/clause order above: MATCH ?, expires-at-now,
+        # namespaces, scope, kinds, LIMIT.
+        params: List[Any] = [fts_q, now, *namespaces, *scope_params, *kinds, limit * 4]
 
         sql = f"""
             SELECT m.*, bm25(memories_fts) AS fts_rank
@@ -497,7 +574,8 @@ class MemoryManager:
             except sqlite3.OperationalError as e:
                 # Malformed FTS query (e.g. stray operator) — degrade to LIKE.
                 if 'malformed MATCH' in str(e) or 'fts5' in str(e).lower():
-                    rows = cls._search_like(c, q, namespaces, kinds, limit * 4)
+                    rows = cls._search_like(c, q, namespaces, kinds, limit * 4,
+                                            namespace_scope=namespace_scope)
                 else:
                     raise
 
@@ -516,7 +594,8 @@ class MemoryManager:
             by_id: Dict[int, Dict[str, Any]] = {int(r['id']): r for r in fts_dicts}
             if vec_ids:
                 missing = [mid for mid in vec_ids if mid not in by_id]
-                for r in cls._fetch_by_ids(c, missing, namespaces, kinds, now):
+                for r in cls._fetch_by_ids(c, missing, namespaces, kinds, now,
+                                           namespace_scope=namespace_scope):
                     by_id[int(r['id'])] = r
 
         if not vec_ids:
@@ -604,10 +683,13 @@ class MemoryManager:
         return ordered
 
     @staticmethod
-    def _fetch_by_ids(c, ids: List[int], namespaces, kinds, now: float
+    def _fetch_by_ids(c, ids: List[int], namespaces, kinds, now: float,
+                      *, namespace_scope: Optional[str] = None
                       ) -> List[Dict[str, Any]]:
-        """Load live memory rows by id, honoring the same ns/kind/expiry gate
-        as the FTS query so vector-only hits can't smuggle in filtered rows."""
+        """Load live memory rows by id, honoring the same ns/scope/kind/expiry
+        gate as the FTS query so vector-only hits can't smuggle in filtered
+        rows. _vector_search itself does an unfiltered KNN, so this gate is what
+        actually keeps out-of-scope memories out of the fused result (#359)."""
         if not ids:
             return []
         clauses = ['id IN (' + ','.join('?' * len(ids)) + ')',
@@ -617,6 +699,10 @@ class MemoryManager:
         if namespaces:
             clauses.append('namespace IN (' + ','.join('?' * len(namespaces)) + ')')
             params.extend(namespaces)
+        scope_clause, scope_params = _ns_scope_clause(namespace_scope)
+        if scope_clause:
+            clauses.append(scope_clause)
+            params.extend(scope_params)
         if kinds:
             clauses.append('kind IN (' + ','.join('?' * len(kinds)) + ')')
             params.extend(kinds)
@@ -641,7 +727,8 @@ class MemoryManager:
         return 0.55 * rrf_norm + 0.27 * importance + 0.18 * recency
 
     @staticmethod
-    def _search_like(c, q, namespaces, kinds, limit):
+    def _search_like(c, q, namespaces, kinds, limit, *,
+                     namespace_scope: Optional[str] = None):
         params: List[Any] = [time.time()]
         clauses = ['deleted_at IS NULL',
                    '(expires_at IS NULL OR expires_at > ?)']
@@ -651,6 +738,10 @@ class MemoryManager:
         if namespaces:
             clauses.append('namespace IN (' + ','.join('?' * len(namespaces)) + ')')
             params.extend(namespaces)
+        scope_clause, scope_params = _ns_scope_clause(namespace_scope)
+        if scope_clause:
+            clauses.append(scope_clause)
+            params.extend(scope_params)
         if kinds:
             clauses.append('kind IN (' + ','.join('?' * len(kinds)) + ')')
             params.extend(kinds)
@@ -688,29 +779,40 @@ class MemoryManager:
         min_score: float = 0.30,
         max_chars: int = 4096,
         exclude_secret_tag: bool = True,
+        namespace_scope: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Pick the top-K memories relevant to a free-form prompt.
 
         Phase 1: keyword-extracted FTS query, re-ranked with importance +
         recency, secret-tagged entries optionally excluded. Phase 2 will
         union this with vector top-K via reciprocal-rank fusion.
+
+        `namespace_scope` (#359) confines retrieval to one namespace root and
+        everything under it — e.g. `project.foo` for a project-bound chat, so a
+        `project.bar` memory can't be injected into it. None = the previous
+        workspace-global behaviour.
         """
         terms = _extract_terms(prompt)
         if not terms:
             # Empty / stopword-only prompt — fall back to most-important
-            # recently-updated preferences/procedurals.
+            # recently-updated preferences/procedurals. Scope applies here too,
+            # otherwise a scoped chat with a stopword-only prompt would still
+            # pull the whole workspace.
+            scope_clause, scope_params = _ns_scope_clause(namespace_scope)
+            extra = f' AND {scope_clause}' if scope_clause else ''
             with cls.store().conn() as c:
                 rows = c.execute(
                     "SELECT * FROM memories WHERE deleted_at IS NULL "
                     " AND (expires_at IS NULL OR expires_at > ?) "
-                    " AND kind IN ('preference','procedural') "
+                    " AND kind IN ('preference','procedural')"
+                    f"{extra}"
                     " ORDER BY importance DESC, updated_at DESC LIMIT ?",
-                    (time.time(), k * 2),
+                    (time.time(), *scope_params, k * 2),
                 ).fetchall()
             results = [_row_to_dict(r) for r in rows]
         else:
             q = ' OR '.join(terms)
-            results = cls.search(q=q, limit=k * 3)
+            results = cls.search(q=q, limit=k * 3, namespace_scope=namespace_scope)
 
         out: List[Dict[str, Any]] = []
         budget = max_chars
@@ -736,8 +838,10 @@ class MemoryManager:
         for m in memories:
             tags = m.get('tags') or ''
             tag_part = f' (tags: {tags})' if tags else ''
+            # Inject the write-time summary when the entry has one (#359) so a
+            # long memory arrives condensed rather than sliced mid-sentence.
             lines.append(
-                f"- [{m['namespace']}.{m['key']}] {m['value']}{tag_part}"
+                f"- [{m['namespace']}.{m['key']}] {injection_text(m)}{tag_part}"
             )
         return (
             "<workspace_memories>\n"

--- a/charts/workspace/memory/store.py
+++ b/charts/workspace/memory/store.py
@@ -22,7 +22,7 @@ from typing import Iterator, List, Optional, Sequence, Tuple
 
 DB_PATH = '/home/dev/.claude-memory/memory.db'
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 # Width of the vec_memories FLOAT[N] column. Embedding providers must emit
 # (or reduce to) this many dimensions — see memory/embeddings.py. A provider
@@ -118,6 +118,31 @@ def _migrate(conn: sqlite3.Connection) -> None:
             "INSERT INTO _meta(key, value) VALUES('schema_version', '2')"
             " ON CONFLICT(key) DO UPDATE SET value=excluded.value"
         )
+
+    if current < 3:
+        _migration_003(conn)
+        conn.execute(
+            "INSERT INTO _meta(key, value) VALUES('schema_version', '3')"
+            " ON CONFLICT(key) DO UPDATE SET value=excluded.value"
+        )
+
+
+def _migration_003(conn: sqlite3.Connection) -> None:
+    """Add the derived `summary` column (#359).
+
+    Long memories were hard-cut mid-sentence at 280 chars every time they were
+    injected. We instead compute a short summary at WRITE time and inject that,
+    while `value` keeps the user's full content — so recall/search/export are
+    unaffected and nothing is ever lost. NULL means "not summarized" (every
+    pre-existing row, and any row short enough not to need one); readers fall
+    back to `value`, so the column is purely additive.
+
+    Deliberately NOT added to the FTS index: search must keep matching the full
+    text, not a lossy digest.
+    """
+    cols = {r[1] for r in conn.execute('PRAGMA table_info(memories)').fetchall()}
+    if 'summary' not in cols:      # idempotent: safe to re-run
+        conn.execute('ALTER TABLE memories ADD COLUMN summary TEXT')
 
 
 def _migration_002(conn: sqlite3.Connection) -> None:

--- a/charts/workspace/memory/summarize.py
+++ b/charts/workspace/memory/summarize.py
@@ -1,0 +1,140 @@
+"""Write-time summarization for memory values (#359).
+
+WHY THIS EXISTS
+    Injection used to hard-cut every entry at 280 characters, mid-sentence,
+    mid-word — and drop entries entirely once the block budget ran out. That is
+    truncation, not shortening: the reader gets a fragment that may end in the
+    middle of a clause and carries no signal about what was removed.
+
+    Instead we compute a short, self-contained summary once at WRITE time and
+    inject that. The original `value` is never modified — recall, search, the
+    UI and export all keep returning the user's full text (see
+    _migration_003). Summarizing on write also means the cost is paid once per
+    write rather than on every prompt.
+
+WHY EXTRACTIVE BY DEFAULT
+    The only provider-shaped dependency in this subsystem (embeddings) defaults
+    to `none`, so an LLM-only summarizer would be a no-op on most deployments —
+    and a write that can fail because a remote model is down is a bad trade for
+    a *memory* store. The default is therefore deterministic, offline, and
+    allocation-light: it never fails, never blocks, and needs no credential.
+
+    `set_summarizer()` leaves a seam for an LLM-backed implementation; callers
+    that install one are responsible for its latency/failure behaviour (upsert
+    already treats summarization as best-effort and falls back to no summary).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Callable, Optional
+
+# Values at or under this length are already short enough to inject verbatim —
+# summarizing them would only add noise. Comfortably above the injection
+# per-entry budget so a "short" memory never needs trimming downstream.
+SUMMARIZE_THRESHOLD = 240
+
+# Target length for a generated summary. Kept under the injection per-entry
+# budget so a summary never itself needs trimming.
+DEFAULT_TARGET = 220
+
+# Sentence boundary: ., ! or ? followed by whitespace. Deliberately simple —
+# this runs on every write, and over-splitting on "e.g." merely yields a
+# slightly shorter first sentence, never a crash or data loss.
+_SENTENCE_SPLIT = re.compile(r'(?<=[.!?])\s+')
+_WS = re.compile(r'\s+')
+
+
+def _normalize(text: str) -> str:
+    """Collapse whitespace/newlines — injection renders one entry per line."""
+    return _WS.sub(' ', (text or '')).strip()
+
+
+def truncate_on_boundary(text: str, limit: int) -> str:
+    """Shorten `text` to at most `limit` chars, breaking on a word boundary and
+    marking the elision with '…'.
+
+    This is the graceful floor used when even a summary must be shortened. It
+    never splits a word in half, which is exactly what the old fixed 280-char
+    slice did.
+    """
+    text = _normalize(text)
+    if limit <= 0:
+        return ''
+    if len(text) <= limit:
+        return text
+    # Reserve one char for the ellipsis.
+    cut = text[:max(0, limit - 1)]
+    space = cut.rfind(' ')
+    # Only honour the word boundary if it doesn't gut the string (a single very
+    # long token has no usable boundary).
+    if space > limit * 0.6:
+        cut = cut[:space]
+    return cut.rstrip(' ,;:.') + '…'
+
+
+def extractive_summary(value: str, target: int = DEFAULT_TARGET) -> str:
+    """Condense `value` to ~`target` chars by keeping whole leading sentences.
+
+    Memories are written lead-first ("X is Y because Z"), so the opening
+    sentences carry the fact and later ones carry elaboration. We accumulate
+    whole sentences while they fit, which yields a summary that always ends on
+    a real sentence boundary. If even the first sentence overflows, fall back to
+    a word-boundary trim so the result is still clean.
+    """
+    text = _normalize(value)
+    if not text:
+        return ''
+    if len(text) <= target:
+        return text
+
+    out = ''
+    for sentence in _SENTENCE_SPLIT.split(text):
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+        candidate = f'{out} {sentence}'.strip() if out else sentence
+        if len(candidate) > target:
+            break
+        out = candidate
+
+    if not out:
+        # First sentence alone overflows — degrade to a clean word-boundary cut.
+        return truncate_on_boundary(text, target)
+    # Signal that content was elided, so the reader knows to consult the full
+    # entry (via memory_recall) rather than assuming this is everything.
+    return out + ' …'
+
+
+# ── Pluggable seam ──────────────────────────────────────────────────────────
+# A summarizer takes (value, target) and returns the summary text. Swap in an
+# LLM-backed one via set_summarizer(); callers treat failures as "no summary".
+Summarizer = Callable[[str, int], str]
+_summarizer: Summarizer = extractive_summary
+
+
+def set_summarizer(fn: Optional[Summarizer]) -> None:
+    """Install a custom summarizer (None restores the extractive default)."""
+    global _summarizer
+    _summarizer = fn or extractive_summary
+
+
+def summarize(value: str, target: int = DEFAULT_TARGET) -> Optional[str]:
+    """The write-path entry point.
+
+    Returns None when no summary is warranted (empty, already short, or the
+    summarizer produced nothing useful) — the reader then falls back to `value`,
+    so None is always a safe outcome. Never raises: a summarization failure must
+    not fail a memory write.
+    """
+    text = _normalize(value)
+    if not text or len(text) <= SUMMARIZE_THRESHOLD:
+        return None
+    try:
+        summary = _normalize(_summarizer(text, target))
+    except Exception:
+        return None
+    # A "summary" that didn't actually shorten anything is not worth storing.
+    if not summary or len(summary) >= len(text):
+        return None
+    return summary

--- a/charts/workspace/memory_inject_hook.py
+++ b/charts/workspace/memory_inject_hook.py
@@ -33,12 +33,44 @@ import urllib.request
 API_BASE = 'http://localhost:6080/api/memory'
 TOKEN_FILE = '/home/dev/.claude-tasks/.api-token'
 TIMEOUT = 3.0
-MAX_ENTRIES = 8
-MAX_CHARS = 4000
-# Match the documented relevance floor (see values.yaml memory.inject.minScore
-# and MemoryManager.top_for_prompt). Below this the auto-inject prepends
-# noise; the dashboard's create_task path enforces the same floor.
-MIN_SCORE = 0.30
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int((os.environ.get(name) or '').strip() or default)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float((os.environ.get(name) or '').strip() or default)
+    except ValueError:
+        return default
+
+
+# Injection budget. These now come from the chart (memory.inject.* ->
+# KC_MEMORY_INJECT_* in deployment.yaml) so the values and the code are ONE
+# source of truth — previously the hook hardcoded 4000 while values.yaml said
+# 4096 and nothing read it (#359).
+MAX_ENTRIES = _env_int('KC_MEMORY_INJECT_TOPK', 8)
+MAX_CHARS = _env_int('KC_MEMORY_INJECT_MAX_CHARS', 4096)
+# Relevance floor (values.yaml memory.inject.minScore / top_for_prompt). Below
+# this the auto-inject prepends noise; create_task enforces the same floor.
+MIN_SCORE = _env_float('KC_MEMORY_INJECT_MIN_SCORE', 0.30)
+
+# Per-entry ceiling, and the floor we shrink to when the block budget is tight.
+# An entry is never cut mid-word (see _shorten); when the budget runs low we
+# shrink the remaining entries down to MIN_ENTRY_CHARS instead of dropping them
+# outright, so later memories degrade rather than silently vanishing.
+MAX_ENTRY_CHARS = _env_int('KC_MEMORY_INJECT_MAX_ENTRY_CHARS', 280)
+MIN_ENTRY_CHARS = 80
+
+# Namespace scope (#359). A project-bound session exports KC_PROJECT_ID, whose
+# memories live under `project.<id>`; we confine retrieval to that root so a
+# sibling project's memories are never injected here. Unset (a plain terminal
+# session) => no scope => the previous workspace-global behaviour, unchanged.
+PROJECT_NS_PREFIX = 'project.'
 
 
 def _read_token() -> str:
@@ -71,11 +103,30 @@ def _read_prompt() -> str:
     return raw
 
 
+def _namespace_scope() -> str:
+    """The namespace root this session's memories should come from, or '' for
+    workspace-global retrieval (#359).
+
+    KC_PROJECT_ID is exported into every project-bound turn, so a project chat
+    scopes to `project.<id>` (which also covers `project.<id>.decisions`,
+    `.goals`, … — the server anchors the prefix on the '.' separator).
+    KC_MEMORY_NS_SCOPE overrides it for callers that aren't project-bound.
+    """
+    explicit = (os.environ.get('KC_MEMORY_NS_SCOPE') or '').strip()
+    if explicit:
+        return explicit
+    project = (os.environ.get('KC_PROJECT_ID') or '').strip()
+    return f'{PROJECT_NS_PREFIX}{project}' if project else ''
+
+
 def _query_memories(prompt: str, token: str) -> list:
     if not prompt or not token:
         return []
     q = urllib.parse.quote(prompt[:512])
     url = f'{API_BASE}?q={q}&limit={MAX_ENTRIES}'
+    scope = _namespace_scope()
+    if scope:
+        url += f'&namespace_scope={urllib.parse.quote(scope)}'
     req = urllib.request.Request(url, headers={'Authorization': f'Bearer {token}'})
     try:
         with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
@@ -93,6 +144,31 @@ def _query_memories(prompt: str, token: str) -> list:
     return [m for m in memories if _keep(m)]
 
 
+def _shorten(text: str, limit: int) -> str:
+    """Shorten to `limit` chars on a WORD boundary, marking the elision.
+
+    Replaces the old fixed `value[:280]` slice, which cut mid-word and gave the
+    model a fragment with no signal that anything was removed (#359).
+    """
+    text = ' '.join((text or '').split())
+    if limit <= 0 or len(text) <= limit:
+        return text
+    cut = text[:max(0, limit - 1)]
+    space = cut.rfind(' ')
+    if space > limit * 0.6:      # keep a usable boundary; a single huge token has none
+        cut = cut[:space]
+    return cut.rstrip(' ,;:.') + '…'
+
+
+def _entry_text(m: dict) -> str:
+    """Prefer the write-time summary over the raw value (#359): long memories
+    are condensed once at write time, so injection shows a whole-sentence digest
+    rather than an arbitrary slice. Short entries have no summary and are shown
+    verbatim."""
+    return ((m.get('summary') or m.get('value') or '')
+            .replace('\n', ' ').strip())
+
+
 def _format_block(memories: list) -> str:
     if not memories:
         return ''
@@ -101,23 +177,33 @@ def _format_block(memories: list) -> str:
              'prior context; consult before saying you do not know. '
              'When in doubt about facts the user may have told you, '
              'call the `memory_search` tool instead of guessing.']
-    budget = MAX_CHARS
-    used = 0
+    # Only entries that survive the secret filter compete for the budget.
+    entries = []
     for m in memories:
         tags = (m.get('tags') or '').split(',')
         if 'secret' in (t.strip() for t in tags):
             continue
-        ns = m.get('namespace') or ''
-        key = m.get('key') or ''
-        value = (m.get('value') or '').replace('\n', ' ').strip()
-        # Trim individual values so one long entry can't dominate.
-        if len(value) > 280:
-            value = value[:280].rstrip() + '…'
-        line = f'- [{ns}.{key}] {value}'
-        if used + len(line) > budget:
+        text = _entry_text(m)
+        if not text:
+            continue
+        entries.append((f"{m.get('namespace') or ''}.{m.get('key') or ''}", text))
+
+    remaining = MAX_CHARS
+    for i, (label, text) in enumerate(entries):
+        prefix = f'- [{label}] '
+        left = len(entries) - i
+        # Share what's left of the budget with the entries still to come, so a
+        # long early memory can't starve the rest. Each entry gets at least
+        # MIN_ENTRY_CHARS: past the point where even that won't fit, we stop —
+        # but entries shrink long before they're dropped, which is the whole
+        # point (the old code just `break`-ed and lost them).
+        fair = max(MIN_ENTRY_CHARS, (remaining - len(prefix) * left) // max(1, left))
+        allowance = min(MAX_ENTRY_CHARS, fair)
+        line = prefix + _shorten(text, allowance)
+        if len(line) + 1 > remaining:
             break
         lines.append(line)
-        used += len(line) + 1
+        remaining -= len(line) + 1
     lines.append('</workspace_memories>')
     return '\n'.join(lines)
 

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -2126,7 +2126,12 @@ class ClaudeTaskManager:
         injection_block = ''
         if _MEMORY_AVAILABLE and _preinject and not disable_memory_injection:
             try:
-                injected_memories = MemoryManager.top_for_prompt(prompt or '')
+                # Scope retrieval to the task's project (#359) so a build for
+                # one project can't be primed with another's memories. No
+                # project => workspace-global, exactly as before.
+                _scope = f'project.{project_id}' if project_id else None
+                injected_memories = MemoryManager.top_for_prompt(
+                    prompt or '', namespace_scope=_scope)
                 injection_block = MemoryManager.format_injection_block(injected_memories)
             except Exception as e:  # never fail task creation on memory errors
                 print(f'[memory] auto-inject failed: {e}', file=sys.stderr)
@@ -10331,6 +10336,11 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
                 kind=(query.get('kind') or [None])[0],
                 q=(query.get('q') or [None])[0],
                 limit=int((query.get('limit') or ['500'])[0]),
+                # Namespace-scoped retrieval (#359): confines results to one
+                # namespace root and everything nested under it, so a
+                # project-bound caller (the inject hook) never sees a sibling
+                # project's memories. Absent => workspace-global, as before.
+                namespace_scope=(query.get('namespace_scope') or [None])[0],
             )
         except Exception as e:
             self._memory_error(e); return

--- a/charts/workspace/templates/deployment.yaml
+++ b/charts/workspace/templates/deployment.yaml
@@ -195,6 +195,26 @@ spec:
           value: {{ . | quote }}
         {{- end }}
         {{- end }}
+        {{- /* Memory auto-injection budget (#359). These make memory.inject.*
+               the single source of truth: the UserPromptSubmit hook reads them
+               instead of hardcoding its own limits (which had drifted from the
+               chart — 4000 in code vs 4096 here). */}}
+        {{- with (.Values.memory.inject).topK }}
+        - name: KC_MEMORY_INJECT_TOPK
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with (.Values.memory.inject).maxChars }}
+        - name: KC_MEMORY_INJECT_MAX_CHARS
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with (.Values.memory.inject).minScore }}
+        - name: KC_MEMORY_INJECT_MIN_SCORE
+          value: {{ . | quote }}
+        {{- end }}
+        {{- with (.Values.memory.inject).maxEntryChars }}
+        - name: KC_MEMORY_INJECT_MAX_ENTRY_CHARS
+          value: {{ . | quote }}
+        {{- end }}
         {{- if .Values.github.app.appId }}
         # GITHUB_APP_PRIVATE_KEY is deliberately NOT here (issue #558). The
         # agent runs in this container and every process it spawns inherits

--- a/charts/workspace/tests/deployment_test.yaml
+++ b/charts/workspace/tests/deployment_test.yaml
@@ -615,3 +615,41 @@ tests:
           any: true
           content:
             name: KC_HARNESS_EFFORT
+
+  # ── Memory auto-injection budget (#359) ────────────────────────────────────
+
+  - it: projects memory.inject.* so the hook and the chart share one source of truth
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_MEMORY_INJECT_TOPK
+            value: "8"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_MEMORY_INJECT_MAX_CHARS
+            value: "4096"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_MEMORY_INJECT_MAX_ENTRY_CHARS
+            value: "280"
+
+  - it: honours an overridden injection budget
+    template: templates/deployment.yaml
+    set:
+      memory.inject.topK: 4
+      memory.inject.maxChars: 2048
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_MEMORY_INJECT_TOPK
+            value: "4"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_MEMORY_INJECT_MAX_CHARS
+            value: "2048"

--- a/charts/workspace/tests/memory_scope_test.py
+++ b/charts/workspace/tests/memory_scope_test.py
@@ -1,0 +1,133 @@
+"""Namespace-scoped memory retrieval (#359).
+
+Injection used to retrieve from the whole workspace DB, so a `project.foo`
+memory could surface inside a `project.bar` chat whenever it out-scored the
+local ones. These tests pin the scoping contract, including the prefix-anchoring
+and LIKE-escaping edge cases that make `project.foo` NOT match `project.foobar`
+or `project.foo_x`.
+
+Run with:   python3 -m unittest tests.memory_scope_test   (from charts/workspace/)
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+
+from memory import store as _store_mod  # noqa: E402
+from memory.store import MemoryStore  # noqa: E402
+from memory.manager import MemoryManager  # noqa: E402
+
+
+class ScopeTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self._orig_store = MemoryManager._store
+        self._orig_init = _store_mod._INITIALIZED
+        _store_mod._INITIALIZED = False
+        MemoryManager._store = MemoryStore(
+            os.path.join(self._tmpdir.name, 'memory.db'))
+        # A deliberately adversarial namespace set: siblings that share a
+        # textual prefix with the scope, and one containing a LIKE wildcard.
+        for ns, key in (
+            ('project.foo', 'a'),
+            ('project.foo.decisions', 'b'),
+            ('project.foo.goals', 'c'),
+            ('project.foobar', 'd'),      # prefix-shares, must NOT match
+            ('project.foo_x', 'e'),       # '_' is a LIKE wildcard, must NOT match
+            ('project.bar', 'f'),
+            ('user', 'g'),
+        ):
+            MemoryManager.upsert(namespace=ns, key=key,
+                                 value='deployment pipeline notes')
+
+    def tearDown(self):
+        MemoryManager._store = self._orig_store
+        _store_mod._INITIALIZED = self._orig_init
+
+    def _namespaces(self, rows):
+        return sorted(r['namespace'] for r in rows)
+
+    IN_SCOPE = ['project.foo', 'project.foo.decisions', 'project.foo.goals']
+
+
+class SearchScopeTests(ScopeTestCase):
+    def test_scope_matches_root_and_descendants_only(self):
+        rows = MemoryManager.search(q='deployment', namespace_scope='project.foo',
+                                    limit=50)
+        self.assertEqual(self._namespaces(rows), self.IN_SCOPE)
+
+    def test_scope_excludes_prefix_sharing_sibling(self):
+        # The classic bug: a naive LIKE 'project.foo%' also matches
+        # `project.foobar`. Anchoring on the '.' separator prevents it.
+        rows = MemoryManager.search(q='deployment', namespace_scope='project.foo',
+                                    limit=50)
+        self.assertNotIn('project.foobar', self._namespaces(rows))
+
+    def test_scope_escapes_like_wildcards(self):
+        # '_' matches any single char in LIKE; unescaped, `project.foo_x` would
+        # be pulled in by a scope of `project.foo`.
+        rows = MemoryManager.search(q='deployment', namespace_scope='project.foo',
+                                    limit=50)
+        self.assertNotIn('project.foo_x', self._namespaces(rows))
+
+    def test_underscore_scope_is_literal(self):
+        rows = MemoryManager.search(q='deployment', namespace_scope='project.foo_x',
+                                    limit=50)
+        self.assertEqual(self._namespaces(rows), ['project.foo_x'])
+
+    def test_no_scope_is_workspace_global(self):
+        # Unscoped retrieval must keep the previous behaviour exactly.
+        rows = MemoryManager.search(q='deployment', limit=50)
+        self.assertEqual(len(rows), 7)
+
+    def test_unknown_scope_returns_nothing(self):
+        rows = MemoryManager.search(q='deployment', namespace_scope='project.nope',
+                                    limit=50)
+        self.assertEqual(rows, [])
+
+
+class TopForPromptScopeTests(ScopeTestCase):
+    def test_scoped_injection_excludes_other_projects(self):
+        rows = MemoryManager.top_for_prompt('deployment pipeline',
+                                            namespace_scope='project.foo')
+        got = self._namespaces(rows)
+        self.assertTrue(got)
+        for ns in got:
+            self.assertIn(ns, self.IN_SCOPE)
+
+    def test_stopword_only_prompt_still_honours_scope(self):
+        # The empty-terms fallback path selects preference/procedural rows
+        # directly; it must be scoped too, or a scoped chat with a trivial
+        # prompt would still pull the whole workspace.
+        MemoryManager.upsert(namespace='project.foo', key='pref',
+                             value='prefers tabs', kind='preference')
+        MemoryManager.upsert(namespace='project.bar', key='pref',
+                             value='prefers spaces', kind='preference')
+        rows = MemoryManager.top_for_prompt('the and of',
+                                            namespace_scope='project.foo')
+        for ns in self._namespaces(rows):
+            self.assertTrue(ns.startswith('project.foo'))
+
+    def test_unscoped_is_unchanged(self):
+        rows = MemoryManager.top_for_prompt('deployment pipeline')
+        self.assertTrue(len(rows) > 0)
+
+
+class ListScopeTests(ScopeTestCase):
+    def test_list_honours_scope(self):
+        rows = MemoryManager.list(namespace_scope='project.foo', limit=50)
+        self.assertEqual(self._namespaces(rows), self.IN_SCOPE)
+
+    def test_list_with_query_honours_scope(self):
+        rows = MemoryManager.list(q='deployment', namespace_scope='project.foo',
+                                  limit=50)
+        self.assertEqual(self._namespaces(rows), self.IN_SCOPE)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/tests/memory_summarize_test.py
+++ b/charts/workspace/tests/memory_summarize_test.py
@@ -1,0 +1,270 @@
+"""Write-time summarization + graceful injection budgeting (#359).
+
+Long memories used to be hard-cut at 280 chars mid-sentence on every injection,
+and entries past the block budget were dropped entirely. These tests pin the
+replacement: a summary computed once at write time (with `value` preserved
+untouched), word-boundary trimming, and shrink-rather-than-drop budgeting.
+
+Run with:  python3 -m unittest tests.memory_summarize_test  (from charts/workspace/)
+"""
+
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+
+import memory_inject_hook as hook  # noqa: E402
+from memory import store as _store_mod  # noqa: E402
+from memory import summarize as S  # noqa: E402
+from memory.store import MemoryStore  # noqa: E402
+from memory.manager import MemoryManager, injection_text  # noqa: E402
+
+LONG = ('The deploy pipeline pushes to DigitalOcean first. '
+        'It then runs helm upgrade against the ws namespace. '
+        'If the rollout stalls the operator must check the kaniko builder pod. '
+        'Historically this failed because the regcred secret was not replicated. '
+        'A follow-up added namespace seeding to make that automatic.')
+
+
+class ExtractiveSummaryTests(unittest.TestCase):
+    def test_short_text_needs_no_summary(self):
+        self.assertIsNone(S.summarize('Postgres runs on port 5432.'))
+
+    def test_empty_text_needs_no_summary(self):
+        self.assertIsNone(S.summarize(''))
+        self.assertIsNone(S.summarize('   '))
+
+    def test_long_text_is_shortened(self):
+        out = S.summarize(LONG)
+        self.assertIsNotNone(out)
+        self.assertLess(len(out), len(LONG))
+
+    def test_summary_ends_on_a_sentence_boundary(self):
+        # The whole point: no mid-sentence cut.
+        out = S.summarize(LONG)
+        self.assertTrue(out.rstrip('… ').endswith('.'), out)
+
+    def test_summary_keeps_the_leading_fact(self):
+        out = S.summarize(LONG)
+        self.assertTrue(out.startswith('The deploy pipeline pushes'), out)
+
+    def test_single_giant_sentence_degrades_to_word_boundary(self):
+        # No sentence fits, so we fall back to a clean word-boundary trim
+        # rather than slicing mid-word.
+        giant = 'alpha beta gamma delta epsilon ' * 40
+        out = S.summarize(giant)
+        self.assertIsNotNone(out)
+        self.assertTrue(out.endswith('…'))
+        for fragment in ('alph…', 'bet…', 'gamm…', 'delt…'):
+            self.assertFalse(out.endswith(fragment), out)
+
+    def test_newlines_are_collapsed(self):
+        out = S.summarize('First line.\nSecond line.\n' * 20)
+        self.assertNotIn('\n', out)
+
+    def test_summarizer_failure_is_swallowed(self):
+        # A summarization failure must never fail a memory write.
+        def boom(_value, _target):
+            raise RuntimeError('provider down')
+        S.set_summarizer(boom)
+        self.addCleanup(S.set_summarizer, None)
+        self.assertIsNone(S.summarize(LONG))
+
+    def test_custom_summarizer_is_used(self):
+        S.set_summarizer(lambda value, target: 'CUSTOM')
+        self.addCleanup(S.set_summarizer, None)
+        self.assertEqual(S.summarize(LONG), 'CUSTOM')
+
+    def test_truncate_on_boundary_never_splits_a_word(self):
+        out = S.truncate_on_boundary('alpha beta gamma delta', 14)
+        self.assertTrue(out.endswith('…'))
+        self.assertNotIn('gam…', out)
+
+    def test_truncate_handles_a_single_unbroken_token(self):
+        out = S.truncate_on_boundary('x' * 100, 10)
+        self.assertEqual(len(out), 10)
+
+
+class StoreTestCase(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.db = os.path.join(self._tmpdir.name, 'memory.db')
+        self._orig_store = MemoryManager._store
+        self._orig_init = _store_mod._INITIALIZED
+        _store_mod._INITIALIZED = False
+        MemoryManager._store = MemoryStore(self.db)
+
+    def tearDown(self):
+        MemoryManager._store = self._orig_store
+        _store_mod._INITIALIZED = self._orig_init
+
+
+class WritePathTests(StoreTestCase):
+    def test_upsert_stores_summary_and_preserves_value(self):
+        row = MemoryManager.upsert(namespace='p.a', key='k', value=LONG)
+        # The user's full text is never modified — this is the whole reason the
+        # summary is a separate, derived column.
+        self.assertEqual(row['value'], LONG)
+        self.assertIsNotNone(row['summary'])
+        self.assertLess(len(row['summary']), len(LONG))
+
+    def test_short_value_has_no_summary(self):
+        row = MemoryManager.upsert(namespace='p.a', key='k', value='Short fact.')
+        self.assertIsNone(row['summary'])
+
+    def test_injection_text_prefers_summary_then_falls_back(self):
+        long_row = MemoryManager.upsert(namespace='p.a', key='k1', value=LONG)
+        short_row = MemoryManager.upsert(namespace='p.a', key='k2', value='Short.')
+        self.assertEqual(injection_text(long_row), long_row['summary'])
+        self.assertEqual(injection_text(short_row), 'Short.')
+
+    def test_summary_is_recomputed_when_value_changes(self):
+        MemoryManager.upsert(namespace='p.a', key='k', value=LONG)
+        row = MemoryManager.update_partial(namespace='p.a', key='k',
+                                           value='Now brief.')
+        self.assertIsNone(row['summary'])
+        self.assertEqual(row['value'], 'Now brief.')
+
+    def test_metadata_only_update_keeps_summary(self):
+        MemoryManager.upsert(namespace='p.a', key='k', value=LONG)
+        row = MemoryManager.update_partial(namespace='p.a', key='k',
+                                           importance=0.9)
+        self.assertIsNotNone(row['summary'])
+        self.assertEqual(row['value'], LONG)
+
+    def test_search_still_matches_text_only_in_the_full_value(self):
+        # The summary is NOT in the FTS index, so search must still find a term
+        # that only appears in the elided tail.
+        MemoryManager.upsert(namespace='p.a', key='k', value=LONG)
+        rows = MemoryManager.search(q='seeding', limit=10)
+        self.assertEqual([r['key'] for r in rows], ['k'])
+
+
+class MigrationTests(unittest.TestCase):
+    """A v2 database (pre-summary) must upgrade in place without data loss."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.db = os.path.join(self._tmpdir.name, 'legacy.db')
+        self._orig_store = MemoryManager._store
+        self._orig_init = _store_mod._INITIALIZED
+        self.addCleanup(self._restore)
+        # Build a genuine v2 DB with raw SQL (migrations 001+002 only).
+        conn = sqlite3.connect(self.db)
+        conn.row_factory = sqlite3.Row
+        conn.execute('CREATE TABLE IF NOT EXISTS _meta ('
+                     ' key TEXT PRIMARY KEY, value TEXT NOT NULL)')
+        _store_mod._migration_001(conn)
+        _store_mod._migration_002(conn)
+        conn.execute("INSERT INTO _meta(key,value) VALUES('schema_version','2')")
+        now = time.time()
+        conn.execute(
+            'INSERT INTO memories (namespace,key,value,kind,tags,importance,'
+            'confidence,source,created_at,updated_at,version)'
+            ' VALUES (?,?,?,?,?,?,?,?,?,?,?)',
+            ('legacy.ns', 'old', LONG, 'semantic', '', 0.5, 1.0, '', now, now, 1))
+        conn.commit()
+        conn.close()
+
+    def _restore(self):
+        MemoryManager._store = self._orig_store
+        _store_mod._INITIALIZED = self._orig_init
+
+    def _open(self):
+        _store_mod._INITIALIZED = False
+        MemoryManager._store = MemoryStore(self.db)
+
+    def test_legacy_row_survives_and_falls_back_to_value(self):
+        self._open()
+        row = MemoryManager.get(namespace='legacy.ns', key='old')
+        self.assertEqual(row['value'], LONG)
+        self.assertIsNone(row['summary'])
+        self.assertEqual(injection_text(row), LONG)
+
+    def test_migration_is_idempotent(self):
+        self._open()
+        self._open()  # re-run migrations on the already-upgraded DB
+        self.assertEqual(
+            MemoryManager.get(namespace='legacy.ns', key='old')['value'], LONG)
+
+    def test_rewriting_a_legacy_row_backfills_its_summary(self):
+        self._open()
+        row = MemoryManager.upsert(namespace='legacy.ns', key='old', value=LONG)
+        self.assertIsNotNone(row['summary'])
+
+
+class InjectionBudgetTests(unittest.TestCase):
+    """The hook's block builder: no mid-word cuts, no silently dropped entries."""
+
+    def _mem(self, i, value, **over):
+        m = {'namespace': 'p', 'key': f'k{i}', 'value': value}
+        m.update(over)
+        return m
+
+    def test_long_entries_are_shrunk_not_dropped(self):
+        mems = [self._mem(i, 'word ' * 400) for i in range(8)]
+        block = hook._format_block(mems)
+        for i in range(8):
+            self.assertIn(f'p.k{i}]', block, f'entry {i} was dropped')
+
+    def test_block_respects_the_char_budget(self):
+        mems = [self._mem(i, 'word ' * 400) for i in range(8)]
+        block = hook._format_block(mems)
+        # Allow for the wrapper/preamble lines, which sit outside the entry budget.
+        self.assertLessEqual(len(block), hook.MAX_CHARS + 400)
+
+    def test_entries_are_not_cut_mid_word(self):
+        block = hook._format_block([self._mem(0, 'alpha beta gamma ' * 60)])
+        for line in block.splitlines():
+            if line.startswith('- ['):
+                self.assertFalse(line.rstrip('…').endswith(('alph', 'bet', 'gamm')),
+                                 line)
+
+    def test_summary_is_preferred_over_value(self):
+        block = hook._format_block(
+            [self._mem(0, 'the full untruncated value', summary='the digest')])
+        self.assertIn('the digest', block)
+        self.assertNotIn('untruncated', block)
+
+    def test_secret_tagged_entries_are_excluded(self):
+        block = hook._format_block([self._mem(0, 'hunter2', tags='secret')])
+        self.assertNotIn('p.k0]', block)
+
+    def test_empty_memories_produce_no_block(self):
+        self.assertEqual(hook._format_block([]), '')
+
+    def test_short_entries_are_untouched(self):
+        block = hook._format_block([self._mem(0, 'Postgres runs on 5432.')])
+        self.assertIn('Postgres runs on 5432.', block)
+        self.assertNotIn('…', block)
+
+
+class ScopeResolutionTests(unittest.TestCase):
+    def tearDown(self):
+        for k in ('KC_PROJECT_ID', 'KC_MEMORY_NS_SCOPE'):
+            os.environ.pop(k, None)
+
+    def test_no_project_means_global(self):
+        os.environ.pop('KC_PROJECT_ID', None)
+        os.environ.pop('KC_MEMORY_NS_SCOPE', None)
+        self.assertEqual(hook._namespace_scope(), '')
+
+    def test_project_id_maps_to_project_namespace(self):
+        os.environ['KC_PROJECT_ID'] = 'kube-coder'
+        self.assertEqual(hook._namespace_scope(), 'project.kube-coder')
+
+    def test_explicit_override_wins(self):
+        os.environ['KC_PROJECT_ID'] = 'kube-coder'
+        os.environ['KC_MEMORY_NS_SCOPE'] = 'team.infra'
+        self.assertEqual(hook._namespace_scope(), 'team.infra')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -589,11 +589,18 @@ memory:
     existingSecretName: ""
     baseUrl: ""             # openai-compatible endpoint (self-hosted / proxy)
   # Auto-injection: prefix new task prompts with the top-K relevant memories.
+  # Auto-injection budget. These are the single source of truth: the chart
+  # projects them as KC_MEMORY_INJECT_* and the UserPromptSubmit hook reads
+  # them (it used to hardcode its own, drifted, copies — #359).
   inject:
     enabled: true
     topK: 8
     minScore: 0.30
+    # Whole-block ceiling. Entries are shrunk to fit rather than dropped.
     maxChars: 4096
+    # Per-entry ceiling. Long memories are summarized at write time, so this
+    # is a backstop — and it now trims on a word boundary, never mid-word.
+    maxEntryChars: 280
   # Background consolidation (dedupe + decay). Phase 3 activates this thread.
   consolidation:
     enabled: false


### PR DESCRIPTION


Two memory problems, both confirmed in the code:

(a) Retrieval was workspace-global. Nothing filtered injection by namespace, so a project.foo memory could be pulled into a project.bar chat whenever it scored well — paying tokens for context that belongs to a different project. search() already accepted a `namespaces` allow-list but nothing passed one, and it only matched exactly. Adds a `namespace_scope` root that matches the root plus everything nested under it, applied on every retrieval path (FTS, the LIKE degradation, the vector-only hits loaded by _fetch_by_ids, and top_for_prompt's stopword-only fallback, which previously ignored filtering entirely). The prefix is anchored on the '.' separator and LIKE metacharacters are escaped, so a scope of project.foo matches project.foo.decisions but NOT project.foobar or project.foo_x — the underscore case is a real leak, since _ is a LIKE wildcard.

The inject hook derives its scope from KC_PROJECT_ID (already exported into project-bound turns) and create_task from the task's project_id. No project means no scope, i.e. the previous global behaviour, so terminal sessions are unchanged.

(b) Long entries were truncated, not shortened. Injection hard-cut every value at 280 chars mid-sentence, and once the block budget was hit the remaining entries were dropped outright. Adds a derived `summary` column (schema v3) computed once at write time by an extractive summarizer that keeps whole leading sentences, so what gets injected ends on a real boundary. `value` is never modified — recall, search, the UI and export all still return the user's full text, and the summary is deliberately kept out of the FTS index so search still matches the elided tail. Injection now prefers the summary, trims on word boundaries, and shrinks the remaining entries to a fair share of the budget instead of dropping them.

The summarizer is extractive by default rather than LLM-backed: the only provider-shaped dependency here (embeddings) defaults to none, so an LLM-only implementation would be a no-op on most deployments, and a write that can fail because a remote model is down is a bad trade for a memory store. set_summarizer() leaves the seam for one.

Also makes memory.inject.* the single source of truth. The hook hardcoded MAX_CHARS = 4000 while values.yaml said maxChars: 4096 and nothing read it; the chart now projects KC_MEMORY_INJECT_* and the hook reads those.

Tests: 41 new (11 scoping, 30 summarization/injection) plus 2 helm cases. The v2 -> v3 upgrade is verified against a legacy database built with raw SQL — data intact, migration idempotent, and a NULL summary falls back to the full value. Export omits the derived column and import recomputes it. Full suite diffed against baseline: no new failures.