### PR TITLE
feat(kc-issue): lint the issue body before spawning an agent on it

### DIFF
--- a/.claude/skills/kc-issue/SKILL.md
+++ b/.claude/skills/kc-issue/SKILL.md
@@ -3,7 +3,7 @@ name: kc-issue
 description: Spin up an isolated agent to work a kube-coder issue. Given an issue number, creates a clean git worktree branched from a freshly-fetched origin/main, pulls the issue text, and launches a background Claude task that is BORN inside that worktree (workdir=worktree) so it cannot work in the shared clone. Use whenever the user wants to "work on issue N", "start an agent on issue N", or set up a per-issue worktree. Also lists issue worktrees and their task status.
 user-invocable: true
 allowed-tools: Bash, Read, mcp__dashboard__create_task, mcp__dashboard__list_tasks, mcp__dashboard__get_task
-argument-hint: "<issue-number> [--pr]  |  list  |  <slug> \"free text\""
+argument-hint: "<issue-number> [--pr]  |  list  |  lint [file]  |  <slug> \"free text\""
 ---
 
 # kc-issue — one issue, one clean worktree, one agent
@@ -38,7 +38,27 @@ bash "$CLAUDE_SKILL_DIR/kc-issue.sh" <N>
 KC_AUTO_PR=1 bash "$CLAUDE_SKILL_DIR/kc-issue.sh" <N>
 ```
 Capture the JSON it prints on stdout:
-`{issue,title,url,worktree,branch,port,prompt_file,auto_pr}`.
+`{issue,title,url,worktree,branch,port,prompt_file,auto_pr,lint,lint_blockers}`.
+
+**Step 1b — surface the issue-body lint (#569).** The script lints the body
+*before* the worktree exists, because the body is baked verbatim into the agent
+prompt: a thin issue silently produces a thin prompt, and the cost is paid
+before anyone can react. Findings arrive two ways — human-readable on **stderr**,
+and structured in the JSON's `lint` array (`{severity,code,message}`).
+
+If `lint` is non-empty, **show the user the findings before Step 3** — a short
+list, one per line. Then:
+
+- **`lint_blockers > 0`** (today: the `needs-scoping` label — the repo itself
+  saying this isn't ready to implement): **stop and ask** whether to proceed.
+  Spawning on a `needs-scoping` issue is almost always wrong, so this is the one
+  case where you wait for an explicit yes.
+- **warnings only**: mention them in one line and continue. A terse issue is
+  sometimes genuinely fine and the operator knows it — the script warns, it
+  never blocks, and the human makes the call.
+
+Never edit or enrich the issue body to silence a warning; the lint reports, it
+doesn't rewrite.
 
 **Step 2 — read the baked prompt** (do NOT reconstruct it — use the file):
 ```bash
@@ -56,7 +76,18 @@ worktree path, and the preview port. Offer to show live output with
 up, use the port at `/api/app-proxy/<port>/`.
 
 ### `<slug> "free text"` — ad-hoc (no GitHub issue)
-Same flow; the description text is used in place of an issue body.
+Same flow; the description text is used in place of an issue body — and it is
+linted the same way. This path is **more** exposed than the issue path: a
+one-line `--desc` becomes the entire specification the agent ever sees, so take
+its warnings seriously.
+
+### `lint [file]` — check a body without spawning anything
+```bash
+bash "$CLAUDE_SKILL_DIR/kc-issue.sh" lint path/to/draft.md   # or pipe on stdin
+```
+Touches no git, no GitHub, no worktree. Findings print on stderr, JSON on
+stdout; exits 1 on a blocker. Useful for sanity-checking a draft issue before
+filing it, and it's what `lint_test.sh` drives.
 
 ## Notes & footguns
 
@@ -68,6 +99,16 @@ Same flow; the description text is used in place of an issue body.
   which is why this orchestration skill lives in the user-global skills dir.)
 - **Idempotent.** Re-running for the same issue reuses the existing worktree +
   branch and rewrites the prompt; it won't clobber committed work.
