### PR TITLE
chore(controller): pin provision.image to the signed v1.54.0 provisioner

### DIFF
--- a/charts/workspace-controller/tests/provisioner-vap_test.yaml
+++ b/charts/workspace-controller/tests/provisioner-vap_test.yaml
@@ -73,12 +73,13 @@ tests:
           path: spec.matchConditions[0].expression
           pattern: 'serviceAccountName == "workspace-provisioner"'
 
-  - it: pins the approved image repository
+  - it: falls back to the controller image repository when provision.image is empty
     set:
       provision.enabled: true
       provision.workspaceDomain: dev.test.io
       provision.gitops.repo: github.com/x/y.git
       provision.gitToken: xxx
+      provision.image: ""   # empty => VAP approves the controller.image repo (rendering-only default; the controller itself fails closed on empty provision.image)
     documentIndex: 0
     asserts:
       - matchRegex:

--- a/charts/workspace-controller/values.yaml
+++ b/charts/workspace-controller/values.yaml
@@ -274,7 +274,7 @@ provision:
   # image, a Job on any other image would run THAT image's entrypoint and could
   # exit 0 having provisioned nothing. The controller fails closed instead, with
   # an error naming this setting.
-  image: ""
+  image: "ghcr.io/imran31415/kube-coder/provisioner@sha256:e5cdbfcce29c805b654454ae7444c259031b2464707d5ccd6fd69b2a43480805"  # v1.54.0 cosign-signed provisioner (bakes python3 #576; RBAC cilium #577)
 
   # Fallback image tag for new workspaces (chart prefixes it with `devlaptop-`).
   # New workspaces default to the latest published release; this is used only

--- a/charts/workspace-controller/values.yaml
+++ b/charts/workspace-controller/values.yaml
@@ -273,8 +273,11 @@ provision:
   # Empty no longer falls back to the controller image: with the script in the
   # image, a Job on any other image would run THAT image's entrypoint and could
   # exit 0 having provisioned nothing. The controller fails closed instead, with
-  # an error naming this setting.
-  image: "ghcr.io/imran31415/kube-coder/provisioner@sha256:e5cdbfcce29c805b654454ae7444c259031b2464707d5ccd6fd69b2a43480805"  # v1.54.0 cosign-signed provisioner (bakes python3 #576; RBAC cilium #577)
+  # an error naming this setting. Renovate keeps the tag+digest fresh (see
+  # renovate.json — tracked like the oauth2-proxy pin), so it does not rot as new
+  # provisioner images are released. Pinned tag+digest: the digest is what admission
+  # enforces; the tag is what Renovate follows.
+  image: "ghcr.io/imran31415/kube-coder/provisioner:1.54.0@sha256:e5cdbfcce29c805b654454ae7444c259031b2464707d5ccd6fd69b2a43480805"  # cosign-signed provisioner (bakes python3 #576; RBAC cilium #577)
 
   # Fallback image tag for new workspaces (chart prefixes it with `devlaptop-`).
   # New workspaces default to the latest published release; this is used only

--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,17 @@
         "(?<depName>quay\\.io/oauth2-proxy/oauth2-proxy):(?<currentValue>[^\\s@\"]+)@(?<currentDigest>sha256:[a-f0-9]+)"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "The cosign-signed provisioner image the cluster-privileged provisioning Job runs (#571/#422), pinned tag+digest in the controller chart values. The digest is what the ValidatingAdmissionPolicy enforces, so without tracking it the pin rots as new provisioner images ship each release.",
+      "managerFilePatterns": [
+        "charts/workspace-controller/values.yaml"
+      ],
+      "matchStrings": [
+        "(?<depName>ghcr\\.io/imran31415/kube-coder/provisioner):(?<currentValue>[^\\s@\"]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker"
     }
   ],
   "packageRules": [
@@ -67,6 +78,12 @@
       "description": "oauth2-proxy — the auth boundary. Never batch it with anything else, and label it security so it is reviewed as such, not as routine dependency noise.",
       "matchDepNames": ["quay.io/oauth2-proxy/oauth2-proxy"],
       "groupName": "oauth2-proxy (auth gate)",
+      "addLabels": ["security"]
+    },
+    {
+      "description": "Provisioner image — runs under the cluster-privileged provisioner SA and is admission-pinned by digest. Keep it on its own and label security so bumps are reviewed as supply-chain changes, not routine noise.",
+      "matchDepNames": ["ghcr.io/imran31415/kube-coder/provisioner"],
+      "groupName": "provisioner image (privileged path)",
       "addLabels": ["security"]
     },
     {


### PR DESCRIPTION
Pins the controller's `provision.image` to the **cosign-signed** `ghcr.io/imran31415/kube-coder/provisioner` image built by `release.yml` for **v1.54.0**.

## Why
Since #571, `provision.image` is **required** (the controller fails closed with no fallback) and must be a dedicated provisioner image pinned by digest. The v1.54.0 provisioner is the first that completes a real end-to-end provision — it bakes **python3** (#576) and runs against the **cilium RBAC** grant (#577). Until now the live controller was pointed at a *temporary, unsigned* DO-registry build to unblock provisioning; this restores the signed-ghcr supply-chain posture (#571) and persists the pin so a clean-checkout `make deploy-controller` no longer fails closed.

## Details
- `charts/workspace-controller/values.yaml`: `provision.image` → `ghcr.io/imran31415/kube-coder/provisioner@sha256:e5cdbfc…`.
- Digest verified **anonymously pullable (HTTP 200)** — the cluster pulls it without a ghcr credential.
- The provisioner-vap ValidatingAdmissionPolicy derives its approved-image check from `provision.image`, so it re-renders to this digest on deploy (verified: a real provision Job admits + runs).

Note: this digest is per-release; a future release cutting a new provisioner image will need this bumped (candidate for Renovate on the provisioner image / deriving it from appVersion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)