### PR TITLE
feat(ops): add `make doctor` operator preflight for Option B (#580)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,22 @@ jobs:
         # stdlib, no cluster, no network; this is seconds.
         run: make controller-python-tests
 
+  shell-tests:
+    name: Shell Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Syntax-check doctor.sh
+        run: bash -n scripts/doctor.sh
+
+      - name: doctor.sh operator-preflight tests (#580)
+        # scripts/doctor.sh reaches the cluster only through read-only CLIs, so
+        # the suite shims kubectl/helm/dig/git on PATH and drives each check's
+        # inputs from env — fully offline, no cluster, no network, seconds.
+        run: bash scripts/doctor_test.sh
+
   web-tests:
     name: Dashboard SPA Tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile for kube-coder
-.PHONY: build push deploy-base deploy-all clean help status version deploy logs shell test rollback delete-user migrate-user migrate-all migrate-status new-user validate-user require-user release users-sync dashboard-web dashboard-web-install dashboard-web-test dashboard-web-clean python-tests python-coverage dashboard-web-coverage coverage test-coverage local local-up local-build local-secret local-deploy local-forward local-info local-down mobile-install mobile-typecheck mobile-web mobile-export-web mobile-screenshots mobile-build mobile-build-ios mobile-build-android mobile-submit-ios mobile-fastlane-install mobile-metadata mobile-metadata-text mobile-ios-screenshots mobile-metadata-download mobile-play-metadata mobile-play-metadata-text mobile-play-metadata-download mobile-clean
+.PHONY: build push deploy-base deploy-all clean help status version deploy logs shell test rollback delete-user migrate-user migrate-all migrate-status new-user validate-user doctor require-user release users-sync dashboard-web dashboard-web-install dashboard-web-test dashboard-web-clean python-tests python-coverage dashboard-web-coverage coverage test-coverage local local-up local-build local-secret local-deploy local-forward local-info local-down mobile-install mobile-typecheck mobile-web mobile-export-web mobile-screenshots mobile-build mobile-build-ios mobile-build-android mobile-submit-ios mobile-fastlane-install mobile-metadata mobile-metadata-text mobile-ios-screenshots mobile-metadata-download mobile-play-metadata mobile-play-metadata-text mobile-play-metadata-download mobile-clean
 
 # =============================================================================
 # Generic per-user helpers
@@ -109,6 +109,19 @@ clean: ## Clean up local Docker images
 # =============================================================================
 # Deployment
 # =============================================================================
+
+# Operator preflight — the FIRST step of an Option B (cloud / multi-tenant)
+# install, run BEFORE any user or workspace exists. READ-ONLY: it checks the
+# documented cloud prerequisites (kubectl/helm versions, nginx-ingress, cert-
+# manager + a ClusterIssuer, wildcard DNS, regcred, the GitOps repo), reports
+# EVERY failure at once with a remediation, and exits non-zero if any FAILed.
+# Supply DOMAIN to enable the wildcard-DNS check; NAMESPACE targets the control-
+# plane namespace where regcred lives (default $(NAMESPACE)).
+#   make doctor
+#   DOMAIN=dev.example.io make doctor
+#   NAMESPACE=coder DOMAIN=dev.example.io make doctor
+doctor: ## Operator preflight for Option B — check cloud prerequisites, read-only (DOMAIN=<domain> to check wildcard DNS)
+	@NAMESPACE=$(NAMESPACE) DOMAIN=$(DOMAIN) USERS_REPO=$(USERS_REPO) ./scripts/doctor.sh
 
 deploy-base: ## Deploy base infrastructure
 	@echo "Deploying base infrastructure..."

--- a/README.md
+++ b/README.md
@@ -332,9 +332,12 @@ make local-forward                                            # keep running in 
 **Prerequisites:** Kubernetes 1.19+, Helm 3.0+, an nginx-ingress controller, **wildcard DNS** (`*.<your-domain>` → the ingress IP), a GitHub OAuth App for the controller console, a private GitHub repo as the GitOps config store, and a `regcred` image-pull secret.
 
 ```bash
+DOMAIN=<your-domain> make doctor  # preflight: check ALL of the above at once (read-only)
 make deploy-base                  # base infra: nginx-ingress, oauth2-proxy, cert-manager
 make ship-controller-config       # the admin console (workspace-controller)
 ```
+
+Run `make doctor` **first**. It's a read-only preflight that verifies every prerequisite above — kubectl/helm versions, the ingress controller and its external IP, cert-manager plus a ClusterIssuer, that `*.<your-domain>` actually resolves **to your ingress IP** (the failure that otherwise only surfaces as a dead workspace later), the `regcred` secret, and GitOps-repo reachability — reporting all failures at once with a fix for each. Pass `DOMAIN=<your-domain>` to include the wildcard-DNS check (skipped otherwise).
 
 Two things make self-service onboarding work; you set them once:
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# scripts/doctor.sh — operator preflight for a cloud / multi-tenant ("Option B")
+# kube-coder install. Runs BEFORE the first user or workspace exists.
+#
+# Usage: scripts/doctor.sh          (env: NAMESPACE, DOMAIN, USERS_REPO)
+#        NAMESPACE=coder DOMAIN=dev.example.io scripts/doctor.sh
+#
+# READ-ONLY diagnosis. It never installs, applies, patches, or mutates anything
+# — every cluster call is a `get`/`status`/`ls-remote`. It checks the documented
+# Option-B prerequisites and reports ALL failures at once (it never stops at the
+# first), each with a specific remediation, then exits non-zero if any check
+# FAILed. Warnings (e.g. a skipped wildcard-DNS check) never fail the run.
+#
+# Checks:
+#   1. kubectl reachable + cluster server version >= 1.19; helm >= 3.0
+#   2. an nginx-ingress controller is present and its external IP/hostname
+#      is known and resolvable
+#   3. cert-manager present AND at least one ClusterIssuer that actually exists
+#   4. wildcard DNS: <nonce>.$DOMAIN resolves to the ingress external IP
+#      (the single highest-value check — a broken wildcard silently produces a
+#      dead workspace much later). Skipped with a note when DOMAIN is unset.
+#   5. a `regcred` image-pull secret is present in the target namespace
+#   6. the GitOps config repo is reachable with the credentials in use
+#
+# Style mirrors scripts/validate-user.sh (that one is per-user, post-scaffold;
+# this one is cluster-level, pre-first-user — different scope, so they are kept
+# separate). Wired into the Makefile as `make doctor`.
+
+set -uo pipefail
+
+# --- Parameters (env, matching the Makefile's NAMESPACE / DOMAIN naming) ------
+# The shared regcred image-pull Secret + control-plane releases live in the
+# control-plane namespace, which the Makefile calls NAMESPACE (default `coder`).
+NS="${NAMESPACE:-coder}"
+# Operator-supplied base domain for the wildcard-DNS check (e.g. dev.example.io).
+# Empty => that check is skipped with a note on how to run it.
+DOMAIN="${DOMAIN:-}"
+# GitOps workspace-config repo (host/path, no scheme). Resolved from KC_USERS_REPO
+# / USERS_REPO, or the gitignored controller values, mirroring the Makefile.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+USERS_REPO="${USERS_REPO:-${KC_USERS_REPO:-}}"
+if [ -z "$USERS_REPO" ]; then
+  USERS_REPO="$(awk '/^[[:space:]]*gitops:/{f=1} f&&/repo:/{print $2; exit}' \
+    "$ROOT/users-private/_controller/values.yaml" 2>/dev/null || true)"
+fi
+
+# --- Pretty output. Plain ASCII markers so this works in any TTY. -------------
+PASS_COUNT=0
+WARN_COUNT=0
+FAIL_COUNT=0
+pass() { echo "  [OK]   $*"; PASS_COUNT=$((PASS_COUNT+1)); }
+warn() { echo "  [WARN] $*"; WARN_COUNT=$((WARN_COUNT+1)); }
+fail() { echo "  [FAIL] $*"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+# Indent a remediation hint under the preceding [FAIL]/[WARN] line.
+hint() { echo "         -> $*"; }
+
+echo "doctor: kube-coder operator preflight (namespace: $NS${DOMAIN:+, domain: $DOMAIN})"
+echo
+
+# Resolve an A record (IPv4) for a name, best-effort across the tools that might
+# be installed. Prints one IP per line (may be empty). Never fails the shell.
+resolve_ipv4() {
+  local name="$1" out=""
+  if command -v dig >/dev/null 2>&1; then
+    out="$(dig +short A "$name" 2>/dev/null | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$')"
+  fi
+  if [ -z "$out" ] && command -v host >/dev/null 2>&1; then
+    out="$(host -t A "$name" 2>/dev/null | awk '/has address/{print $NF}')"
+  fi
+  if [ -z "$out" ] && command -v getent >/dev/null 2>&1; then
+    out="$(getent ahostsv4 "$name" 2>/dev/null | awk '{print $1}' | sort -u)"
+  fi
+  echo "$out"
+}
+
+# True if a name resolves to anything at all (A record or otherwise).
+resolves_at_all() {
+  local name="$1"
+  getent hosts "$name" >/dev/null 2>&1 && return 0
+  command -v host >/dev/null 2>&1 && host "$name" >/dev/null 2>&1 && return 0
+  command -v dig  >/dev/null 2>&1 && [ -n "$(dig +short "$name" 2>/dev/null)" ] && return 0
+  return 1
+}
+
+# =============================================================================
+# 1. kubectl reachable + versions
+# =============================================================================
+echo "1. CLI tooling + cluster reachability"
+KUBECTL_OK=0
+if ! command -v kubectl >/dev/null 2>&1; then
+  fail "kubectl not on PATH"
+  hint "install kubectl: https://kubernetes.io/docs/tasks/tools/"
+elif ! kubectl version -o json >/dev/null 2>&1 && ! kubectl cluster-info >/dev/null 2>&1; then
+  fail "kubectl is installed but cannot reach a cluster"
+  hint "check your kubeconfig / context: kubectl config current-context && kubectl cluster-info"
+else
+  KUBECTL_OK=1
+  # serverVersion.minor can carry a '+' suffix (e.g. \"24+\"); strip non-digits.
+  SRV_JSON="$(kubectl version -o json 2>/dev/null)"
+  SRV_MAJOR="$(printf '%s' "$SRV_JSON" | awk -F'"' '/"serverVersion"/{f=1} f&&/"major"/{gsub(/[^0-9]/,"",$4); print $4; exit}')"
+  SRV_MINOR="$(printf '%s' "$SRV_JSON" | awk -F'"' '/"serverVersion"/{f=1} f&&/"minor"/{gsub(/[^0-9]/,"",$4); print $4; exit}')"
+  if [ -z "$SRV_MAJOR" ] || [ -z "$SRV_MINOR" ]; then
+    warn "reached the cluster but could not parse its server version — skipping the >=1.19 check"
+    hint "check manually: kubectl version -o json | grep -A3 serverVersion"
+  elif [ "$SRV_MAJOR" -gt 1 ] || { [ "$SRV_MAJOR" -eq 1 ] && [ "$SRV_MINOR" -ge 19 ]; }; then
+    pass "cluster reachable, server version $SRV_MAJOR.$SRV_MINOR (>= 1.19)"
+  else
+    fail "cluster server version $SRV_MAJOR.$SRV_MINOR is below the required 1.19"
+    hint "upgrade the cluster control plane to Kubernetes 1.19 or newer"
+  fi
+fi
+
+if ! command -v helm >/dev/null 2>&1; then
+  fail "helm not on PATH"
+  hint "install Helm 3: https://helm.sh/docs/intro/install/"
+else
+  HELM_VER="$(helm version --short 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+  HELM_MAJOR="$(printf '%s' "$HELM_VER" | sed -E 's/^v?([0-9]+)\..*/\1/')"
+  if [ -z "$HELM_MAJOR" ]; then
+    warn "helm is installed but its version could not be parsed — skipping the >=3.0 check"
+    hint "check manually: helm version --short"
+  elif [ "$HELM_MAJOR" -ge 3 ]; then
+    pass "helm ${HELM_VER} (>= 3.0)"
+  else
+    fail "helm ${HELM_VER} is below the required 3.0"
+    hint "upgrade Helm to v3: https://helm.sh/docs/intro/install/"
+  fi
+fi
+echo
+
+# =============================================================================
+# 2. nginx-ingress controller present + external address known
+# =============================================================================
+echo "2. nginx-ingress controller"
+INGRESS_IP=""      # external IPv4 of the ingress LoadBalancer, when it has one
+INGRESS_HOST=""    # external hostname (cloud LB CNAME), when it has one instead
+if [ "$KUBECTL_OK" -ne 1 ]; then
+  warn "skipping (no reachable cluster)"
+else
+  # Find the controller Service (type LoadBalancer) by the canonical ingress-nginx
+  # labels, across every namespace it might have been installed into.
+  ING_SVC="$(kubectl get svc -A \
+    -l app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller \
+    -o jsonpath='{range .items[?(@.spec.type=="LoadBalancer")]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}' 2>/dev/null | head -1)"
+  # Fall back to the well-known default name if the labels differ.
+  if [ -z "$ING_SVC" ] && kubectl get svc -n ingress-nginx ingress-nginx-controller >/dev/null 2>&1; then
+    ING_SVC="ingress-nginx/ingress-nginx-controller"
+  fi
+  if [ -z "$ING_SVC" ]; then
+    fail "no nginx-ingress controller LoadBalancer Service found"
+    hint "install it, e.g.: helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx && helm install ingress-nginx ingress-nginx/ingress-nginx -n ingress-nginx --create-namespace"
+  else
+    ISNS="${ING_SVC%%/*}"; ISNAME="${ING_SVC##*/}"
+    INGRESS_IP="$(kubectl get svc -n "$ISNS" "$ISNAME" -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null)"
+    INGRESS_HOST="$(kubectl get svc -n "$ISNS" "$ISNAME" -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)"
+    if [ -n "$INGRESS_IP" ]; then
+      pass "ingress controller found: $ING_SVC (external IP $INGRESS_IP)"
+    elif [ -n "$INGRESS_HOST" ]; then
+      # A cloud LB hostname (e.g. AWS ELB). Resolve it so downstream checks and
+      # the operator both have a concrete target IP.
+      pass "ingress controller found: $ING_SVC (external hostname $INGRESS_HOST)"
+      if resolves_at_all "$INGRESS_HOST"; then
+        pass "ingress hostname resolves: $INGRESS_HOST"
+        INGRESS_IP="$(resolve_ipv4 "$INGRESS_HOST" | head -1)"
+      else
+        fail "ingress hostname does not resolve yet: $INGRESS_HOST"
+        hint "wait for the cloud load balancer's DNS to propagate, then re-run"
+      fi
+    else
+      fail "ingress controller $ING_SVC has no external IP/hostname yet (LoadBalancer pending)"
+      hint "check your cloud LoadBalancer provisioning: kubectl get svc -n $ISNS $ISNAME -w"
+    fi
+  fi
+fi
+echo
+
+# =============================================================================
+# 3. cert-manager present + at least one ClusterIssuer that exists
+# =============================================================================
+echo "3. cert-manager + ClusterIssuer"
+if [ "$KUBECTL_OK" -ne 1 ]; then
+  warn "skipping (no reachable cluster)"
+else
+  # The ClusterIssuer CRD's presence is the reliable signal cert-manager's CRDs
+  # are installed; then confirm the controller Deployment is actually running.
+  if ! kubectl get crd clusterissuers.cert-manager.io >/dev/null 2>&1; then
+    fail "cert-manager is not installed (no clusterissuers.cert-manager.io CRD)"
+    hint "install it: helm repo add jetstack https://charts.jetstack.io && helm install cert-manager jetstack/cert-manager -n cert-manager --create-namespace --set crds.enabled=true"
+  else
+    if kubectl get deploy -l app.kubernetes.io/name=cert-manager -A >/dev/null 2>&1 \
+       && [ -n "$(kubectl get deploy -l app.kubernetes.io/name=cert-manager -A -o name 2>/dev/null)" ]; then
+      pass "cert-manager is installed"
+    else
+      warn "cert-manager CRDs exist but its controller Deployment was not found"
+      hint "confirm the controller is running: kubectl get pods -n cert-manager"
+    fi
+    # At least one ClusterIssuer must actually exist — the workspace ingresses
+    # annotate cert-manager.io/cluster-issuer: letsencrypt-production by default.
+    ISSUERS="$(kubectl get clusterissuers.cert-manager.io -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null)"
+    if [ -n "$ISSUERS" ]; then
+      pass "ClusterIssuer(s) present: $(echo "$ISSUERS" | paste -sd, - )"
+    else
+      fail "cert-manager is installed but no ClusterIssuer exists"
+      hint "create one (e.g. letsencrypt-production) — see docs/deploy-on-kubernetes.md; without it workspace TLS never issues"
+    fi
+  fi
+fi
+echo
+
+# =============================================================================
+# 4. Wildcard DNS — <nonce>.$DOMAIN resolves to the ingress external IP.
+#    Highest-value check: a broken wildcard silently yields a dead workspace
+#    much later, not here.
+# =============================================================================
+echo "4. wildcard DNS (*.\$DOMAIN -> ingress)"
+if [ -z "$DOMAIN" ]; then
+  warn "skipped — no DOMAIN supplied"
+  hint "run with your base domain to check it: DOMAIN=dev.example.io make doctor"
+else
+  NONCE="kc-doctor-$(date +%s)-$$"
+  PROBE="${NONCE}.${DOMAIN}"
+  WILDCARD_IPS="$(resolve_ipv4 "$PROBE")"
+  if [ -z "$WILDCARD_IPS" ]; then
+    fail "wildcard DNS does not resolve: $PROBE returned no A record"
+    hint "add a wildcard record: *.$DOMAIN  ->  ${INGRESS_IP:-<your ingress external IP>}"
+  elif [ -z "$INGRESS_IP" ]; then
+    # We got an answer but have no ingress IP to compare against (check 2 failed
+    # or the LB only exposes a hostname we could not resolve).
+    warn "wildcard $PROBE resolves to $(echo "$WILDCARD_IPS" | paste -sd, - ) but the ingress external IP is unknown — cannot confirm it points at the ingress"
+    hint "fix check 2 (ingress external address) then re-run to verify the wildcard target"
+  elif echo "$WILDCARD_IPS" | grep -qxF "$INGRESS_IP"; then
+    pass "wildcard DNS resolves to the ingress IP: $PROBE -> $INGRESS_IP"
+  else
+    fail "wildcard DNS points at the WRONG address: $PROBE -> $(echo "$WILDCARD_IPS" | paste -sd, - ), but the ingress external IP is $INGRESS_IP"
+    hint "repoint the wildcard record: *.$DOMAIN  ->  $INGRESS_IP"
+  fi
+fi
+echo
+
+# =============================================================================
+# 5. regcred image-pull secret present in the target namespace
+# =============================================================================
+echo "5. regcred image-pull secret (namespace: $NS)"
+if [ "$KUBECTL_OK" -ne 1 ]; then
+  warn "skipping (no reachable cluster)"
+elif ! kubectl get ns "$NS" >/dev/null 2>&1 && ! kubectl get serviceaccount default -n "$NS" >/dev/null 2>&1; then
+  fail "target namespace '$NS' does not exist"
+  hint "create it (kubectl create namespace $NS) or pass the right one: NAMESPACE=<ns> make doctor"
+elif kubectl get secret regcred -n "$NS" >/dev/null 2>&1; then
+  TYPE="$(kubectl get secret regcred -n "$NS" -o jsonpath='{.type}' 2>/dev/null)"
+  if [ "$TYPE" = "kubernetes.io/dockerconfigjson" ]; then
+    pass "image-pull secret 'regcred' present in $NS (kubernetes.io/dockerconfigjson)"
+  else
+    fail "secret 'regcred' in $NS is of type '$TYPE', not kubernetes.io/dockerconfigjson"
+    hint "recreate it: kubectl create secret docker-registry regcred --docker-server=... --docker-username=... --docker-password=... -n $NS"
+  fi
+else
+  fail "image-pull secret 'regcred' not found in namespace $NS"
+  hint "create it: kubectl create secret docker-registry regcred --docker-server=<registry> --docker-username=<user> --docker-password=<token> -n $NS"
+fi
+echo
+
+# =============================================================================
+# 6. GitOps config repo reachable with the credentials in use
+# =============================================================================
+echo "6. GitOps config repo"
+if [ -z "$USERS_REPO" ]; then
+  warn "skipped — GitOps repo unknown"
+  hint "set it to check reachability: USERS_REPO=github.com/<org>/<repo>.git make doctor  (or provision.gitops.repo in users-private/_controller/values.yaml)"
+elif ! command -v git >/dev/null 2>&1; then
+  warn "git not on PATH — cannot check GitOps repo reachability"
+  hint "install git to verify $USERS_REPO"
+else
+  # Strip any scheme the operator may have included, then probe over https with
+  # whatever credential helper / token git is configured to use. Read-only.
+  REPO_NOSCHEME="${USERS_REPO#https://}"; REPO_NOSCHEME="${REPO_NOSCHEME#http://}"
+  if GIT_TERMINAL_PROMPT=0 git ls-remote "https://${REPO_NOSCHEME}" >/dev/null 2>&1; then
+    pass "GitOps repo reachable with current credentials: $REPO_NOSCHEME"
+  else
+    fail "GitOps repo not reachable with current credentials: $REPO_NOSCHEME"
+    hint "authenticate git for it (e.g. 'gh auth login' or a PAT credential helper); confirm manually: git ls-remote https://$REPO_NOSCHEME"
+  fi
+fi
+echo
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo "Summary: $PASS_COUNT ok, $WARN_COUNT warn, $FAIL_COUNT fail"
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo "doctor: FAILED — fix the items above before onboarding the first workspace."
+  exit 1
+fi
+if [ "$WARN_COUNT" -gt 0 ]; then
+  echo "doctor: OK (with warnings — review the notes above)"
+else
+  echo "doctor: OK — cloud prerequisites look good."
+fi
+exit 0

--- a/scripts/doctor_test.sh
+++ b/scripts/doctor_test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Tests for scripts/doctor.sh — the operator preflight (#580).
+#
+# doctor.sh only talks to the outside world through a handful of CLIs
+# (kubectl, helm, dig/host/getent, git), so its logic is fully exercisable
+# offline by shimming those on PATH and driving each check's inputs from env.
+#
+# The properties that actually matter here:
+#   * it reports ALL failures in one run (never stops at the first),
+#   * it exits non-zero iff at least one check FAILed (warnings never fail),
+#   * the wildcard-DNS check compares against the ingress IP — matching passes,
+#     a wrong/absent record fails (the single highest-value check), and
+#   * it is READ-ONLY: it must never invoke a mutating kubectl verb.
+#
+# Run:  bash scripts/doctor_test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCTOR="$HERE/doctor.sh"
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+
+# --- PATH shims --------------------------------------------------------------
+# A temp bin/ shadowing the real kubectl/helm/dig/host/getent/git. Each shim
+# reads its behavior from KC_* env vars the individual tests set. kubectl also
+# appends any mutating verb to $KC_MUTATION_LOG so we can assert read-only.
+SHIMDIR="$(mktemp -d)"
+export KC_MUTATION_LOG="$SHIMDIR/mutations.log"
+trap 'rm -rf "$SHIMDIR"' EXIT
+
+cat > "$SHIMDIR/kubectl" <<'SHIM'
+#!/usr/bin/env bash
+verb="${1:-}"
+case "$verb" in
+  apply|create|patch|delete|replace|edit|scale|annotate|label|rollout|set|cp|exec|drain|cordon|uncordon)
+    echo "kubectl $*" >> "$KC_MUTATION_LOG"; exit 1 ;;
+esac
+args="$*"
+case "$args" in
+  "version -o json"*)
+    [ -n "${KC_KUBECTL_OK:-}" ] || exit 1
+    printf '{\n "serverVersion": {\n  "major": "%s",\n  "minor": "%s"\n }\n}\n' \
+      "${KC_K8S_MAJOR:-1}" "${KC_K8S_MINOR:-27}"; exit 0 ;;
+  "cluster-info"*) [ -n "${KC_KUBECTL_OK:-}" ] && exit 0 || exit 1 ;;
+esac
+[ -n "${KC_KUBECTL_OK:-}" ] || exit 1
+case "$args" in
+  *loadBalancer.ingress*ip*)       printf '%s' "${KC_INGRESS_IP:-}";   exit 0 ;;
+  *loadBalancer.ingress*hostname*) printf '%s' "${KC_INGRESS_HOST:-}"; exit 0 ;;
+  *"get svc -A"*ingress-nginx*)
+    [ -n "${KC_INGRESS_PRESENT:-}" ] && { printf '%s\n' "${KC_INGRESS_SVC:-ingress-nginx/ingress-nginx-controller}"; exit 0; }
+    exit 0 ;;  # empty result, but the command itself succeeds
+  *"get svc -n ingress-nginx ingress-nginx-controller"*)
+    [ -n "${KC_INGRESS_PRESENT:-}" ] && exit 0 || exit 1 ;;
+  *"get crd clusterissuers"*)      [ -n "${KC_CM_CRD:-}" ] && exit 0 || exit 1 ;;
+  *"get deploy"*cert-manager*"-o name"*)
+    [ -n "${KC_CM_DEPLOY:-}" ] && { echo "deployment.apps/cert-manager"; exit 0; }; exit 0 ;;
+  *"get deploy"*cert-manager*)     [ -n "${KC_CM_DEPLOY:-}" ] && exit 0 || exit 0 ;;
+  *"get clusterissuers"*jsonpath*) printf '%s' "${KC_ISSUERS:-}"; [ -n "${KC_ISSUERS:-}" ] && echo; exit 0 ;;
+  *"get secret regcred"*jsonpath*) printf '%s' "${KC_REGCRED_TYPE:-}"; exit 0 ;;
+  *"get secret regcred"*)          [ -n "${KC_REGCRED:-}" ] && exit 0 || exit 1 ;;
+  *"get ns "*)                     [ -n "${KC_NS_EXISTS:-}" ] && exit 0 || exit 1 ;;
+  *"get serviceaccount default"*)  [ -n "${KC_NS_EXISTS:-}" ] && exit 0 || exit 1 ;;
+esac
+exit 0
+SHIM
+
+cat > "$SHIMDIR/helm" <<'SHIM'
+#!/usr/bin/env bash
+[ "${1:-}" = "version" ] && { printf '%s\n' "${KC_HELM_VER:-v3.14.4+gtest}"; exit 0; }
+exit 0
+SHIM
+
+# dig is the authoritative resolver in the shim world; host/getent report nothing
+# so resolution deterministically flows through dig.
+cat > "$SHIMDIR/dig" <<'SHIM'
+#!/usr/bin/env bash
+name="${!#}"   # last arg is the queried name
+case "$name" in
+  *"${KC_TEST_DOMAIN:-__no_such_domain__}") printf '%s\n' ${KC_WILDCARD_IPS:-} ;;
+esac
+exit 0
+SHIM
+cat > "$SHIMDIR/host"   <<'SHIM'
+#!/usr/bin/env bash
+exit 1
+SHIM
+cat > "$SHIMDIR/getent" <<'SHIM'
+#!/usr/bin/env bash
+exit 2
+SHIM
+
+cat > "$SHIMDIR/git" <<'SHIM'
+#!/usr/bin/env bash
+[ "${1:-}" = "ls-remote" ] && { [ -n "${KC_GIT_OK:-}" ] && exit 0 || exit 128; }
+exit 0
+SHIM
+chmod +x "$SHIMDIR"/*
+
+# run_doctor: run doctor.sh with the shims first on PATH. Env for the scenario is
+# passed by the caller via the environment. Captures combined output + rc.
+run_doctor() {
+  DOCTOR_OUT="$(PATH="$SHIMDIR:$PATH" bash "$DOCTOR" 2>&1)"; DOCTOR_RC=$?
+}
+
+# A fully-healthy environment. Individual tests override single vars to break one
+# check at a time. `env -i`-style: we export everything the shims read.
+healthy_env() {
+  export KC_KUBECTL_OK=1 KC_K8S_MAJOR=1 KC_K8S_MINOR=27 KC_HELM_VER="v3.14.4+gtest"
+  export KC_INGRESS_PRESENT=1 KC_INGRESS_SVC="ingress-nginx/ingress-nginx-controller"
+  export KC_INGRESS_IP="203.0.113.10" KC_INGRESS_HOST=""
+  export KC_CM_CRD=1 KC_CM_DEPLOY=1 KC_ISSUERS="letsencrypt-production"
+  export KC_REGCRED=1 KC_REGCRED_TYPE="kubernetes.io/dockerconfigjson"
+  export KC_NS_EXISTS=1
+  export NAMESPACE="coder" DOMAIN="" USERS_REPO=""
+  export KC_TEST_DOMAIN="dev.example.io" KC_WILDCARD_IPS="203.0.113.10" KC_GIT_OK=1
+  : > "$KC_MUTATION_LOG"
+}
+
+assert_fail_contains() { # <name> <substr> ; inspects the last run_doctor output
+  local name="$1" sub="$2"
+  if grep -q '\[FAIL\]' <<<"$DOCTOR_OUT" && grep -qi "$sub" <<<"$DOCTOR_OUT"; then
+    ok "$name"
+  else
+    bad "$name" "expected a FAIL mentioning '$sub'; got: $DOCTOR_OUT"
+  fi
+}
+
+# Scenarios run in the current shell (not a subshell) so ok/bad update the
+# tallies. healthy_env re-exports every shim var on each call, so a scenario's
+# overrides never leak into the next one.
+echo "doctor tests"
+
+# ── 1. Healthy cluster: all pass, exit 0, no [FAIL] ─────────────────────────
+echo "- all-healthy"
+healthy_env; run_doctor
+grep -q '\[FAIL\]' <<<"$DOCTOR_OUT" && bad "no FAIL on healthy env" "$DOCTOR_OUT" || ok "no FAIL on healthy env"
+[ "$DOCTOR_RC" -eq 0 ] && ok "healthy env exits 0" || bad "healthy env exits 0" "rc=$DOCTOR_RC"
+
+# ── 2. Read-only: a healthy run touches no mutating verb ────────────────────
+echo "- read-only"
+healthy_env; run_doctor
+if [ -s "$KC_MUTATION_LOG" ]; then bad "no mutating kubectl calls" "$(cat "$KC_MUTATION_LOG")"
+else ok "no mutating kubectl calls"; fi
+
+# ── 3. Reports ALL failures in one run (never stops at the first) ───────────
+echo "- reports all failures at once"
+healthy_env
+KC_K8S_MINOR=15            # too-old cluster  -> FAIL
+KC_INGRESS_PRESENT=""      # no ingress       -> FAIL
+KC_ISSUERS=""              # no ClusterIssuer -> FAIL
+KC_REGCRED=""              # no regcred       -> FAIL
+run_doctor
+n=$(grep -c '\[FAIL\]' <<<"$DOCTOR_OUT")
+[ "$n" -ge 4 ] && ok "all four failures reported ($n)" || bad "all four failures reported" "got $n: $DOCTOR_OUT"
+[ "$DOCTOR_RC" -ne 0 ] && ok "any failure => non-zero exit" || bad "any failure => non-zero exit" "rc=$DOCTOR_RC"
+
+# ── 4. Individual check failures each FAIL ──────────────────────────────────
+echo "- individual checks fail on bad input"
+healthy_env; KC_K8S_MINOR=15; run_doctor;         assert_fail_contains "old k8s version"     "below the required 1.19"
+healthy_env; KC_HELM_VER="v2.17.0"; run_doctor;   assert_fail_contains "old helm"            "below the required 3.0"
+healthy_env; KC_INGRESS_PRESENT=""; run_doctor;   assert_fail_contains "no ingress"          "no nginx-ingress controller"
+healthy_env; KC_CM_CRD=""; run_doctor;            assert_fail_contains "no cert-manager"     "cert-manager is not installed"
+healthy_env; KC_ISSUERS=""; run_doctor;           assert_fail_contains "no ClusterIssuer"    "no ClusterIssuer exists"
+healthy_env; KC_REGCRED=""; run_doctor;           assert_fail_contains "no regcred"          "regcred' not found"
+healthy_env; KC_KUBECTL_OK=""; run_doctor;        assert_fail_contains "unreachable cluster" "cannot reach a cluster"
+
+# ── 5. Wildcard DNS — the highest-value check ───────────────────────────────
+echo "- wildcard DNS vs ingress IP"
+healthy_env; DOMAIN="dev.example.io"; KC_WILDCARD_IPS="203.0.113.10"   # == ingress IP
+run_doctor
+grep -Eq '\[OK\].*wildcard DNS resolves to the ingress IP' <<<"$DOCTOR_OUT" \
+  && ok "matching wildcard passes" || bad "matching wildcard passes" "$DOCTOR_OUT"
+
+healthy_env; DOMAIN="dev.example.io"; KC_WILDCARD_IPS="198.51.100.99"  # != ingress IP
+run_doctor
+grep -Eq '\[FAIL\].*WRONG address' <<<"$DOCTOR_OUT" \
+  && ok "mismatched wildcard fails" || bad "mismatched wildcard fails" "$DOCTOR_OUT"
+[ "$DOCTOR_RC" -ne 0 ] && ok "mismatched wildcard => non-zero" || bad "mismatched wildcard => non-zero" "rc=$DOCTOR_RC"
+
+healthy_env; DOMAIN="dev.example.io"; KC_WILDCARD_IPS=""               # no record
+run_doctor
+grep -Eq '\[FAIL\].*wildcard DNS does not resolve' <<<"$DOCTOR_OUT" \
+  && ok "absent wildcard fails" || bad "absent wildcard fails" "$DOCTOR_OUT"
+
+healthy_env   # DOMAIN unset -> skipped as a WARN, must NOT fail the run
+run_doctor
+grep -Eq '\[WARN\].*no DOMAIN supplied' <<<"$DOCTOR_OUT" \
+  && ok "no DOMAIN => wildcard skipped (warn)" || bad "no DOMAIN => wildcard skipped (warn)" "$DOCTOR_OUT"
+[ "$DOCTOR_RC" -eq 0 ] && ok "skipped wildcard does not fail the run" || bad "skipped wildcard does not fail the run" "rc=$DOCTOR_RC"
+
+# ── 6. Warnings alone never fail the run ────────────────────────────────────
+echo "- warnings never fail the run"
+healthy_env   # DOMAIN + USERS_REPO unset => two WARN skips, zero FAIL
+run_doctor
+w=$(grep -c '\[WARN\]' <<<"$DOCTOR_OUT")
+[ "$w" -ge 2 ] && ok "warnings present ($w)" || bad "warnings present" "got $w"
+[ "$DOCTOR_RC" -eq 0 ] && ok "warnings-only exits 0" || bad "warnings-only exits 0" "rc=$DOCTOR_RC"
+
+# ── 7. GitOps repo reachability ─────────────────────────────────────────────
+echo "- gitops repo reachability"
+healthy_env; USERS_REPO="github.com/acme/kube-coder-users.git"; KC_GIT_OK=1
+run_doctor
+grep -Eq '\[OK\].*GitOps repo reachable' <<<"$DOCTOR_OUT" \
+  && ok "reachable repo passes" || bad "reachable repo passes" "$DOCTOR_OUT"
+
+healthy_env; USERS_REPO="github.com/acme/kube-coder-users.git"; KC_GIT_OK=""
+run_doctor
+grep -Eq '\[FAIL\].*GitOps repo not reachable' <<<"$DOCTOR_OUT" \
+  && ok "unreachable repo fails" || bad "unreachable repo fails" "$DOCTOR_OUT"
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## What

Adds a **`make doctor`** target — a read-only operator preflight that runs **before the first user or workspace exists** and verifies the documented cloud / multi-tenant ("Option B") prerequisites. It **reports every failure at once** (never stops at the first), each with a specific remediation, then exits non-zero if any check FAILed. Warnings (e.g. a skipped optional check) never fail the run.

New: `scripts/doctor.sh` + a `doctor:` Makefile target + a README "Option B" mention (run it first) + `scripts/doctor_test.sh`.

## Checks implemented

1. **CLI + reachability** — `kubectl` on PATH and reaching a cluster; cluster server version ≥ 1.19; `helm` ≥ 3.0.
2. **nginx-ingress** — a controller LoadBalancer Service is present and its external IP (or hostname, resolved) is known.
3. **cert-manager** — installed (CRD + controller) **and at least one ClusterIssuer that actually exists**.
4. **Wildcard DNS** — resolves a random `<nonce>.$DOMAIN` and compares it against the ingress external IP. **This is the highest-value check** — a broken wildcard silently produces a dead workspace much later, not here. Supply `DOMAIN=<domain>` to enable it; skipped with a clear how-to note otherwise.
5. **regcred** — a `kubernetes.io/dockerconfigjson` image-pull secret named `regcred` is present in the target namespace (`NAMESPACE`, default `coder`).
6. **GitOps repo** — the config repo is reachable via `git ls-remote` with the credentials in use.

```bash
make doctor
DOMAIN=dev.example.io make doctor
NAMESPACE=coder DOMAIN=dev.example.io make doctor
```

## Design notes

- **Read-only.** Every cluster call is a `get`/`status`/`ls-remote`. Nothing is installed, applied, patched, or mutated. The test asserts this by shimming `kubectl` and failing if any mutating verb is ever invoked.
- **Reports all failures**, then exits 0 iff none FAILed. Warnings don't fail.
- **Does NOT touch `scripts/validate-user.sh`.** Per the issue's non-goals, that script is a *per-user, post-scaffold* check; `doctor` is *cluster-level, pre-first-user*. It mirrors validate-user's `[OK]/[WARN]/[FAIL]` + summary + actionable-remediation style rather than coupling to it.
- Parameterized via env consistent with the Makefile (`NAMESPACE`, `DOMAIN`, `USERS_REPO`/`KC_USERS_REPO`, the latter also resolved from the gitignored controller values like the rest of the Makefile).

## Testing

- `scripts/doctor_test.sh` — 22 assertions, offline via PATH shims for `kubectl`/`helm`/`dig`/`git`. Covers: all-healthy → exit 0; report-all (four simultaneous failures in one run); each individual check failing; wildcard match vs. mismatch vs. absent vs. skipped; warnings-only still exits 0; GitOps reachable/unreachable; and read-only (no mutating kubectl verb). Follows the existing `.claude/skills/kc-issue/lint_test.sh` shell-test pattern.
- `bash -n` clean on both scripts.
- Ran `make doctor` against a live cluster: all six sections execute, `[OK]`/`[WARN]`/`[FAIL]` render, and it exits 0 when healthy / non-zero (via `make`) when a check fails.

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)