+- **The lint warns, it never blocks.** Default behaviour always proceeds. Set
+  `KC_ISSUE_STRICT=1` to make the script *refuse* to spawn when a blocker fires
+  — it exits before creating the worktree, so nothing is spent. Leave it unset
+  unless you want that guardrail.
+  ```bash
+  KC_ISSUE_STRICT=1 bash "$CLAUDE_SKILL_DIR/kc-issue.sh" <N>
+  ```
+- **Lint runs at spawn time, not issue-creation time.** That's deliberate: it's
+  the cheaper place to catch the problem, and it also covers issues written
+  before the lint existed.
 - **Cleanup when done** (after the PR merges): remove the worktree dir but keep
   history via the repo's worktree helper:
   ```bash

--- a/.claude/skills/kc-issue/kc-issue.sh
+++ b/.claude/skills/kc-issue/kc-issue.sh
@@ -3,10 +3,11 @@
 #
 # Does the filesystem/git half of the framework so it's reliable and testable:
 #   1. fetch a FRESH origin/main (never trust a stale/dirty local HEAD)
-#   2. resolve the issue (gh) -> title/body/url  (numeric arg = issue #)
+#   2. resolve the issue (gh) -> title/body/url/labels  (numeric arg = issue #)
+#   2b. LINT the body before spending anything on it (#569)
 #   3. create OR reuse an isolated worktree branched from origin/main
 #   4. write a ready-to-use agent prompt into the worktree
-#   5. print a JSON blob {issue,title,url,worktree,branch,port,prompt_file}
+#   5. print a JSON blob {issue,title,url,worktree,branch,port,prompt_file,lint}
 #
 # It does NOT launch the agent -- the caller (the Hypervisor) reads the JSON and
 # launches a background task with workdir=<worktree>, so the agent is BORN inside
@@ -16,27 +17,168 @@
 #   kc-issue.sh <issue-number>            # e.g. kc-issue.sh 284  (or "#284")
 #   kc-issue.sh <slug> "free text desc"   # ad-hoc, no GitHub issue
 #   kc-issue.sh list                      # show issue worktrees for the repo
+#   kc-issue.sh lint [file]               # lint a body (file or stdin); no git
+#
+# Env:
+#   KC_AUTO_PR=1       bake "open a PR" into the done-list
+#   KC_ISSUE_STRICT=1  refuse to spawn when the body trips a lint blocker
 set -euo pipefail
 
 REPO_ROOT="${KC_REPO_ROOT:-/home/dev/kube-coder}"
 REPO_SLUG="${KC_REPO_SLUG:-imran31415/kube-coder}"
 WT_HELPER="$REPO_ROOT/.claude/skills/worktree/worktree.sh"
 AUTO_PR="${KC_AUTO_PR:-0}"   # set to 1 to bake "open a PR" into the done-list
+# Refuse to spawn when the issue body trips a lint blocker (default: warn only).
+# Env rather than a flag to match KC_AUTO_PR / KC_REPO_* — the positional args
+# are already <issue|slug> [desc] and adding a flag would mean reworking parsing.
+STRICT="${KC_ISSUE_STRICT:-0}"
 
 die() { echo "kc-issue: $*" >&2; exit 1; }
 
-[ -f "$WT_HELPER" ] || die "worktree helper missing at $WT_HELPER"
-[ -d "$REPO_ROOT/.git" ] || die "$REPO_ROOT is not a git repo"
+# ── Issue-body lint (#569) ──────────────────────────────────────────────────
+# The body is baked verbatim into the agent prompt, so a thin issue silently
+# produces a thin prompt: the agent spawns, burns a worktree and real tokens,
+# and only discovers the ambiguity 20 minutes in — or doesn't, and confidently
+# ships the wrong thing. This looks at the text BEFORE any of that is spent.
+#
+# Warn, never block (unless KC_ISSUE_STRICT=1). A terse issue is sometimes
+# genuinely fine and the operator knows it, so the script surfaces the signal
+# and leaves the judgement to a human.
+#
+# Findings go to STDERR and into the JSON. Never stdout — that is the caller's
+# machine-readable contract and anything else there breaks its `jq`.
+LINT_FINDINGS=()   # "severity|code|message"
+LINT_BLOCKERS=0
+
+_lint_add() {  # severity code message
+  LINT_FINDINGS+=("$1|$2|$3")
+  [ "$1" = blocker ] && LINT_BLOCKERS=$((LINT_BLOCKERS + 1))
+  return 0
+}
+
+# lint_issue_body <body> [labels_csv]
+# Populates LINT_FINDINGS/LINT_BLOCKERS. Always returns 0 — the caller decides
+# what to do about the findings.
+lint_issue_body() {
+  local body="${1:-}" labels="${2:-}"
+  LINT_FINDINGS=(); LINT_BLOCKERS=0
+
+  # Lowercased copy for case-insensitive matching; `compact` strips whitespace
+  # so "near-empty" means real content, not blank lines and a heading.
+  local lower compact
+  lower=$(printf '%s' "$body" | tr '[:upper:]' '[:lower:]')
+  compact=$(printf '%s' "$body" | tr -d '[:space:]')
+
+  # 1. needs-scoping label — the repo itself says this isn't ready to implement.
+  #    Cheapest and strongest signal, so it is the one blocker.
+  if printf '%s' "$labels" | tr '[:upper:]' '[:lower:]' | grep -q 'needs-scoping'; then
+    _lint_add blocker needs-scoping \
+      "issue carries the 'needs-scoping' label — the repo says it is not ready to implement"
+  fi
+
+  # 2. Empty / near-empty body — a title-only issue gives the agent a headline.
+  if [ "${#compact}" -lt 80 ]; then
+    _lint_add warn thin-body \
+      "body is empty or near-empty (${#compact} non-whitespace chars) — the agent gets little beyond the title"
+  fi
+
+  # 3. No acceptance criteria — nothing states what "done" looks like, so the
+  #    agent invents its own bar.
+  if ! grep -qE 'acceptance|criteria|done when|definition of done|- \[ \]|- \[x\]' <<<"$lower"; then
+    _lint_add warn no-acceptance-criteria \
+      "no acceptance criteria found — nothing states what 'done' looks like"
+  fi
+
+  # 4. No file/path/component pointer — the agent has to guess where the change
+  #    goes, and guessing wrong is expensive to unwind.
+  if ! grep -qE '[a-z0-9_./-]+\.(sh|py|ts|tsx|js|jsx|ya?ml|json|md|toml)|`[^`]*/[^`]*`|(charts|scripts|docs|mobile|devlaptop|provisioner)/' <<<"$lower"; then
+    _lint_add warn no-file-pointers \
+      "no file/path/component pointers — the agent has to guess where the change goes"
+  fi
+
+  # 5. No verification path — nothing says how to confirm the change works.
+  if ! grep -qE 'test|verif|reproduc|repro |how to check|expected|assert|preflight' <<<"$lower"; then
+    _lint_add warn no-verification \
+      "no verification path — nothing says how to confirm the change works"
+  fi
+
+  # 6. Unquantified comparatives — "make it faster" with no target. Only fires
+  #    when the body carries no digit at all, so "cut p95 to 200ms" is fine.
+  if grep -qE 'faster|slower|improve|better|optimi[sz]e|clean up|cleanup|reduce|speed up' <<<"$lower" \
+     && ! grep -qE '[0-9]' <<<"$body"; then
+    _lint_add warn unquantified-comparative \
+      "comparative goal with no number (faster/improve/reduce/…) — no target to hit or measure"
+  fi
+  return 0
+}
+
+# Print findings for a human. stderr only.
+lint_report() {
+  [ "${#LINT_FINDINGS[@]}" -eq 0 ] && return 0
+  echo "kc-issue: lint: ${#LINT_FINDINGS[@]} finding(s) on this issue body:" >&2
+  local f sev code msg
+  for f in "${LINT_FINDINGS[@]}"; do
+    sev="${f%%|*}"; code="${f#*|}"; code="${code%%|*}"; msg="${f##*|}"
+    echo "kc-issue: lint:   [$sev] $code: $msg" >&2
+  done
+  if [ "$LINT_BLOCKERS" -gt 0 ] && [ "$STRICT" != 1 ]; then
+    echo "kc-issue: lint: proceeding anyway (set KC_ISSUE_STRICT=1 to refuse on blockers)." >&2
+  elif [ "$STRICT" != 1 ]; then
+    echo "kc-issue: lint: warnings only — proceeding." >&2
+  fi
+  return 0
+}
+
+# Findings as a JSON array, for the machine-readable result.
+lint_json() {
+  local f sev code msg
+  # jq is a hard dependency of the spawn path, but `lint` is meant to run
+  # anywhere (CI, a laptop). Degrade to an empty array rather than dying — the
+  # human report on stderr is the part that matters offline.
+  command -v jq >/dev/null 2>&1 || { echo '[]'; return 0; }
+  { for f in "${LINT_FINDINGS[@]:-}"; do
+      [ -n "$f" ] || continue
+      sev="${f%%|*}"; code="${f#*|}"; code="${code%%|*}"; msg="${f##*|}"
+      jq -n --arg s "$sev" --arg c "$code" --arg m "$msg" \
+        '{severity:$s, code:$c, message:$m}'
+    done; } | jq -s '.'
+}
+
+# Only the git-touching subcommands need the repo + worktree helper. `lint` is
+# pure text analysis, so it must stay runnable anywhere — including CI and a
+# laptop that has no pod layout.
+require_repo() {
+  [ -f "$WT_HELPER" ] || die "worktree helper missing at $WT_HELPER"
+  [ -d "$REPO_ROOT/.git" ] || die "$REPO_ROOT is not a git repo"
+}
 
 cmd_list() {
+  require_repo
   echo "# issue worktrees for $REPO_SLUG" >&2
   git -C "$REPO_ROOT" worktree list | grep -E 'kc/issue-|issue-' || echo "(none)" >&2
 }
 
+# kc-issue.sh lint [file]   (no file / "-" => stdin)
+# Lint a body without touching GitHub, git, or a worktree. Exists so every
+# signal is exercisable offline (the repo has no shell test harness) and so an
+# operator can sanity-check a draft before filing it. Prints the findings as
+# JSON on stdout and the human report on stderr; exits 1 on a blocker.
+cmd_lint() {
+  local src="${1:--}" body
+  if [ "$src" = "-" ]; then body=$(cat)
+  else [ -f "$src" ] || die "no such file: $src"; body=$(cat "$src"); fi
+  lint_issue_body "$body" "${KC_ISSUE_LABELS:-}"
+  lint_report
+  lint_json
+  [ "$LINT_BLOCKERS" -gt 0 ] && return 1
+  return 0
+}
+
 cmd_new() {
+  require_repo
   local arg="${1:?usage: kc-issue.sh <issue-number|slug> [desc]}" ; shift || true
   local desc="${*:-}"
-  local n slug title body url is_gh_issue=0
+  local n slug title body url labels="" is_gh_issue=0
 
   arg="${arg#\#}"
   if [[ "$arg" =~ ^[0-9]+$ ]]; then
@@ -57,13 +199,27 @@ cmd_new() {
   if [ "$is_gh_issue" = 1 ]; then
     source /home/dev/.credentials/.github-env 2>/dev/null || true
     local ij
-    ij=$(gh issue view "$n" --repo "$REPO_SLUG" --json number,title,body,url 2>/dev/null) \
+    # `labels` feeds the needs-scoping lint signal (#569) — we did not fetch it
+    # before. An older gh that omits the field degrades to an empty list rather
+    # than failing the spawn.
+    ij=$(gh issue view "$n" --repo "$REPO_SLUG" --json number,title,body,url,labels 2>/dev/null) \
       || die "could not fetch issue #$n via gh (does it exist? is gh authed?)"
     title=$(jq -r '.title' <<<"$ij")
     body=$(jq -r '.body // ""' <<<"$ij")
     url=$(jq -r '.url' <<<"$ij")
+    labels=$(jq -r '[(.labels // [])[].name] | join(",")' <<<"$ij" 2>/dev/null || true)
   else
+    # The ad-hoc path is MORE exposed than the issue path: a one-line --desc
+    # becomes the entire specification, and nothing else ever looks at it.
     title="$desc"; body="$desc"; url="(no GitHub issue)"
+  fi
+
+  # 2b. Lint the body BEFORE spending a worktree or a spawn on it (#569).
+  # Warn and continue by default; KC_ISSUE_STRICT=1 refuses on a blocker.
+  lint_issue_body "$body" "$labels"
+  lint_report
+  if [ "$STRICT" = 1 ] && [ "$LINT_BLOCKERS" -gt 0 ]; then
+    die "refusing to spawn: $LINT_BLOCKERS lint blocker(s) and KC_ISSUE_STRICT=1 (unset it to proceed anyway)"
   fi
 
   # 3. create OR reuse the worktree (branched from FRESH origin/main)
@@ -123,18 +279,24 @@ ${done_list}
 - One fact per change; keep the branch focused on issue #${n} only.
 EOF
 
-  # 5. machine-readable result for the caller
+  # 5. machine-readable result for the caller. `lint`/`lint_blockers` are
+  # additive (#569) so existing consumers keep working; the skill renders them
+  # so the operator sees the findings before deciding to proceed.
   jq -n \
     --arg issue "$n" --arg title "$title" --arg url "$url" \
     --arg worktree "$wt" --arg branch "$branch" \
     --arg port "${port:-}" --arg prompt_file "$prompt_file" \
     --arg auto_pr "$AUTO_PR" \
+    --argjson lint "$(lint_json)" \
+    --argjson lint_blockers "$LINT_BLOCKERS" \
     '{issue:$issue, title:$title, url:$url, worktree:$worktree,
-      branch:$branch, port:$port, prompt_file:$prompt_file, auto_pr:$auto_pr}'
+      branch:$branch, port:$port, prompt_file:$prompt_file, auto_pr:$auto_pr,
+      lint:$lint, lint_blockers:$lint_blockers}'
 }
 
 case "${1:-}" in
-  ""|-h|--help) die "usage: kc-issue.sh <issue-number|slug> [desc] | list" ;;
+  ""|-h|--help) die "usage: kc-issue.sh <issue-number|slug> [desc] | list | lint [file]" ;;
   list)         cmd_list ;;
+  lint)         shift; cmd_lint "$@" ;;
   *)            cmd_new "$@" ;;
 esac

--- a/.claude/skills/kc-issue/lint_test.sh
+++ b/.claude/skills/kc-issue/lint_test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Tests for kc-issue's issue-body lint (#569).
+#
+# The lint decides whether we spend a worktree and real tokens on an issue, so
+# it needs to be exercisable without GitHub, git, or a spawn. `kc-issue.sh lint`
+# exists for exactly that, and this is its test suite.
+#
+# The two properties that actually matter:
+#   * it FIRES on a thin body (otherwise it is useless), and
+#   * it stays SILENT on a good one (a noisy lint gets ignored, which is worse
+#     than no lint at all).
+#
+# Run:  bash .claude/skills/kc-issue/lint_test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KC="$HERE/kc-issue.sh"
+PASS=0; FAIL=0
+
+# A body that trips nothing — the false-positive control.
+GOOD_BODY=$(cat <<'EOF'
+## Problem
+`charts/workspace/server.py` returns a 500 when the memory store is empty
+because `top_for_prompt` assumes at least one row exists in the table.
+
+## Proposal
+Guard the empty case and return an empty list instead of indexing blindly.
+
+## Acceptance criteria
+- [ ] `/api/memory` returns 200 with `{"memories": []}` on an empty store
+- [ ] A unit test covers the empty-store path
+
+## Verification
+Run `python3 -m unittest tests.memory_test` and confirm it passes.
+EOF
+)
+
+ok()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+
+# _lint <body> [labels] -> stderr text on stdout (findings are stderr-only)
+_lint() {
+  local body="$1" labels="${2:-}"
+  KC_ISSUE_LABELS="$labels" bash "$KC" lint - <<<"$body" 2>&1 >/dev/null
+}
+
+# assert_fires <name> <code> <body> [labels]
+assert_fires() {
+  local name="$1" code="$2" body="$3" labels="${4:-}" out
+  out=$(_lint "$body" "$labels")
+  if grep -q "$code" <<<"$out"; then ok "$name"
+  else bad "$name" "expected '$code' in findings, got: ${out:-<none>}"; fi
+}
+
+# assert_silent <name> <code> <body> [labels]
+assert_silent() {
+  local name="$1" code="$2" body="$3" labels="${4:-}" out
+  out=$(_lint "$body" "$labels")
+  if grep -q "$code" <<<"$out"; then bad "$name" "did NOT expect '$code', got: $out"
+  else ok "$name"; fi
+}
+
+echo "kc-issue lint tests"
+
+# ── Each signal fires on a body that deserves it ────────────────────────────
+echo "- signals fire"
+assert_fires "thin body"                thin-body                 "fix it"
+assert_fires "no acceptance criteria"   no-acceptance-criteria    "Refactor the thing in charts/workspace/server.py and test it thoroughly please."
+assert_fires "no file pointers"         no-file-pointers          "We should rework the whole retrieval flow. Acceptance criteria: it works. Tested by hand."
+assert_fires "no verification path"     no-verification           "Change \`charts/workspace/server.py\` per the acceptance criteria listed in the linked design doc above."
+assert_fires "unquantified comparative" unquantified-comparative  "Make the dashboard faster. Acceptance criteria in charts/workspace/server.py. Tested manually."
+assert_fires "needs-scoping label"      needs-scoping             "$GOOD_BODY" "bug,needs-scoping"
+
+# ── No false positives on a well-formed body ───────────────────────────────
+echo "- no false positives on a good body"
+for code in thin-body no-acceptance-criteria no-file-pointers no-verification \
+            unquantified-comparative needs-scoping; do
+  assert_silent "good body: no $code" "$code" "$GOOD_BODY"
+done
+
+# ── Signal-specific non-firing ─────────────────────────────────────────────
+echo "- signals stay quiet when satisfied"
+assert_silent "quantified comparative is fine" unquantified-comparative \
+  "Make it faster: cut p95 from 800ms to 200ms. Acceptance criteria above. See charts/workspace/server.py. Tested with a benchmark."
+assert_silent "checkbox counts as criteria" no-acceptance-criteria \
+  "Do the thing.
+- [ ] it works
+See charts/workspace/server.py and run the tests."
+assert_silent "labels without needs-scoping" needs-scoping "$GOOD_BODY" "bug,enhancement"
+
+# ── Exit codes ─────────────────────────────────────────────────────────────
+echo "- exit codes"
+bash "$KC" lint - <<<"$GOOD_BODY" >/dev/null 2>&1
+[ $? -eq 0 ] && ok "good body exits 0" || bad "good body exits 0"
+
+KC_ISSUE_LABELS="needs-scoping" bash "$KC" lint - <<<"$GOOD_BODY" >/dev/null 2>&1
+[ $? -eq 1 ] && ok "blocker exits 1" || bad "blocker exits 1"
+
+bash "$KC" lint - <<<"fix it" >/dev/null 2>&1
+[ $? -eq 0 ] && ok "warnings alone still exit 0 (warn, never block)" \
+             || bad "warnings alone still exit 0 (warn, never block)"
+
+# ── stdout purity: the caller parses stdout as JSON, so findings must not
+#    leak into it. This is the regression that would break the Hypervisor.
+echo "- stdout stays machine-readable"
+# This half needs no jq and is the property that actually protects the caller:
+# the human report must never contaminate the JSON channel.
+out=$(bash "$KC" lint - <<<"fix it" 2>/dev/null)
+grep -q 'kc-issue: lint:' <<<"$out" && bad "no human text on stdout" "found it: $out" \
+                                    || ok "no human text on stdout"
+[ -n "$out" ] && ok "stdout is non-empty" || bad "stdout is non-empty"
+
+if command -v jq >/dev/null 2>&1; then
+  if jq -e 'type == "array"' <<<"$out" >/dev/null 2>&1; then
+    ok "stdout is a JSON array"
+  else
+    bad "stdout is a JSON array" "got: $out"
+  fi
+  n=$(jq 'length' <<<"$out" 2>/dev/null)
+  [ "${n:-0}" -ge 4 ] && ok "findings present in JSON ($n)" \
+                      || bad "findings present in JSON" "got $n"
+  # Every finding carries the three fields the skill renders.
+  jq -e 'all(.[]; has("severity") and has("code") and has("message"))' \
+     <<<"$out" >/dev/null 2>&1 \
+    && ok "findings have severity/code/message" \
+    || bad "findings have severity/code/message" "got: $out"
+else
+  echo "  skip jq-shape assertions (jq not installed; present in the pod image)"
+fi
+
+# ── Hostile input must not break the script ────────────────────────────────
+echo "- hostile input"
+out=$(_lint 'body with `backticks`, $(command substitution), "quotes" and émoji 🚀')
+[ -n "$out" ] && ok "quotes/substitution/unicode handled" \
+              || bad "quotes/substitution/unicode handled" "no output at all"
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #569.

## The issue

`kc-issue.sh` fetched an issue and baked its body **verbatim** into the agent prompt with nothing inspecting it in between — `gh issue view --json number,title,body,url` at `:60`, interpolated straight into `## Description` at `:97-105`.

So a thin issue silently produced a thin prompt. The agent got spawned, burned a worktree and real tokens, and discovered the ambiguity twenty minutes in — or worse, didn't, and confidently shipped the wrong thing. The failure was silent and the cost was paid before anyone could react.

The ad-hoc path was more exposed still: `title="$desc"; body="$desc"` at `:66` means a one-line `--desc` becomes the entire specification the agent ever sees.

## How it's solved

A `lint_issue_body()` pass that runs **before the worktree is created**, so a bad issue costs nothing. Signals, cheapest first:

| Signal | Severity | Why it matters |
|---|---|---|
| `needs-scoping` label | **blocker** | the repo already says this isn't ready to implement |
| Empty / near-empty body | warn | title-only issues give the agent nothing but a headline |
| No acceptance criteria | warn | nothing states what "done" looks like, so the agent invents its own bar |
| No file/path/component pointers | warn | the agent has to guess where the change goes, and guessing wrong is expensive to unwind |
| No verification path | warn | nothing says how to confirm the change works |
| Unquantified comparative | warn | "make it faster" with no target |

The comparative check only fires when the body carries **no digit at all**, so "cut p95 from 800ms to 200ms" stays quiet. `labels` is now in the `gh issue view --json` list — it wasn't fetched before and the first signal needs it; an older `gh` that omits the field degrades to an empty list rather than failing the spawn.

**Warn, never block.** Findings print on stderr and ride the JSON as an additive `lint` array plus `lint_blockers`, so existing consumers keep working. `KC_ISSUE_STRICT=1` makes it refuse on a blocker, exiting before the worktree is created so nothing is spent.

### Answers to the three open questions

- **Strict mode → env var.** Matches the script's existing `KC_AUTO_PR` / `KC_REPO_*` idiom. The positional args are already `<issue|slug> [desc]`, so a flag would mean reworking parsing for no gain.
- **`needs-scoping` is louder — but not a prompt inside the script.** `kc-issue.sh` prints JSON for the Hypervisor to consume, so a `read -p` there would *hang its caller*. It emits a `blocker` severity and the skill's **Step 1b** makes the assistant stop and ask. That puts the call with the operator rather than the script, which is what the issue asked for.
- **Spawn time, not issue-creation time.** Cheaper, and it also covers issues written before the lint existed.

## Files changed

| File | What changed |
|---|---|
| `.claude/skills/kc-issue/kc-issue.sh` | `lint_issue_body()` + `lint_report()` + `lint_json()`; `labels` added to the gh query; lint wired into **both** the issue and ad-hoc `--desc` paths before worktree creation; `lint`/`lint_blockers` in the JSON; `KC_ISSUE_STRICT` gate; new `lint [file]` subcommand; git guards moved into `require_repo()` |
| `.claude/skills/kc-issue/SKILL.md` | New Step 1b: surface the findings, stop and ask on a blocker, continue on warnings; documents `KC_ISSUE_STRICT`, the `lint` subcommand, and why the lint runs at spawn time |
| `.claude/skills/kc-issue/lint_test.sh` | **New.** 24-case suite driving the `lint` subcommand |

## Backend flow
