### PR TITLE
feat(controller): auto-pause idle workspaces, preserving the PVC (#612)

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ All per-workspace, in the same console:
 
 - **Right-size resources** — **Edit limits** → set CPU / memory. Applying patches the live pod **and** commits the new limits to GitOps, so it's durable across redeploys. Live usage + estimated monthly cost sit right above the control.
 - **Keep them current** — each workspace shows its release and an **update** action; users can also self-update from their own dashboard.
-- **Pause to save spend** — **Stop** scales the pod to zero (PVC preserved); **Start** brings it back unchanged.
+- **Pause to save spend** — **Stop** scales the pod to zero (PVC preserved); **Start** brings it back unchanged. Opt a workspace into **auto-pause** and the controller does it for you once the workspace has been idle, never while a build, chat turn or terminal is live. Waking stays manual — a request to a paused workspace fails until it's started. See [docs/auto-pause.md](docs/auto-pause.md).
 
 #### Automation / break-glass: the CLI
 

--- a/charts/workspace-controller/controller.py
+++ b/charts/workspace-controller/controller.py
@@ -309,6 +309,10 @@ def _ws_item(dep):
         'image': image,
         'imageTag': image_tag,
         'version': version,
+        # Auto-pause opt-in + whether THIS controller was what stopped it
+        # (#612). Read from the Deployment's own annotations, so the fleet
+        # listing stays one deployments read per namespace — no pod query.
+        'autoPause': auto_pause_config(dep),
     }
 
 
@@ -396,6 +400,285 @@ def scale_workspace(user, replicas):
                  namespace=ws['namespace'])
     invalidate_workspaces_cache()   # reflect start/stop on the next console poll
     return name
+
+
+# --- Auto-pause (#612) -------------------------------------------------------
+#
+# An idle workspace is the dominant waste in a multi-tenant deployment. Every
+# mechanical piece already existed — scale_workspace() above turns a workspace
+# off while preserving the PVC, the console shows `stopped`, and the insights
+# pass already NOTICES idleness and prices it. All that was missing was acting
+# on it, which is policy, and policy here is almost entirely about safety.
+#
+# Scaling a busy workspace to 0 destroys a running agent's work, which is
+# strictly worse than leaving a pod idle. The controller cannot see busyness on
+# its own: it reads Prometheus (cadvisor / kube-state-metrics) and never talks
+# to a workspace, and CPU cannot distinguish an idle workspace from an agent
+# parked at a permission prompt — that one burns no CPU and must never be
+# paused. So the workspace publishes the answer itself, onto its own pod's
+# annotations (server.py: ActivityBeacon), and this reads it back.
+#
+# Every rule below fails CLOSED: unknown, unparseable, missing or stale inputs
+# all mean "do not pause". Not pausing costs cents; pausing a working agent
+# costs the user their run.
+
+# Fleet kill switch. Per-workspace opt-in is off by default anyway, so this
+# stays on and operators enable individual workspaces.
+AUTOPAUSE_ENABLED = os.environ.get('AUTOPAUSE_ENABLED', 'true').strip().lower() \
+    not in ('0', 'false', 'no', 'off')
+AUTOPAUSE_INTERVAL = float(os.environ.get('AUTOPAUSE_INTERVAL_SECONDS', '300'))
+# How old a beacon may be and still be believed. Must comfortably exceed the
+# workspace's publish interval (KC_BEACON_INTERVAL, default 30s) so ordinary
+# scheduling jitter never reads as a dead beacon.
+AUTOPAUSE_BEACON_MAX_AGE = float(os.environ.get('AUTOPAUSE_BEACON_MAX_AGE_SECONDS', '300'))
+# Used when a workspace opted in without naming its own threshold.
+AUTOPAUSE_DEFAULT_IDLE_MINUTES = float(
+    os.environ.get('AUTOPAUSE_DEFAULT_IDLE_MINUTES', '120'))
+
+# Written by the workspace chart onto the Deployment (the operator's intent).
+ANN_AUTO_PAUSE = 'kube-coder.io/auto-pause'
+ANN_AUTO_PAUSE_IDLE = 'kube-coder.io/auto-pause-idle-minutes'
+# Written by this controller onto the Deployment when it pauses one, so the
+# console can tell an auto-pause from someone pressing Stop.
+ANN_AUTO_PAUSED_AT = 'kube-coder.io/auto-paused-at'
+# Written by the workspace onto its own pod (server.py: ActivityBeacon).
+ANN_BUSY = 'kube-coder.io/busy'
+ANN_LAST_ACTIVITY = 'kube-coder.io/last-activity'
+ANN_BEACON_AT = 'kube-coder.io/beacon-at'
+
+
+def _ann_float(value):
+    """An annotation value → float, or None. Annotations are free-form strings
+    that anyone with edit rights can set to anything, so every read of one has
+    to survive garbage without deciding to scale a workspace to zero."""
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _ann_bool(value, default=False):
+    v = str(value).strip().lower()
+    if v in ('1', 'true', 'yes', 'on'):
+        return True
+    if v in ('0', 'false', 'no', 'off'):
+        return False
+    return default
+
+
+def auto_pause_config(dep):
+    """The workspace's opt-in, read off its Deployment annotations."""
+    ann = (dep.get('metadata', {}) or {}).get('annotations', {}) or {}
+    idle = _ann_float(ann.get(ANN_AUTO_PAUSE_IDLE))
+    if idle is None or idle <= 0:
+        idle = AUTOPAUSE_DEFAULT_IDLE_MINUTES
+    return {
+        'enabled': _ann_bool(ann.get(ANN_AUTO_PAUSE), False),
+        'idleMinutes': idle,
+        'autoPausedAt': _ann_float(ann.get(ANN_AUTO_PAUSED_AT)),
+    }
+
+
+def should_pause(ws, beacon, now, beacon_max_age=None):
+    """Decide whether ONE workspace may be auto-paused. Returns (bool, reason).
+
+    Pure — every input is a plain dict — so the entire policy is table-testable
+    without a cluster, which matters for a decision whose failure mode is
+    destroying someone's work.
+
+    `ws` is a _ws_item(); `beacon` is the pod's annotation map (or None when
+    there is no pod, or no beacon on it). `reason` is the audit trail: why it
+    paused, or precisely why it declined.
+    """
+    max_age = AUTOPAUSE_BEACON_MAX_AGE if beacon_max_age is None else beacon_max_age
+    cfg = ws.get('autoPause') or {}
+
+    if not cfg.get('enabled'):
+        return False, 'not opted in'
+    if (ws.get('desiredReplicas') or 0) == 0:
+        return False, 'already stopped'
+    # Only ever pause a settled, healthy workspace. Pausing something mid-roll
+    # or already degraded turns one problem into two, and the state is about to
+    # change anyway.
+    if ws.get('state') != 'running':
+        return False, f"state is {ws.get('state')!r}, not running"
+
+    if not beacon:
+        return False, 'no activity beacon (older image, or no pod)'
+
+    beacon_at = _ann_float(beacon.get(ANN_BEACON_AT))
+    if beacon_at is None:
+        return False, 'beacon has no readable timestamp'
+    age = now - beacon_at
+    if age > max_age:
+        return False, f'beacon is stale ({int(age)}s old, max {int(max_age)}s)'
+
+    # Anything that is not literally "false" counts as busy — including a value
+    # we do not recognise. The default has to be the one that preserves work.
+    if str(beacon.get(ANN_BUSY, '')).strip().lower() != 'false':
+        return False, 'workspace reports busy'
+
+    last = _ann_float(beacon.get(ANN_LAST_ACTIVITY))
+    if last is None:
+        return False, 'beacon has no readable last-activity'
+
+    idle_for = now - last
+    threshold = float(cfg.get('idleMinutes') or AUTOPAUSE_DEFAULT_IDLE_MINUTES) * 60.0
+    if idle_for < threshold:
+        return False, f'idle {int(idle_for)}s < threshold {int(threshold)}s'
+
+    return True, f'idle {int(idle_for)}s >= threshold {int(threshold)}s'
+
+
+def _pod_beacon(namespace, deployment):
+    """Annotations of the workspace's pod, or None. Deliberately NOT part of
+    _ws_item: that runs on the console's poll path, where an all-namespace pod
+    read previously stacked enough JSON to OOM this pod. This is called only
+    from the auto-pause pass, once per opted-in workspace, every few minutes."""
+    try:
+        out = _kubectl_json(['get', 'pods', '-l', f'app={deployment}'],
+                            namespace=namespace)
+    except KubectlError:
+        return None
+    for pod in (out.get('items') or []):
+        meta = pod.get('metadata', {}) or {}
+        ann = meta.get('annotations', {}) or {}
+        if ANN_BEACON_AT in ann:
+            return ann
+    return None
+
+
+def _cpu_is_idle(namespace, deployment):
+    """Second opinion from Prometheus: True only if measured CPU is under the
+    idle threshold. None when it cannot be measured.
+
+    The beacon knows about Builds, chat turns and terminals — it does NOT know
+    about a dev server or a compile someone left running in a detached tmux.
+    That work is invisible to every other signal here and very visible in CPU,
+    so this is the check that catches it. An unmeasurable answer blocks the
+    pause rather than allowing it."""
+    pod_re = f'{deployment}-.*'
+    expr = (f'sum(avg by (pod, container) (rate(container_cpu_usage_seconds_total'
+            f'{{namespace="{namespace}",pod=~"{pod_re}",container!=""}}[5m])))')
+    try:
+        cores = prom_scalar(expr)
+    except PromError:
+        return None
+    if cores is None:
+        return None
+    return cores < INSIGHTS_IDLE_CPU_CORES
+
+
+def _mark_auto_paused(namespace, deployment, when):
+    """Record that WE paused this one, so the console can distinguish it from a
+    workspace someone stopped by hand — and so a manual Start can clear it."""
+    patch = json.dumps({'metadata': {'annotations': {
+        ANN_AUTO_PAUSED_AT: f'{when:.0f}'}}})
+    _kubectl_run(['patch', f'deployment/{deployment}', '--type=merge', '-p', patch],
+                 namespace=namespace)
+
+
+def clear_auto_paused(user):
+    """Drop the auto-paused marker. Called when a workspace is started, so a
+    workspace resumed by hand stops being labelled 'paused automatically'.
+    Best-effort: never block a start on bookkeeping."""
+    try:
+        ws = find_workspace(user)
+    except (LookupError, ValueError):
+        return
+    patch = json.dumps({'metadata': {'annotations': {ANN_AUTO_PAUSED_AT: None}}})
+    try:
+        _kubectl_run(['patch', f'deployment/{ws["deployment"]}', '--type=merge',
+                      '-p', patch], namespace=ws['namespace'])
+    except KubectlError as exc:
+        sys.stderr.write(f'[autopause] clearing marker for {user} failed: {exc}\n')
+
+
+def autopause_pass(now=None):
+    """One sweep of the fleet. Returns a list of per-workspace decisions —
+    returned rather than only logged so the pass is testable and so a future
+    endpoint can show an operator why a workspace did or did not pause."""
+    now = time.time() if now is None else now
+    decisions = []
+    try:
+        listing = list_workspaces()
+    except Exception as exc:
+        sys.stderr.write(f'[autopause] listing failed: {exc}\n')
+        return decisions
+
+    for ws in listing.get('workspaces', []):
+        cfg = ws.get('autoPause') or {}
+        if not cfg.get('enabled'):
+            continue                      # keep the log about opted-in workspaces
+        beacon = _pod_beacon(ws['namespace'], ws['deployment'])
+        ok, reason = should_pause(ws, beacon, now)
+        if ok:
+            # Only now spend a Prometheus query — the cheap local checks have
+            # already ruled out everything else.
+            cpu_idle = _cpu_is_idle(ws['namespace'], ws['deployment'])
+            if cpu_idle is not True:
+                ok, reason = False, ('cpu not measurably idle' if cpu_idle is None
+                                     else 'cpu above idle threshold')
+        decisions.append({'user': ws['user'], 'paused': False, 'reason': reason})
+        if not ok:
+            continue
+        try:
+            scale_workspace(ws['user'], 0)
+            _mark_auto_paused(ws['namespace'], ws['deployment'], now)
+            decisions[-1]['paused'] = True
+            sys.stderr.write(f'[autopause] paused {ws["user"]}: {reason}\n')
+        except (KubectlError, LookupError, ValueError) as exc:
+            decisions[-1]['reason'] = f'pause failed: {exc}'
+            sys.stderr.write(f'[autopause] pausing {ws["user"]} failed: {exc}\n')
+    return decisions
+
+
+class AutoPauser:
+    """Background sweep. The controller is otherwise entirely request-driven —
+    it computes advisories only when the console asks — but auto-pause has to
+    happen whether or not anyone is looking at it."""
+
+    _started = False
+    _thread = None
+    _stop_event = threading.Event()
+    _start_lock = threading.Lock()
+    _last_run_at = 0.0
+    _last_decisions = []
+
+    @classmethod
+    def start(cls, *, interval_seconds=None):
+        interval = AUTOPAUSE_INTERVAL if interval_seconds is None else interval_seconds
+        with cls._start_lock:
+            if cls._started:
+                return
+            cls._started = True
+
+        def _loop():
+            while not cls._stop_event.is_set():
+                # Wait FIRST. Nothing should be scaled to zero in the first
+                # moments after a controller restart, while the fleet listing
+                # and Prometheus are both cold — a restart must never be a way
+                # to pause the fleet.
+                cls._stop_event.wait(interval)
+                if cls._stop_event.is_set():
+                    break
+                try:
+                    cls._last_decisions = autopause_pass()
+                    cls._last_run_at = time.time()
+                except Exception as exc:
+                    sys.stderr.write(f'[autopause] pass failed: {exc}\n')
+
+        t = threading.Thread(target=_loop, name='auto-pauser', daemon=True)
+        cls._thread = t
+        t.start()
+
+    @classmethod
+    def status(cls):
+        return {
+            'running': cls._started and (cls._thread is not None and cls._thread.is_alive()),
+            'lastRunAt': cls._last_run_at or None,
+            'lastDecisions': cls._last_decisions,
+        }
 
 
 # --- Resource limits ---------------------------------------------------------
@@ -733,6 +1016,112 @@ def gitops_update_resources(slug, limits):
     summary = ', '.join(f'{k}={v}' for k, v in limits.items())
     return _gitops_edit_values(slug, lambda c: _swap_resource_limits(c, limits),
                                f'update {slug} resource limits ({summary})')
+
+
+def _swap_auto_pause(content, enabled, idle_minutes):
+    """Set autoPause.enabled / .idleMinutes in a values.yaml body, appending the
+    block when it isn't there yet. Returns (new_content, changed).
+
+    Appending matters: every workspace provisioned before #612 has a values.yaml
+    with no autoPause block at all, and an operator toggling auto-pause on one of
+    those must persist — otherwise the next reconcile silently turns it back off
+    and the console would be lying about the setting. Line/regex based, matching
+    _swap_resource_limits — no YAML dependency in this path.
+    """
+    desired = {'enabled': 'true' if enabled else 'false',
+               'idleMinutes': f'{int(idle_minutes)}'}
+    m = re.search(r'(?m)^autoPause:[ \t]*$', content)
+    if not m:
+        block = ('\n# Auto-pause an idle workspace (#612): scale to 0, keep the PVC.\n'
+                 '# Wake is manual — press Start in the console.\n'
+                 'autoPause:\n'
+                 f'  enabled: {desired["enabled"]}\n'
+                 f'  idleMinutes: {desired["idleMinutes"]}\n')
+        sep = '' if content.endswith('\n') else '\n'
+        return content + sep + block, True
+
+    nl = content.find('\n', m.end())
+    if nl == -1:
+        return content, False
+    body_start = nl + 1
+    i = body_start
+    while i < len(content):
+        end = content.find('\n', i)
+        end = len(content) if end == -1 else end + 1
+        line = content[i:end]
+        if line.strip() != '':
+            indent = len(line) - len(line.lstrip(' \t'))
+            if indent == 0:                  # dedent → autoPause block ended
+                break
+        i = end
+    body = content[body_start:i]
+    new_body, changed = body, False
+    for key, value in desired.items():
+        pattern = re.compile(rf'(?m)^([ \t]+{key}:[ \t]*)(.*)$')
+        km = pattern.search(new_body)
+        if km:
+            if km.group(2).strip() != value:
+                new_body = pattern.sub(lambda mm: f'{mm.group(1)}{value}', new_body, count=1)
+                changed = True
+        else:                                # partial block — add the missing key
+            new_body = new_body + f'  {key}: {value}\n'
+            changed = True
+    if not changed:
+        return content, False
+    return content[:body_start] + new_body + content[i:], True
+
+
+def gitops_update_auto_pause(slug, enabled, idle_minutes):
+    """Persist an auto-pause toggle to the user's values.yaml. Returns True iff
+    pushed."""
+    state = 'on' if enabled else 'off'
+    return _gitops_edit_values(
+        slug, lambda c: _swap_auto_pause(c, enabled, idle_minutes),
+        f'turn auto-pause {state} for {slug} (idle {int(idle_minutes)}m)')
+
+
+def set_workspace_auto_pause(user, enabled, idle_minutes=None, persist=True):
+    """Turn auto-pause on/off for one workspace.
+
+    Same dual write as set_workspace_resources: patch the live Deployment so the
+    change takes effect on the next sweep, AND commit it to the user's
+    values.yaml so the next reconcile doesn't undo it. The annotation goes on
+    the Deployment's metadata, not its pod template, so changing the policy
+    never rolls the pod — restarting a workspace to tell it it might be paused
+    later would be its own small outage.
+    """
+    if not _USER_RE.match(user):
+        raise ValueError('invalid workspace name')
+    enabled = bool(enabled)
+    if idle_minutes in (None, ''):
+        idle = AUTOPAUSE_DEFAULT_IDLE_MINUTES
+    else:
+        parsed = _ann_float(idle_minutes)
+        if parsed is None or parsed <= 0:
+            raise ValueError('idleMinutes must be a positive number')
+        if parsed > 43200:                   # 30 days — a typo, not a policy
+            raise ValueError('idleMinutes exceeds max 43200 (30 days)')
+        idle = parsed
+
+    ws = find_workspace(user)
+    patch = json.dumps({'metadata': {'annotations': {
+        ANN_AUTO_PAUSE: 'true' if enabled else 'false',
+        ANN_AUTO_PAUSE_IDLE: f'{int(idle)}',
+    }}})
+    _kubectl_run(['patch', f"deployment/{ws['deployment']}", '--type=merge', '-p', patch],
+                 namespace=ws['namespace'])
+
+    persisted = False
+    persist_error = None
+    if persist and GITOPS_REPO and GITOPS_TOKEN:
+        try:
+            persisted = gitops_update_auto_pause(user, enabled, idle)
+        except (ProvisionError, GithubError) as exc:
+            persist_error = str(exc)
+            sys.stderr.write(f'[controller] gitops auto-pause update {user} failed: {exc}\n')
+    invalidate_workspaces_cache()
+    return {'user': user, 'autoPause': {'enabled': enabled, 'idleMinutes': idle},
+            'persisted': persisted, 'persistError': persist_error}
 
 
 def set_workspace_image(user, target_version=None, persist=True):
@@ -2400,6 +2789,29 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             self.send_json({'ok': True, 'user': user, 'limits': result['limits'],
                             'persisted': result['persisted'], 'persistError': result['persistError']})
             return
+        # Auto-pause opt-in for one workspace (#612).
+        am = re.match(r'^/api/workspaces/([a-z0-9-]{1,41})/auto-pause$', path)
+        if am:
+            if not self.check_admin():
+                self.send_json({'error': 'unauthorized'}, 401)
+                return
+            user = am.group(1)
+            try:
+                body = self.read_json_body()
+                result = set_workspace_auto_pause(
+                    user, body.get('enabled'), body.get('idleMinutes'))
+            except ValueError as exc:
+                self.send_json({'error': str(exc)}, 400)
+                return
+            except LookupError:
+                self.send_json({'error': f'no workspace {WORKSPACE_PREFIX}{user}'}, 404)
+                return
+            except KubectlError as exc:
+                sys.stderr.write(f'[controller] set auto-pause {user}: {exc}: {exc.stderr}\n')
+                self.send_json({'error': str(exc)}, 502)
+                return
+            self.send_json({'ok': True, **result})
+            return
         # Restart-and-update: repoint the workspace at a release version (latest
         # by default). Admin route (oauth2-gated) and the workspace-brokered
         # self-serve route (shared-token-gated) share one handler.
@@ -2468,6 +2880,9 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         try:
             self.read_json_body()  # drain body if any; we don't need it
             scale_workspace(user, replicas)
+            if action == 'start':
+                # Started by hand — it is no longer "paused automatically".
+                clear_auto_paused(user)
         except ValueError:
             self.send_json({'error': 'invalid workspace name'}, 400)
             return
@@ -2537,6 +2952,16 @@ def main():
                   file=sys.stderr)
     else:
         print('[controller] self-serve disabled (SELF_SERVE_TOKEN unset)', file=sys.stderr)
+
+    # Auto-pause sweep (#612). Opt-in is per workspace and off by default, so
+    # starting the sweep here changes nothing until an operator enables it on a
+    # specific workspace.
+    if AUTOPAUSE_ENABLED:
+        AutoPauser.start()
+        print(f'[controller] auto-pause sweep every {AUTOPAUSE_INTERVAL:.0f}s '
+              f'(per-workspace opt-in)', file=sys.stderr)
+    else:
+        print('[controller] auto-pause disabled (AUTOPAUSE_ENABLED)', file=sys.stderr)
 
     httpd = http.server.ThreadingHTTPServer(('0.0.0.0', PORT), Handler)
     print(f'[controller] listening on 0.0.0.0:{PORT}', file=sys.stderr)

--- a/charts/workspace-controller/tests/controller_test.py
+++ b/charts/workspace-controller/tests/controller_test.py
@@ -1356,5 +1356,308 @@ class SelfServeTokenBindingTest(unittest.TestCase):
         self.assertFalse(self.check(self.MASTER, None))
 
 
+NOW = 1_000_000.0
+
+
+def _ws(**over):
+    """An opted-in, running workspace that IS eligible to pause. Each test
+    breaks exactly one thing, so a failure names its own cause."""
+    ws = {
+        'user': 'octo', 'deployment': 'ws-octo', 'namespace': 'ws-octo',
+        'state': 'running', 'desiredReplicas': 1,
+        'autoPause': {'enabled': True, 'idleMinutes': 120, 'autoPausedAt': None},
+    }
+    ws.update(over)
+    return ws
+
+
+def _beacon(busy='false', last=NOW - 7200, at=NOW - 10):
+    b = {}
+    if busy is not None:
+        b[controller.ANN_BUSY] = busy
+    if last is not None:
+        b[controller.ANN_LAST_ACTIVITY] = str(last)
+    if at is not None:
+        b[controller.ANN_BEACON_AT] = str(at)
+    return b
+
+
+class ShouldPauseTest(unittest.TestCase):
+    """The auto-pause decision (#612).
+
+    This is the highest-stakes pure function in the controller: a wrong `True`
+    scales a workspace to 0 while an agent is mid-run and destroys that work.
+    Every case below that is not the happy path must come back False.
+    """
+
+    def test_pauses_an_idle_opted_in_workspace(self):
+        ok, why = controller.should_pause(_ws(), _beacon(), NOW)
+        self.assertTrue(ok, why)
+
+    def test_never_pauses_a_workspace_that_did_not_opt_in(self):
+        ws = _ws(autoPause={'enabled': False, 'idleMinutes': 120})
+        ok, why = controller.should_pause(ws, _beacon(), NOW)
+        self.assertFalse(ok)
+        self.assertIn('not opted in', why)
+
+    def test_never_pauses_a_busy_workspace(self):
+        ok, why = controller.should_pause(_ws(), _beacon(busy='true'), NOW)
+        self.assertFalse(ok)
+        self.assertIn('busy', why)
+
+    def test_unrecognised_busy_value_counts_as_busy(self):
+        # Fail closed: only the literal "false" is permission to pause.
+        for value in ('TRUE', 'maybe', '', 'yes', '1'):
+            ok, _ = controller.should_pause(_ws(), _beacon(busy=value), NOW)
+            self.assertFalse(ok, f'busy={value!r} must not pause')
+
+    def test_busy_is_case_insensitive_for_false(self):
+        ok, why = controller.should_pause(_ws(), _beacon(busy='False'), NOW)
+        self.assertTrue(ok, why)
+
+    def test_never_pauses_before_the_threshold(self):
+        ok, why = controller.should_pause(_ws(), _beacon(last=NOW - 60), NOW)
+        self.assertFalse(ok)
+        self.assertIn('threshold', why)
+
+    def test_threshold_comes_from_the_workspace_not_the_default(self):
+        ws = _ws(autoPause={'enabled': True, 'idleMinutes': 5})
+        ok, why = controller.should_pause(ws, _beacon(last=NOW - 600), NOW)
+        self.assertTrue(ok, why)          # 10m idle, 5m threshold
+
+    def test_never_pauses_on_a_stale_beacon(self):
+        # A dead beacon thread must not read as "quiet".
+        ok, why = controller.should_pause(
+            _ws(), _beacon(at=NOW - 9999), NOW, beacon_max_age=300)
+        self.assertFalse(ok)
+        self.assertIn('stale', why)
+
+    def test_never_pauses_without_a_beacon(self):
+        # An older workspace image publishes nothing at all.
+        for beacon in (None, {}):
+            ok, why = controller.should_pause(_ws(), beacon, NOW)
+            self.assertFalse(ok)
+            self.assertIn('beacon', why)
+
+    def test_never_pauses_on_malformed_annotations(self):
+        for bad in ({controller.ANN_BEACON_AT: 'soon',
+                     controller.ANN_BUSY: 'false',
+                     controller.ANN_LAST_ACTIVITY: '1'},
+                    {controller.ANN_BEACON_AT: str(NOW - 10),
+                     controller.ANN_BUSY: 'false',
+                     controller.ANN_LAST_ACTIVITY: 'ages ago'}):
+            ok, why = controller.should_pause(_ws(), bad, NOW)
+            self.assertFalse(ok, why)
+
+    def test_never_pauses_an_already_stopped_workspace(self):
+        ok, why = controller.should_pause(_ws(desiredReplicas=0), _beacon(), NOW)
+        self.assertFalse(ok)
+        self.assertIn('already stopped', why)
+
+    def test_never_pauses_a_workspace_that_is_not_settled(self):
+        for state in ('transitioning', 'degraded', 'stopped'):
+            ok, why = controller.should_pause(_ws(state=state), _beacon(), NOW)
+            self.assertFalse(ok, f'{state} must not pause')
+
+
+class AutoPauseConfigTest(unittest.TestCase):
+    """Reading the opt-in off the Deployment's annotations."""
+
+    def _dep(self, ann):
+        return {'metadata': {'name': 'ws-octo', 'annotations': ann}}
+
+    def test_absent_annotations_mean_disabled(self):
+        cfg = controller.auto_pause_config({'metadata': {'name': 'ws-octo'}})
+        self.assertFalse(cfg['enabled'])
+
+    def test_reads_enabled_and_threshold(self):
+        cfg = controller.auto_pause_config(self._dep({
+            controller.ANN_AUTO_PAUSE: 'true',
+            controller.ANN_AUTO_PAUSE_IDLE: '45'}))
+        self.assertTrue(cfg['enabled'])
+        self.assertEqual(cfg['idleMinutes'], 45)
+
+    def test_bad_threshold_falls_back_to_the_default(self):
+        for bad in ('nonsense', '0', '-5'):
+            cfg = controller.auto_pause_config(self._dep({
+                controller.ANN_AUTO_PAUSE: 'true',
+                controller.ANN_AUTO_PAUSE_IDLE: bad}))
+            self.assertEqual(cfg['idleMinutes'],
+                             controller.AUTOPAUSE_DEFAULT_IDLE_MINUTES)
+
+
+class AutoPauseValuesEditTest(unittest.TestCase):
+    """values.yaml write-back, so a toggle survives the next reconcile."""
+
+    BLOCK = 'autoPause:\n  enabled: false\n  idleMinutes: 120\n'
+
+    def test_flips_an_existing_block(self):
+        out, changed = controller._swap_auto_pause(self.BLOCK, True, 30)
+        self.assertTrue(changed)
+        self.assertIn('enabled: true', out)
+        self.assertIn('idleMinutes: 30', out)
+
+    def test_appends_the_block_when_missing(self):
+        # Every workspace provisioned before #612 has no autoPause block; the
+        # toggle has to persist for those too or the next reconcile undoes it.
+        out, changed = controller._swap_auto_pause('image:\n  tag: v1\n', True, 60)
+        self.assertTrue(changed)
+        self.assertIn('autoPause:', out)
+        self.assertIn('enabled: true', out)
+        self.assertIn('idleMinutes: 60', out)
+
+    def test_no_change_is_reported_as_no_change(self):
+        # _gitops_edit_values skips the commit entirely when nothing changed.
+        _, changed = controller._swap_auto_pause(self.BLOCK, False, 120)
+        self.assertFalse(changed)
+
+    def test_only_touches_its_own_block(self):
+        content = ('resources:\n  limits:\n    cpu: "2"\n\n' + self.BLOCK +
+                   '\nssh:\n  enabled: true\n')
+        out, changed = controller._swap_auto_pause(content, True, 15)
+        self.assertTrue(changed)
+        self.assertIn('cpu: "2"', out)
+        self.assertIn('ssh:\n  enabled: true', out)
+
+
+class AutoPauseSweepTest(unittest.TestCase):
+    """The fleet sweep: what it scales, and what it must never touch."""
+
+    def setUp(self):
+        self.calls = []
+        self._orig = (controller.list_workspaces, controller._kubectl_run,
+                      controller._pod_beacon, controller._cpu_is_idle,
+                      controller.find_workspace)
+        controller._kubectl_run = lambda args, namespace=None: self.calls.append(
+            (list(args), namespace))
+        controller.find_workspace = lambda user: {
+            'deployment': f'ws-{user}', 'namespace': f'ws-{user}'}
+        controller._cpu_is_idle = lambda ns, dep: True
+        controller._pod_beacon = lambda ns, dep: _beacon()
+        controller.list_workspaces = lambda: {'workspaces': [_ws()]}
+
+    def tearDown(self):
+        (controller.list_workspaces, controller._kubectl_run,
+         controller._pod_beacon, controller._cpu_is_idle,
+         controller.find_workspace) = self._orig
+
+    def test_pauses_an_eligible_workspace(self):
+        decisions = controller.autopause_pass(now=NOW)
+        self.assertEqual(len(decisions), 1)
+        self.assertTrue(decisions[0]['paused'], decisions[0]['reason'])
+        verbs = [c[0][0] for c in self.calls]
+        self.assertIn('scale', verbs)
+
+    def test_pausing_never_touches_the_pvc(self):
+        """Criterion 4 — PVC preservation asserted, not assumed.
+
+        Pausing is `kubectl scale` and an annotation patch. Nothing in this
+        path may name a PVC or delete anything: the whole point of pause over
+        teardown is that the home volume survives it.
+        """
+        controller.autopause_pass(now=NOW)
+        self.assertTrue(self.calls)
+        for args, _ns in self.calls:
+            self.assertNotIn('delete', args)
+            flat = ' '.join(args).lower()
+            self.assertNotIn('pvc', flat)
+            self.assertNotIn('persistentvolumeclaim', flat)
+
+    def test_scales_to_zero_not_to_something_else(self):
+        controller.autopause_pass(now=NOW)
+        scale = next(c[0] for c in self.calls if c[0][0] == 'scale')
+        self.assertIn('--replicas=0', scale)
+
+    def test_marks_the_workspace_as_auto_paused(self):
+        controller.autopause_pass(now=NOW)
+        patch = next(c[0] for c in self.calls if c[0][0] == 'patch')
+        body = json.loads(patch[patch.index('-p') + 1])
+        self.assertIn(controller.ANN_AUTO_PAUSED_AT,
+                      body['metadata']['annotations'])
+
+    def test_skips_workspaces_that_did_not_opt_in(self):
+        controller.list_workspaces = lambda: {
+            'workspaces': [_ws(autoPause={'enabled': False, 'idleMinutes': 120})]}
+        decisions = controller.autopause_pass(now=NOW)
+        self.assertEqual(decisions, [])
+        self.assertEqual(self.calls, [])
+
+    def test_unmeasurable_cpu_blocks_the_pause(self):
+        # Prometheus down => we cannot confirm idleness => leave it running.
+        controller._cpu_is_idle = lambda ns, dep: None
+        decisions = controller.autopause_pass(now=NOW)
+        self.assertFalse(decisions[0]['paused'])
+        self.assertEqual(self.calls, [])
+
+    def test_busy_cpu_blocks_the_pause(self):
+        # A compile or dev server left running is invisible to the beacon and
+        # very visible here.
+        controller._cpu_is_idle = lambda ns, dep: False
+        decisions = controller.autopause_pass(now=NOW)
+        self.assertFalse(decisions[0]['paused'])
+        self.assertEqual(self.calls, [])
+
+    def test_one_failing_workspace_does_not_stop_the_sweep(self):
+        controller.list_workspaces = lambda: {
+            'workspaces': [_ws(user='a', deployment='ws-a', namespace='ws-a'),
+                           _ws(user='b', deployment='ws-b', namespace='ws-b')]}
+        boom = {'n': 0}
+
+        def flaky(args, namespace=None):
+            boom['n'] += 1
+            if boom['n'] == 1:
+                raise controller.KubectlError('conflict')
+            self.calls.append((list(args), namespace))
+        controller._kubectl_run = flaky
+        decisions = controller.autopause_pass(now=NOW)
+        self.assertEqual(len(decisions), 2)
+        self.assertTrue(any(d['paused'] for d in decisions))
+
+
+class SetAutoPauseTest(unittest.TestCase):
+    """The per-workspace toggle endpoint's business logic."""
+
+    def setUp(self):
+        controller.GITOPS_REPO = ''        # no write-back in tests
+        self.calls = []
+        self._orig = (controller.find_workspace, controller._kubectl_run)
+        controller.find_workspace = lambda user: {
+            'deployment': f'ws-{user}', 'namespace': f'ws-{user}'}
+        controller._kubectl_run = lambda args, namespace=None: self.calls.append(
+            (list(args), namespace))
+
+    def tearDown(self):
+        controller.find_workspace, controller._kubectl_run = self._orig
+
+    def test_enabling_patches_the_deployment_annotations(self):
+        result = controller.set_workspace_auto_pause('octo', True, 45)
+        self.assertEqual(result['autoPause'], {'enabled': True, 'idleMinutes': 45})
+        args, ns = self.calls[0]
+        self.assertEqual(args[0], 'patch')
+        self.assertEqual(args[1], 'deployment/ws-octo')
+        self.assertEqual(ns, 'ws-octo')
+        body = json.loads(args[args.index('-p') + 1])
+        ann = body['metadata']['annotations']
+        self.assertEqual(ann[controller.ANN_AUTO_PAUSE], 'true')
+        self.assertEqual(ann[controller.ANN_AUTO_PAUSE_IDLE], '45')
+
+    def test_toggling_never_rolls_the_pod(self):
+        # The annotation is on the Deployment's own metadata, not the pod
+        # template — restarting a workspace to change a pause policy would
+        # interrupt the very work the policy protects.
+        controller.set_workspace_auto_pause('octo', True, 45)
+        body = json.loads(self.calls[0][0][self.calls[0][0].index('-p') + 1])
+        self.assertNotIn('spec', body)
+
+    def test_rejects_a_nonsense_threshold(self):
+        for bad in ('soon', '-1', '0', '99999999'):
+            with self.assertRaises(ValueError):
+                controller.set_workspace_auto_pause('octo', True, bad)
+
+    def test_rejects_an_invalid_workspace_name(self):
+        with self.assertRaises(ValueError):
+            controller.set_workspace_auto_pause('../etc', True, 60)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/charts/workspace-controller/web/src/api/workspaces.ts
+++ b/charts/workspace-controller/web/src/api/workspaces.ts
@@ -41,7 +41,26 @@ export interface Workspace {
   version: string | null;
   /** True when a newer release exists than this workspace's version. */
   updateAvailable: boolean;
+  /** Auto-pause opt-in and, when the controller paused it, when (#612). */
+  autoPause?: AutoPause;
 }
+
+export interface AutoPause {
+  /** Opted in to being paused automatically when idle. Off by default. */
+  enabled: boolean;
+  /** Minutes of no activity before the controller pauses it. */
+  idleMinutes: number;
+  /**
+   * Unix seconds when the controller paused it, or null. Set only by an
+   * automatic pause — a workspace someone stopped by hand leaves this null,
+   * which is how the console tells the two apart.
+   */
+  autoPausedAt: number | null;
+}
+
+/** True when this workspace is stopped *because* the controller paused it. */
+export const isAutoPaused = (w: Workspace) =>
+  w.state === 'stopped' && !!w.autoPause?.autoPausedAt;
 
 export interface WorkspacesResponse {
   namespace: string;
@@ -108,6 +127,21 @@ export const setWorkspaceResources = (user: string, limits: { cpu?: string; memo
   apiPost<{ ok: true; user: string; limits: { cpu?: string; memory?: string } }>(
     `/api/workspaces/${user}/resources`,
     limits,
+  );
+
+/**
+ * Turn auto-pause on/off for one workspace. Patches the live Deployment's
+ * annotations and, when GitOps is configured, persists it to the user's
+ * values.yaml so the next reconcile doesn't undo it.
+ */
+export const setWorkspaceAutoPause = (
+  user: string,
+  enabled: boolean,
+  idleMinutes?: number,
+) =>
+  apiPost<{ ok: true; user: string; autoPause: AutoPause; persisted: boolean; persistError: string | null }>(
+    `/api/workspaces/${user}/auto-pause`,
+    idleMinutes === undefined ? { enabled } : { enabled, idleMinutes },
   );
 
 export interface UpdateResult {

--- a/charts/workspace-controller/web/src/app.test.tsx
+++ b/charts/workspace-controller/web/src/app.test.tsx
@@ -140,6 +140,52 @@ describe('WorkspaceList state filter (#547)', () => {
     expect(stopped).toEqual([]);
   });
 
+  it('badges an auto-paused workspace so it reads as parked, not turned off (#612)', async () => {
+    rows = [
+      ws('bob', 'stopped', {
+        autoPause: { enabled: true, idleMinutes: 120, autoPausedAt: 1_000_000 },
+      }),
+      ws('dave', 'stopped'),
+    ];
+    workspaces.value = rows;
+    render(<App />);
+    await waitFor(() => expect(chip('Stopped (2)')).toBeInTheDocument());
+    fireEvent.click(chip('Stopped (2)'));
+
+    expect(within(rowFor('bob')).getByText('auto-paused')).toBeInTheDocument();
+    // dave was stopped by a person — it must not claim the controller did it.
+    expect(within(rowFor('dave')).queryByText('auto-paused')).toBeNull();
+  });
+
+  it('an opted-in workspace that is still running is not badged as paused', async () => {
+    rows = [
+      ws('alice', 'running', {
+        autoPause: { enabled: true, idleMinutes: 120, autoPausedAt: null },
+      }),
+    ];
+    workspaces.value = rows;
+    render(<App />);
+    await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
+
+    expect(within(rowFor('alice')).queryByText('auto-paused')).toBeNull();
+  });
+
+  it('an auto-paused workspace is still startable from the list', async () => {
+    // Criterion 5: the way back has to be obvious and has to work.
+    rows = [
+      ws('bob', 'stopped', {
+        autoPause: { enabled: true, idleMinutes: 120, autoPausedAt: 1_000_000 },
+      }),
+    ];
+    workspaces.value = rows;
+    render(<App />);
+    await waitFor(() => expect(chip('Stopped (1)')).toBeInTheDocument());
+    fireEvent.click(chip('Stopped (1)'));
+
+    fireEvent.click(within(rowFor('bob')).getByRole('button', { name: 'Start' }));
+    await waitFor(() => expect(started).toEqual(['bob']));
+  });
+
   it('counts are faceted: search and namespace chips narrow them, the state chip does not', async () => {
     render(<App />);
     await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());

--- a/charts/workspace-controller/web/src/app.tsx
+++ b/charts/workspace-controller/web/src/app.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'preact/hooks';
 import { signal } from '@preact/signals';
-import { type Workspace, type WorkspaceState } from './api/workspaces';
+import { type Workspace, type WorkspaceState, isAutoPaused } from './api/workspaces';
 import {
   workspaces,
   namespace,
@@ -269,6 +269,14 @@ function Row({ ws }: { ws: Workspace }) {
             )}
             <Pill state={ws.state} />
             <IsolationPill isolated={ws.isolated} namespace={ws.namespace} />
+            {isAutoPaused(ws) && (
+              <span
+                class="pill pill-autopaused"
+                title="Paused automatically after being idle. Data is preserved — press Start to wake it."
+              >
+                auto-paused
+              </span>
+            )}
             {ws.updateAvailable && (
               <span class="pill pill-update" title={`Update available: ${ws.version} → latest`}>
                 update

--- a/charts/workspace-controller/web/src/components/WorkspaceDetail.tsx
+++ b/charts/workspace-controller/web/src/components/WorkspaceDetail.tsx
@@ -4,6 +4,7 @@ import {
   type Workspace,
   type WorkspaceMetrics,
   getWorkspaceMetrics,
+  setWorkspaceAutoPause,
   setWorkspaceResources,
   updateWorkspace,
 } from '../api/workspaces';
@@ -156,6 +157,8 @@ export function WorkspaceDetail({ user }: { user: string }) {
             onSaved={() => setReloadKey((k) => k + 1)}
           />
 
+          {ws && <AutoPauseCard ws={ws} onSaved={() => setReloadKey((k) => k + 1)} />}
+
           {ws && <UpdatesCard ws={ws} onUpdated={() => setReloadKey((k) => k + 1)} />}
 
           <div class="detail-foot">
@@ -291,6 +294,97 @@ function ResourceEditor({
         <button class="btn ghost" disabled={saving} onClick={() => setOpen(false)}>
           Cancel
         </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Auto-pause opt-in for one workspace (#612).
+ *
+ * The wake path is manual, so this is the one control in the console whose
+ * consequence is "this workspace will stop answering requests until someone
+ * presses Start". That is stated here rather than in the docs alone.
+ */
+function AutoPauseCard({ ws, onSaved }: { ws: Workspace; onSaved: () => void }) {
+  const cfg = ws.autoPause;
+  const [enabled, setEnabled] = useState(!!cfg?.enabled);
+  const [minutes, setMinutes] = useState(String(cfg?.idleMinutes ?? 120));
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const dirty = enabled !== !!cfg?.enabled || minutes !== String(cfg?.idleMinutes ?? 120);
+
+  async function save() {
+    const mins = Number(minutes);
+    if (!Number.isFinite(mins) || mins <= 0) {
+      setErr('Idle threshold must be a positive number of minutes.');
+      return;
+    }
+    if (
+      enabled &&
+      !window.confirm(
+        `Auto-pause ${ws.user} after ${mins} minutes idle?\n\n` +
+          `Its pod is scaled to 0 and the home volume is kept. Waking is manual — ` +
+          `requests to a paused workspace fail until someone presses Start.`,
+      )
+    ) {
+      return;
+    }
+    setSaving(true);
+    setErr(null);
+    try {
+      await setWorkspaceAutoPause(ws.user, enabled, mins);
+      setDone(true);
+      onSaved();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div class="res-editor">
+      <div class="res-editor-fields">
+        <label class="field">
+          <span class="field-label">Auto-pause when idle</span>
+          <input
+            type="checkbox"
+            checked={enabled}
+            aria-label="Auto-pause when idle"
+            onChange={(e) => {
+              setEnabled((e.target as HTMLInputElement).checked);
+              setDone(false);
+            }}
+          />
+        </label>
+        <label class="field">
+          <span class="field-label">Idle threshold (minutes)</span>
+          <input
+            class="input"
+            value={minutes}
+            disabled={!enabled}
+            placeholder="120"
+            onInput={(e) => {
+              setMinutes((e.target as HTMLInputElement).value);
+              setDone(false);
+            }}
+          />
+        </label>
+      </div>
+      {err && <div class="banner err">{err}</div>}
+      <p class="sub">
+        A paused workspace keeps its home volume — only compute stops. It is never paused while a
+        build is running, a chat turn is in flight, or a terminal is attached.{' '}
+        <strong>Waking is manual:</strong> requests to a paused workspace fail until it is started.
+      </p>
+      <div class="res-editor-actions">
+        <button class="btn start" disabled={saving || !dirty} onClick={save}>
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        {done && !dirty && <span class="res-edit-note">Auto-pause updated.</span>}
       </div>
     </div>
   );

--- a/charts/workspace-controller/web/src/styles.css
+++ b/charts/workspace-controller/web/src/styles.css
@@ -393,6 +393,15 @@ body {
   margin-left: 0.25rem;
 }
 
+/* Auto-paused (#612): stopped BY the controller, not by a person. Amber rather
+   than the grey of `stopped` — it is a state someone may want to undo, and it
+   has to be distinguishable from a workspace that was deliberately turned off. */
+.pill-autopaused {
+  background: rgba(210, 153, 34, 0.16);
+  color: #e3b341;
+  margin-left: 0.25rem;
+}
+
 /* Namespace-isolation badges (#103): teal = migrated to its own namespace,
    amber outline = still in the shared control-plane namespace. */
 .pill-isolated {

--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -16499,6 +16499,10 @@ class BrowserHandler(http.server.SimpleHTTPRequestHandler):
         m = re.match(r'^/api/terminal-proxy(/.*)?$', claude_path)
         if not m:
             return False
+        # Someone is using a terminal — keep auto-pause off this workspace
+        # (#612). tmux clients are the primary signal; this covers the window
+        # between a proxied request and ttyd actually attaching.
+        ActivityBeacon.note_terminal_activity()
         upstream_path = m.group(1) or '/'
         qs = self.path.split('?', 1)
         if len(qs) == 2:
@@ -18358,6 +18362,250 @@ class EventBroker:
         return event
 
 
+class ActivityBeacon:
+    """Publish this workspace's activity onto its own pod's annotations, so the
+    controller can auto-pause an idle workspace without destroying work (#612).
+
+    The controller reads Prometheus (cadvisor / kube-state-metrics) and never
+    talks to a workspace, so CPU usage is all it can see — and CPU cannot tell
+    an idle workspace from an agent parked at a permission prompt, which burns
+    almost no CPU and must never be paused. This process already knows the
+    difference, so it writes the answer where the controller is already
+    looking: the pod object it lists anyway. No new API, no new credential.
+
+    Three annotations, all on our own pod:
+
+        kube-coder.io/busy           "true"/"false" — pausing now would lose work
+        kube-coder.io/last-activity  unix seconds of the most recent activity
+        kube-coder.io/beacon-at      unix seconds of this write
+
+    `beacon-at` is the freshness proof, and it is the reason the whole scheme is
+    safe. The controller treats a missing, unparseable or stale beacon as BUSY,
+    so a workspace on an older image (no beacon at all), or one whose thread has
+    died, is simply never auto-paused. Failing closed is the only defensible
+    direction here: not pausing costs a few cents of idle compute, pausing a
+    working agent costs the user their run.
+    """
+
+    BUSY_ANNOTATION = 'kube-coder.io/busy'
+    LAST_ACTIVITY_ANNOTATION = 'kube-coder.io/last-activity'
+    BEACON_AT_ANNOTATION = 'kube-coder.io/beacon-at'
+
+    #: A terminal counts as attached for this long after its last proxied byte.
+    #: ttyd traffic is bursty — someone reading output sends nothing at all — so
+    #: the window has to outlast a pause in typing, not just the last keystroke.
+    TERMINAL_WINDOW_SECONDS = 600.0
+
+    _started = False
+    _thread = None
+    _stop_event = threading.Event()
+    _start_lock = threading.Lock()
+    _lock = threading.Lock()
+    _terminal_at = 0.0
+    _last_run_at = 0.0
+    _last_error = None
+    _last_state = None
+    #: Boot floors last-activity. A workspace that has never run a Build has no
+    #: activity timestamps at all, and "no timestamp" must not read as "idle
+    #: since the epoch" — that would pause a freshly started workspace the
+    #: moment someone opted it in, which is precisely when they want to use it.
+    _started_at = time.time()
+
+    @classmethod
+    def note_terminal_activity(cls):
+        """Stamp 'a terminal is in use'. Called from the ttyd proxy on every
+        request and websocket upgrade, so it must stay this cheap."""
+        with cls._lock:
+            cls._terminal_at = time.time()
+
+    @classmethod
+    def terminal_at(cls):
+        with cls._lock:
+            return cls._terminal_at
+
+    @staticmethod
+    def _ts(value):
+        """Any stored timestamp → float unix seconds, or 0.0. Task and thread
+        metadata are written with time.time(), but a hand-edited or truncated
+        file must degrade to "no timestamp" rather than raise mid-sweep."""
+        try:
+            ts = float(value)
+        except (TypeError, ValueError):
+            return 0.0
+        return ts if ts > 0 else 0.0
+
+    # ── activity sources ────────────────────────────────────────────────────
+
+    @classmethod
+    def _build_activity(cls):
+        """(a Build is live, newest Build timestamp) across every task on this
+        pod. Reuses ClaudeTaskManager._LIVE_STATUSES so 'busy' means exactly
+        what the rest of the server means by it — including waiting-for-input,
+        which is the case CPU alone gets wrong."""
+        live, last = False, 0.0
+        try:
+            metas = ProjectsManager._scan_task_metas()
+        except Exception as e:
+            # Unreadable tasks dir: report busy. We cannot prove it is idle,
+            # and the fail-closed direction is not pausing.
+            print(f'[beacon] task scan failed: {e}', file=sys.stderr)
+            return True, time.time()
+        for meta in metas:
+            if not isinstance(meta, dict):
+                continue
+            if meta.get('status') in ClaudeTaskManager._LIVE_STATUSES:
+                live = True
+            for key in ('last_activity_at', 'finished_at', 'created_at'):
+                last = max(last, cls._ts(meta.get(key)))
+        return live, last
+
+    @classmethod
+    def _hypervisor_activity(cls):
+        """(a chat turn is in flight, newest chat timestamp). A thread meta
+        status of 'running' is a live turn — stale ones are repaired at boot by
+        reconcile_stale_running_threads(), so after startup 'running' is real."""
+        if not _HYPERVISOR_AVAILABLE or HypervisorSession is None:
+            return False, 0.0
+        live, last = False, 0.0
+        try:
+            tids = os.listdir(HYPERVISOR_DIR)
+        except OSError:
+            return live, last
+        for tid in tids:
+            try:
+                session = HypervisorSession.get(tid)
+                meta = session.read_meta() if session else None
+            except Exception:
+                continue            # one malformed thread must not blind the sweep
+            if not meta:
+                continue
+            if meta.get('status') == 'running':
+                live = True
+            last = max(last, cls._ts(meta.get('updated_at')))
+        return live, last
+
+    @classmethod
+    def _terminal_attached(cls):
+        """True while a browser actually has a terminal open.
+
+        The web terminal at /terminal is routed by the ingress **straight to
+        ttyd:7681** and never passes through this process, so the proxy stamp
+        in note_terminal_activity() cannot see it. What both the web route and
+        the mobile /api/terminal-proxy route do have in common is that ttyd
+        attaches a tmux client — and Build sessions are created detached
+        (`tmux new-session -d`), so they can never look like an attached
+        terminal. A missing tmux, or no server running at all, reads as not
+        attached; the Build and Hypervisor checks still cover real work."""
+        try:
+            r = subprocess.run(['tmux', 'list-clients', '-F', '#{client_name}'],
+                               capture_output=True, text=True, timeout=10)
+        except (OSError, subprocess.SubprocessError):
+            return False
+        if r.returncode != 0:
+            return False
+        return any(line.strip() for line in r.stdout.splitlines())
+
+    @classmethod
+    def compute(cls, now=None):
+        """Current activity as {'busy', 'last_activity', 'reasons'}.
+
+        Pure with respect to Kubernetes — it only reads local state — so the
+        whole busy decision is unit-testable without a cluster."""
+        now = float(now if now is not None else time.time())
+        reasons = []
+
+        build_live, build_ts = cls._build_activity()
+        if build_live:
+            reasons.append('build')
+
+        hv_live, hv_ts = cls._hypervisor_activity()
+        if hv_live:
+            reasons.append('hypervisor')
+
+        term_ts = cls.terminal_at()
+        if cls._terminal_attached():
+            term_ts = now
+        if term_ts and (now - term_ts) <= cls.TERMINAL_WINDOW_SECONDS:
+            reasons.append('terminal')
+
+        return {
+            'busy': bool(reasons),
+            'last_activity': max(build_ts, hv_ts, term_ts, cls._started_at),
+            'reasons': reasons,
+        }
+
+    # ── publication ─────────────────────────────────────────────────────────
+
+    @staticmethod
+    def pod_name():
+        """Our own pod's name. POD_NAME comes from the downward API; the
+        hostname fallback is the same value on a Deployment pod (which sets no
+        spec.hostname), and keeps this working if the env var is ever dropped."""
+        return os.environ.get('POD_NAME') or socket.gethostname()
+
+    @classmethod
+    def publish(cls, state, now=None):
+        """Write `state` onto our pod. Raises on failure so the caller logs it
+        and the annotation goes stale — which the controller reads as busy."""
+        now = float(now if now is not None else time.time())
+        annotations = {
+            cls.BUSY_ANNOTATION: 'true' if state['busy'] else 'false',
+            cls.LAST_ACTIVITY_ANNOTATION: f"{state['last_activity']:.0f}",
+            cls.BEACON_AT_ANNOTATION: f'{now:.0f}',
+        }
+        patch = json.dumps({'metadata': {'annotations': annotations}})
+        result = subprocess.run(
+            ['kubectl', 'patch', 'pod', cls.pod_name(),
+             '-n', CronManager.detect_namespace(), '--type=merge', '-p', patch],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            raise RuntimeError((result.stderr or result.stdout
+                                or 'kubectl patch failed').strip())
+        return annotations
+
+    @classmethod
+    def start(cls, *, interval_seconds=30):
+        with cls._start_lock:
+            if cls._started:
+                return
+            cls._started = True
+
+        def _loop():
+            while not cls._stop_event.is_set():
+                try:
+                    state = cls.compute()
+                    cls.publish(state)
+                    cls._last_state = state
+                    cls._last_error = None
+                    cls._last_run_at = time.time()
+                except Exception as e:
+                    # Never fatal. A workspace with no RBAC to patch its pod, or
+                    # no kubectl at all (local dev), just stops publishing — and
+                    # a workspace the controller cannot read is never paused.
+                    # Log only when the error CHANGES: a permanently missing RBAC
+                    # grant would otherwise print every interval forever and bury
+                    # everything else in the pod log.
+                    message = str(e)
+                    if message != cls._last_error:
+                        print(f'[beacon] publish failed: {message}', file=sys.stderr)
+                    cls._last_error = message
+                cls._stop_event.wait(interval_seconds)
+
+        t = threading.Thread(target=_loop, name='activity-beacon', daemon=True)
+        cls._thread = t
+        t.start()
+
+    @classmethod
+    def status(cls):
+        return {
+            'running': cls._started and (cls._thread is not None and cls._thread.is_alive()),
+            'last_run_at': cls._last_run_at or None,
+            'last_error': cls._last_error,
+            'state': cls._last_state,
+        }
+
+
 class TaskReconciler:
     """Single-process background poller that reconciles non-terminal task
     status on an interval, so completion hooks fire and finished_at /
@@ -18611,6 +18859,21 @@ if __name__ == "__main__":
         print(f'[tasks] background reconciler started ({_reconcile_interval}s)')
     except Exception as e:
         print(f'[tasks] reconciler start failed: {e}', file=sys.stderr)
+
+    # Activity beacon: stamps busy / last-activity onto this pod's annotations
+    # so the controller can auto-pause an idle workspace without killing a live
+    # Build, chat turn or terminal (#612). Opt-in is decided controller-side;
+    # the beacon publishes unconditionally so that enabling auto-pause later
+    # does not have to wait for a pod restart to get a fresh signal.
+    try:
+        _beacon_interval = int(os.environ.get('KC_BEACON_INTERVAL', '30'))
+    except (TypeError, ValueError):
+        _beacon_interval = 30
+    try:
+        ActivityBeacon.start(interval_seconds=_beacon_interval)
+        print(f'[beacon] activity beacon started ({_beacon_interval}s)')
+    except Exception as e:
+        print(f'[beacon] start failed: {e}', file=sys.stderr)
 
     # Board run orphan sweep (#588 Phase 4). A run whose process died is
     # DEFINITIVELY stale at boot — no worker of a previous process can still be

--- a/charts/workspace/templates/deployment.yaml
+++ b/charts/workspace/templates/deployment.yaml
@@ -3,8 +3,17 @@ kind: Deployment
 metadata:
   name: ws-{{ .Values.user.name }}
   namespace: {{ .Values.namespace }}
-  labels: 
+  labels:
     app: ws-{{ .Values.user.name }}
+  annotations:
+    # Auto-pause opt-in (#612), read by the controller off the Deployment it
+    # already lists — no extra API call to decide whether a workspace
+    # participates. On the Deployment rather than the pod template on purpose:
+    # changing the policy must not roll the pod (and so must not interrupt the
+    # very work the policy exists to protect). The beacon's busy/last-activity
+    # annotations are the pod's; these two are the operator's.
+    kube-coder.io/auto-pause: {{ .Values.autoPause.enabled | quote }}
+    kube-coder.io/auto-pause-idle-minutes: {{ .Values.autoPause.idleMinutes | quote }}
 spec:
   replicas: 1
   strategy:
@@ -66,6 +75,13 @@ spec:
         # — the entrypoint creates the file after first mint.
         - name: BASH_ENV
           value: /home/dev/.profile.d-github-env
+        # Which pod the activity beacon annotates (#612). The hostname is the
+        # same value on a Deployment pod, but naming it explicitly means the
+        # beacon never depends on that equivalence holding.
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         {{- if eq .Values.build.mode "buildkit" }}
         - name: DOCKER_HOST
           value: "tcp://localhost:2376"

--- a/charts/workspace/templates/serviceaccount.yaml
+++ b/charts/workspace/templates/serviceaccount.yaml
@@ -37,6 +37,16 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log"]
   verbs: ["get", "list", "watch"]
+# `patch` on pods is what lets the activity beacon stamp busy / last-activity
+# onto THIS pod's annotations, so the controller can auto-pause an idle
+# workspace without killing a live Build, chat turn or terminal (#612). The
+# controller reads Prometheus and never talks to a workspace, so the workspace
+# has to publish where the controller is already looking. Scoped to this
+# namespace like every rule above: the sole tenant here is this user, so the
+# grant reaches nothing but their own pod, and annotations carry no privilege.
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/workspace/tests/activity_beacon_test.py
+++ b/charts/workspace/tests/activity_beacon_test.py
@@ -1,0 +1,254 @@
+"""Unit tests for server.ActivityBeacon — the activity signal behind auto-pause
+(#612).
+
+The controller scales a workspace to 0 when this says "not busy". A wrong
+"false" here destroys a running agent's work, so the cases that matter most are
+the ones where something is broken or unreadable: those must report BUSY, not
+idle.
+
+Run with:    python3 -m unittest tests.activity_beacon_test
+(from charts/workspace/)
+"""
+
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+# Import server.py from the parent directory.
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+import server  # noqa: E402
+
+NOW = 1_000_000.0
+
+
+def _task(status, last_activity=None):
+    return {'status': status, 'last_activity_at': last_activity, 'created_at': 1.0}
+
+
+class BeaconBusyTest(unittest.TestCase):
+    """What counts as busy."""
+
+    def setUp(self):
+        # Isolate from the real workspace: no hypervisor threads, no tmux, no
+        # terminal history. Each test opts its own signal back in.
+        self._hv = server._HYPERVISOR_AVAILABLE
+        server._HYPERVISOR_AVAILABLE = False
+        server.ActivityBeacon._terminal_at = 0.0
+        self._attached = mock.patch.object(
+            server.ActivityBeacon, '_terminal_attached', classmethod(lambda cls: False))
+        self._attached.start()
+        # Keep the boot floor far in the past so it doesn't mask the timestamps
+        # under test; its own behaviour is asserted separately below.
+        self._started_at = server.ActivityBeacon._started_at
+        server.ActivityBeacon._started_at = 0.0
+
+    def tearDown(self):
+        self._attached.stop()
+        server._HYPERVISOR_AVAILABLE = self._hv
+        server.ActivityBeacon._terminal_at = 0.0
+        server.ActivityBeacon._started_at = self._started_at
+
+    def _metas(self, metas):
+        return mock.patch.object(server.ProjectsManager, '_scan_task_metas',
+                                 staticmethod(lambda: metas))
+
+    def test_idle_when_every_task_is_finished(self):
+        with self._metas([_task('completed', 500.0), _task('error', 400.0)]):
+            state = server.ActivityBeacon.compute(now=NOW)
+        self.assertFalse(state['busy'])
+        self.assertEqual(state['reasons'], [])
+        self.assertEqual(state['last_activity'], 500.0)
+
+    def test_a_running_build_is_busy(self):
+        with self._metas([_task('running', 900.0)]):
+            state = server.ActivityBeacon.compute(now=NOW)
+        self.assertTrue(state['busy'])
+        self.assertIn('build', state['reasons'])
+
+    def test_waiting_for_input_is_busy(self):
+        """The case CPU alone gets wrong.
+
+        An agent parked at a permission prompt burns no CPU and looks perfectly
+        idle from outside the pod — but its run is mid-flight and scaling to 0
+        would throw it away. This is the reason the beacon exists at all.
+        """
+        with self._metas([_task('waiting-for-input', 100.0)]):
+            state = server.ActivityBeacon.compute(now=NOW)
+        self.assertTrue(state['busy'])
+        self.assertIn('build', state['reasons'])
+
+    def test_busy_matches_the_servers_own_definition(self):
+        # Not a second opinion about what "live" means — the same tuple.
+        for status in server.ClaudeTaskManager._LIVE_STATUSES:
+            with self._metas([_task(status, 1.0)]):
+                self.assertTrue(server.ActivityBeacon.compute(now=NOW)['busy'],
+                                f'{status} must count as busy')
+
+    def test_an_unreadable_tasks_dir_reports_busy(self):
+        """Fail closed: we could not prove it is idle, so we do not claim it."""
+        def boom():
+            raise OSError('tasks dir gone')
+        with mock.patch.object(server.ProjectsManager, '_scan_task_metas',
+                               staticmethod(boom)):
+            state = server.ActivityBeacon.compute(now=NOW)
+        self.assertTrue(state['busy'])
+
+    def test_malformed_task_metadata_does_not_raise(self):
+        with self._metas([None, 'nonsense', {}, _task('completed', 'later')]):
+            state = server.ActivityBeacon.compute(now=NOW)
+        self.assertFalse(state['busy'])
+
+    def test_an_attached_terminal_is_busy(self):
+        with mock.patch.object(server.ActivityBeacon, '_terminal_attached',
+                               classmethod(lambda cls: True)):
+            with self._metas([]):
+                state = server.ActivityBeacon.compute(now=NOW)
+        self.assertTrue(state['busy'])
+        self.assertIn('terminal', state['reasons'])
+        self.assertEqual(state['last_activity'], NOW)
+
+    def test_recent_terminal_traffic_is_busy_then_ages_out(self):
+        server.ActivityBeacon._terminal_at = NOW - 10
+        with self._metas([]):
+            self.assertTrue(server.ActivityBeacon.compute(now=NOW)['busy'])
+        server.ActivityBeacon._terminal_at = (
+            NOW - server.ActivityBeacon.TERMINAL_WINDOW_SECONDS - 1)
+        with self._metas([]):
+            self.assertFalse(server.ActivityBeacon.compute(now=NOW)['busy'])
+
+    def test_a_live_chat_turn_is_busy(self):
+        server._HYPERVISOR_AVAILABLE = True
+        session = mock.Mock()
+        session.read_meta.return_value = {'status': 'running', 'updated_at': 900.0}
+        with mock.patch.object(server, 'HypervisorSession') as hv, \
+                mock.patch.object(server.os, 'listdir', lambda p: ['t1']):
+            hv.get.return_value = session
+            with self._metas([]):
+                state = server.ActivityBeacon.compute(now=NOW)
+        self.assertTrue(state['busy'])
+        self.assertIn('hypervisor', state['reasons'])
+
+    def test_an_idle_chat_is_not_busy(self):
+        server._HYPERVISOR_AVAILABLE = True
+        session = mock.Mock()
+        session.read_meta.return_value = {'status': 'idle', 'updated_at': 900.0}
+        with mock.patch.object(server, 'HypervisorSession') as hv, \
+                mock.patch.object(server.os, 'listdir', lambda p: ['t1']):
+            hv.get.return_value = session
+            with self._metas([]):
+                state = server.ActivityBeacon.compute(now=NOW)
+        self.assertFalse(state['busy'])
+        self.assertEqual(state['last_activity'], 900.0)
+
+    def test_last_activity_never_predates_boot(self):
+        """A workspace with no history at all is 'active since boot'.
+
+        Otherwise a brand-new workspace reports last-activity 0, the controller
+        computes an idle age of decades, and opting in would pause it instantly
+        — at the exact moment someone provisioned it to use it.
+        """
+        server.ActivityBeacon._started_at = NOW - 5
+        with self._metas([]):
+            state = server.ActivityBeacon.compute(now=NOW)
+        self.assertEqual(state['last_activity'], NOW - 5)
+
+
+class BeaconTerminalDetectionTest(unittest.TestCase):
+    """tmux clients are how an attached web terminal is seen at all."""
+
+    def test_attached_when_tmux_lists_a_client(self):
+        with mock.patch.object(server.subprocess, 'run',
+                               return_value=mock.Mock(returncode=0, stdout='/dev/pts/1\n')):
+            self.assertTrue(server.ActivityBeacon._terminal_attached())
+
+    def test_not_attached_when_no_clients(self):
+        with mock.patch.object(server.subprocess, 'run',
+                               return_value=mock.Mock(returncode=0, stdout='\n')):
+            self.assertFalse(server.ActivityBeacon._terminal_attached())
+
+    def test_not_attached_when_tmux_server_is_not_running(self):
+        with mock.patch.object(server.subprocess, 'run',
+                               return_value=mock.Mock(returncode=1, stdout='')):
+            self.assertFalse(server.ActivityBeacon._terminal_attached())
+
+    def test_missing_tmux_is_not_fatal(self):
+        with mock.patch.object(server.subprocess, 'run', side_effect=OSError('no tmux')):
+            self.assertFalse(server.ActivityBeacon._terminal_attached())
+
+
+class BeaconPublishTest(unittest.TestCase):
+    """What actually lands on the pod."""
+
+    def setUp(self):
+        os.environ['POD_NAME'] = 'ws-octo-abc-123'
+
+    def tearDown(self):
+        os.environ.pop('POD_NAME', None)
+
+    def _patch_args(self, run):
+        return run.call_args.args[0]
+
+    def test_publishes_all_three_annotations(self):
+        state = {'busy': False, 'last_activity': 950.0, 'reasons': []}
+        with mock.patch.object(server.subprocess, 'run',
+                               return_value=mock.Mock(returncode=0, stdout='', stderr='')) as run, \
+                mock.patch.object(server.CronManager, 'detect_namespace',
+                                  staticmethod(lambda: 'ws-octo')):
+            server.ActivityBeacon.publish(state, now=NOW)
+        args = self._patch_args(run)
+        self.assertEqual(args[:4], ['kubectl', 'patch', 'pod', 'ws-octo-abc-123'])
+        self.assertIn('ws-octo', args)
+        body = json.loads(args[args.index('-p') + 1])
+        ann = body['metadata']['annotations']
+        self.assertEqual(ann[server.ActivityBeacon.BUSY_ANNOTATION], 'false')
+        self.assertEqual(ann[server.ActivityBeacon.LAST_ACTIVITY_ANNOTATION], '950')
+        self.assertEqual(ann[server.ActivityBeacon.BEACON_AT_ANNOTATION], '1000000')
+
+    def test_busy_is_published_as_true(self):
+        state = {'busy': True, 'last_activity': NOW, 'reasons': ['build']}
+        with mock.patch.object(server.subprocess, 'run',
+                               return_value=mock.Mock(returncode=0, stdout='', stderr='')) as run, \
+                mock.patch.object(server.CronManager, 'detect_namespace',
+                                  staticmethod(lambda: 'ws-octo')):
+            server.ActivityBeacon.publish(state, now=NOW)
+        args = self._patch_args(run)
+        body = json.loads(args[args.index('-p') + 1])
+        self.assertEqual(body['metadata']['annotations'][
+            server.ActivityBeacon.BUSY_ANNOTATION], 'true')
+
+    def test_only_annotations_are_patched(self):
+        """The beacon must never be able to change the pod's spec."""
+        state = {'busy': False, 'last_activity': 1.0, 'reasons': []}
+        with mock.patch.object(server.subprocess, 'run',
+                               return_value=mock.Mock(returncode=0, stdout='', stderr='')) as run, \
+                mock.patch.object(server.CronManager, 'detect_namespace',
+                                  staticmethod(lambda: 'ws-octo')):
+            server.ActivityBeacon.publish(state, now=NOW)
+        args = self._patch_args(run)
+        body = json.loads(args[args.index('-p') + 1])
+        self.assertEqual(list(body.keys()), ['metadata'])
+        self.assertEqual(list(body['metadata'].keys()), ['annotations'])
+
+    def test_a_failed_patch_raises_so_the_annotation_goes_stale(self):
+        # Going stale is the safe outcome: the controller reads a stale beacon
+        # as busy and leaves the workspace running.
+        state = {'busy': False, 'last_activity': 1.0, 'reasons': []}
+        with mock.patch.object(server.subprocess, 'run',
+                               return_value=mock.Mock(returncode=1, stdout='',
+                                                      stderr='forbidden')), \
+                mock.patch.object(server.CronManager, 'detect_namespace',
+                                  staticmethod(lambda: 'ws-octo')):
+            with self.assertRaises(RuntimeError):
+                server.ActivityBeacon.publish(state, now=NOW)
+
+    def test_pod_name_falls_back_to_the_hostname(self):
+        os.environ.pop('POD_NAME', None)
+        with mock.patch.object(server.socket, 'gethostname', lambda: 'ws-octo-xyz'):
+            self.assertEqual(server.ActivityBeacon.pod_name(), 'ws-octo-xyz')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/charts/workspace/tests/auto_pause_test.yaml
+++ b/charts/workspace/tests/auto_pause_test.yaml
@@ -1,0 +1,101 @@
+suite: auto-pause opt-in + PVC preservation (#612)
+templates:
+  - templates/deployment.yaml
+  - templates/serviceaccount.yaml
+  - templates/pvc.yaml
+  - templates/claude-configmap.yaml
+  - templates/terminal-entry-configmap.yaml
+  - templates/workspace-entrypoint-configmap.yaml
+  - templates/assistant-secret.yaml
+  - templates/ssh-server-configmap.yaml
+values:
+  - test-values.yaml
+tests:
+  - it: is off by default — upgrading the chart must never start pausing a tenant
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["kube-coder.io/auto-pause"]
+          value: "false"
+
+  - it: carries the default idle threshold, distinct from the 6h advisory window
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["kube-coder.io/auto-pause-idle-minutes"]
+          value: "120"
+
+  - it: renders the opt-in and a custom threshold
+    template: templates/deployment.yaml
+    set:
+      autoPause.enabled: true
+      autoPause.idleMinutes: 45
+    asserts:
+      - equal:
+          path: metadata.annotations["kube-coder.io/auto-pause"]
+          value: "true"
+      - equal:
+          path: metadata.annotations["kube-coder.io/auto-pause-idle-minutes"]
+          value: "45"
+
+  - it: keeps the opt-in off the pod template, so toggling never rolls the pod
+    # A policy change must not restart the workspace — that would interrupt the
+    # very work auto-pause exists to protect.
+    template: templates/deployment.yaml
+    set:
+      autoPause.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations["kube-coder.io/auto-pause"]
+
+  - it: tells the beacon which pod to annotate via the downward API
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+
+  - it: lets the workspace annotate its own pod, and nothing more
+    template: templates/serviceaccount.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Role
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["pods"]
+            verbs: ["patch"]
+
+  - it: never grants the workspace delete on pods
+    template: templates/serviceaccount.yaml
+    documentIndex: 1
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["pods"]
+            verbs: ["delete"]
+
+  # --- Criterion 4: pausing preserves the PVC, asserted rather than assumed ---
+  - it: keeps the home volume even through a helm uninstall
+    template: templates/pvc.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: does not tie the home volume's life to the Deployment
+    # Pause scales the Deployment to 0. If the PVC were owned by the Deployment
+    # (or by anything garbage-collected with it), that would delete the user's
+    # home directory instead of parking it.
+    template: templates/pvc.yaml
+    asserts:
+      - notExists:
+          path: metadata.ownerReferences

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -198,6 +198,26 @@ resources:
     cpu: "2"
     memory: 4Gi
 
+# Auto-pause an idle workspace: scale the pod to 0 and keep the PVC (#612).
+# The PVC — the expensive part to retain — is untouched, so pausing only stops
+# paying for compute. Off by default: pausing is safe but not free, because the
+# wake path is manual (see below), and nothing should start switching off a
+# tenant's workspace because they upgraded the chart.
+#
+# The controller runs the policy. It pauses only when the workspace's own
+# activity beacon says it is not busy — no live Build, no Hypervisor turn, no
+# attached terminal — AND the beacon is fresh. A stale or missing beacon counts
+# as busy, so a workspace whose beacon has died is never paused.
+#
+# WAKE IS MANUAL: a request to a paused workspace FAILS until someone presses
+# Start in the console. There is no wake-on-request; see docs/auto-pause.md.
+autoPause:
+  enabled: false
+  # Minutes of no activity before the controller pauses the workspace.
+  # Deliberately separate from the console's 6h "idle" advisory window — that
+  # one decides when to *tell* an operator, this one decides when to *act*.
+  idleMinutes: 120
+
 # Per-namespace ResourceQuota + LimitRange (see templates/resourcequota.yaml).
 # Now that each workspace owns its namespace, the quota bounds a single tenant
 # instead of a shared pool.

--- a/docs/auto-pause.md
+++ b/docs/auto-pause.md
@@ -1,0 +1,124 @@
+# Auto-pause idle workspaces
+
+A per-user dev environment is idle most of the day and all night, but its pod
+keeps its CPU and memory reserved the whole time. Auto-pause scales an idle
+workspace's pod to **0 replicas** and leaves everything else alone — the PVC,
+the ingress, the secrets, the TLS certificate.
+
+**It is off by default and opt-in per workspace.** Issue #612.
+
+## Read this first: waking is manual
+
+> **A request to a paused workspace fails.** It does not queue, it does not
+> wake the workspace, and it does not retry. The workspace stays down until
+> someone presses **Start** in the console (or runs `make start USER=<name>`).
+
+There is no wake-on-request. Real wake-on-request needs a component that sits
+in the request path while the pod is down, holds the connection open, scales the
+Deployment back to 1, waits for readiness and then proxies — a
+Knative-activator-shaped thing, always on, in front of every workspace. That is
+a much larger decision than the pause itself, and the saving does not depend on
+it: the money is in the pod being down, not in how it comes back up.
+
+Turn auto-pause on for workspaces where "it's off until I turn it on" is an
+acceptable trade for the compute bill. Leave it off for anything that has to
+answer an unattended request — a webhook target, a cron trigger, a demo URL
+someone might click.
+
+## What is preserved
+
+Everything except the running process:
+
+| | |
+|---|---|
+| **Home volume** (`ws-<user>-home`) | Preserved. It is a separate PVC carrying `helm.sh/resource-policy: keep`, so neither a pause nor a `helm uninstall` deletes it. |
+| Ingress, TLS certificate, DNS | Untouched — the URL keeps resolving, it just has nothing behind it. |
+| Secrets, OAuth cookie secret | Untouched. |
+| Running processes, tmux sessions, `/tmp` | **Lost.** The pod is gone; only what is on the PVC survives. |
+
+Pausing never deletes anything. Backup and restore of the home volume is a
+separate concern (#579).
+
+## When it will not pause
+
+A pause is only allowed when the workspace itself reports that it is not busy.
+The workspace publishes its own activity onto its pod's annotations every 30s,
+and the controller reads that back. **It will not pause while:**
+
+- a Build is `running` **or** `waiting-for-input` — an agent parked at a
+  permission prompt burns no CPU and looks idle from outside, but its run is
+  mid-flight
+- a Hypervisor chat turn is in flight
+- a terminal is attached (any tmux client — the web terminal, the mobile app, or SSH)
+- measured CPU is above the idle threshold — this catches a dev server or a
+  compile left running, which none of the signals above know about
+- the activity signal is **missing or stale** — a workspace on an older image,
+  or one whose beacon has stopped, is never paused
+- Prometheus cannot be reached to confirm idleness
+
+Every one of those fails in the same direction: **when in doubt, keep running.**
+Leaving a pod up costs a few cents; scaling one down mid-run costs the user
+their work.
+
+## Turning it on
+
+**Console** — open the workspace, tick *Auto-pause when idle*, set the
+threshold, Save. This patches the live Deployment and, when GitOps is
+configured, also commits the setting to the user's `values.yaml` so the next
+reconcile does not undo it.
+
+**Chart** — in the user's `values.yaml`:
+
+```yaml
+autoPause:
+  enabled: true
+  idleMinutes: 120
+```
+
+The annotations live on the Deployment's own metadata, not the pod template, so
+changing the policy **does not restart the workspace**.
+
+## Waking a paused workspace
+
+- Console: press **Start** on the row (an auto-paused workspace is badged
+  `auto-paused`, which is how you tell it from one somebody stopped by hand)
+- CLI: `make start USER=<name>`
+
+Starting clears the auto-paused marker. The workspace comes back with its home
+directory exactly as it was.
+
+## Tuning
+
+| Setting | Where | Default | What it does |
+|---|---|---|---|
+| `autoPause.enabled` | workspace values | `false` | Opt this workspace in. |
+| `autoPause.idleMinutes` | workspace values | `120` | Idle minutes before pausing. Separate from the console's 6h *advisory* window, which only decides when to **tell** an operator. |
+| `AUTOPAUSE_ENABLED` | controller env | `true` | Fleet kill switch. |
+| `AUTOPAUSE_INTERVAL_SECONDS` | controller env | `300` | How often the sweep runs. |
+| `AUTOPAUSE_BEACON_MAX_AGE_SECONDS` | controller env | `300` | How old an activity signal may be and still be believed. Must comfortably exceed `KC_BEACON_INTERVAL`. |
+| `KC_BEACON_INTERVAL` | workspace env | `30` | How often the workspace publishes its activity. |
+
+## How it works
+
+```
+workspace pod                          workspace-controller
+─────────────                          ────────────────────
+ActivityBeacon (every 30s)             AutoPauser (every 5m)
+  live Builds? chat turn?                for each opted-in workspace:
+  tmux client attached?                    read the pod's annotations
+        │                                  fresh? not busy? idle > threshold?
+        ▼                                  CPU confirms idle?
+  kubectl patch pod                              │
+    kube-coder.io/busy          ───────────►     ▼
+    kube-coder.io/last-activity          kubectl scale --replicas=0
+    kube-coder.io/beacon-at              + mark kube-coder.io/auto-paused-at
+```
+
+The workspace annotates **its own pod** — it has `patch` on pods in its own
+namespace and nothing more. The controller never talks to a workspace; it reads
+Kubernetes objects it already lists and Prometheus, which is why the workspace
+has to publish the answer rather than be asked for it.
+
+`beacon-at` is the freshness proof, and it is what makes the whole thing safe to
+run: a beacon that has stopped updating reads as busy, so the failure mode of
+every bug in the publishing path is "this workspace never pauses".


### PR DESCRIPTION
Closes #612.

## The problem

An idle workspace keeps its CPU and memory reserved all day and all night. The controller already *noticed* this and already priced it — the insights pass emits `"<user>'s workspace has been idle for 6h. Stopping it would free compute (~$N/mo)"` — but there was no way to act on it short of a human clicking Stop. Everything mechanical already existed: idle detection, and `scale_workspace()` scaling to 0 while preserving the PVC. This joins them up.

Pausing was the easy half. **The hard half is never pausing a workspace that is actually working**, because scaling to 0 mid-run destroys that work, which is strictly worse than an idle pod.

## Why the workspace reports its own activity

The controller can't see busyness on its own. It reads Prometheus (cadvisor / kube-state-metrics) and never talks to a workspace — and CPU alone cannot tell an idle workspace apart from **an agent parked at a permission prompt**, which burns no CPU and must never be paused.

So the workspace, which already knows the difference, publishes the answer onto its own pod's annotations, and the controller reads it back off an object it already lists. No new API, no new credential, no extra call on the console's poll path.

## Backend flow

```
workspace pod                          workspace-controller
─────────────                          ────────────────────
ActivityBeacon (every 30s)             AutoPauser (every 5m)
  live Builds? chat turn?                for each opted-in workspace:
  tmux client attached?                    read the pod's annotations
        │                                  fresh? not busy? idle > threshold?
        ▼                                  CPU confirms idle?
  kubectl patch pod                              │
    kube-coder.io/busy          ───────────►     ▼
    kube-coder.io/last-activity          kubectl scale --replicas=0
    kube-coder.io/beacon-at              + mark kube-coder.io/auto-paused-at
```

**Every check fails closed.** A missing, stale or unparseable beacon, an unreachable Prometheus, or an unreadable tasks dir all mean *do not pause*. Not pausing costs a few cents; pausing a working agent costs the user their run. `beacon-at` is the freshness proof, so a workspace on an older image — or one whose beacon has died — is simply never paused.

Three details worth calling out:

- **Busy reuses `ClaudeTaskManager._LIVE_STATUSES`** rather than inventing a second opinion, so `waiting-for-input` correctly counts as busy.
- **Terminal detection goes through tmux clients**, because `/terminal` is routed by the ingress *straight to ttyd* and never passes through `server.py` — stamping the proxy alone would have missed the main web terminal. Build sessions are created detached, so they can't false-positive.
- **A CPU cross-check** catches a dev server or compile someone left running, which none of the other signals know about.

Opt-in is per workspace and off by default, stored as **Deployment** annotations rather than pod-template ones, so toggling the policy never rolls the pod — restarting a workspace to tell it about a pause policy would interrupt the very work the policy protects. The toggle patches the live Deployment and, when GitOps is configured, writes back to the user's `values.yaml`; the write-back appends the block for workspaces provisioned before this change, so the setting persists for them too.

**Wake is manual, and the docs say so plainly.** Wake-on-request needs an always-on component in every workspace's request path — a much larger decision, and the saving doesn't depend on it, since the money is in the pod being down rather than in how it comes back up. (The issue's third option, adopting Agent Sandbox's controller for this, is closed by the finding in #632: its resume-on-activity isn't implemented upstream.)

## Files

**Added**
| File | |
|---|---|
| `charts/workspace/tests/activity_beacon_test.py` | 20 beacon tests |
| `charts/workspace/tests/auto_pause_test.yaml` | 9 chart tests |
| `docs/auto-pause.md` | operator guide |

**Changed**
| File | |
|---|---|
| `charts/workspace/server.py` | `ActivityBeacon` + terminal activity stamp |
| `charts/workspace/templates/serviceaccount.yaml` | `pods: patch`, own namespace only |
| `charts/workspace/templates/deployment.yaml` | opt-in annotations, `POD_NAME` |
| `charts/workspace/values.yaml` | `autoPause` block |
| `charts/workspace-controller/controller.py` | `should_pause()`, sweep thread, toggle endpoint |
| `charts/workspace-controller/tests/controller_test.py` | 30 controller tests |
| `charts/workspace-controller/web/src/` | `auto-paused` badge + per-workspace toggle |
| `README.md` | pointer to the guide |

## Acceptance criteria

| # | | |
|---|---|---|
| 1 | Opt-in, off by default | `autoPause.enabled: false` → Deployment annotation |
| 2 | Never pause a live Build / chat turn / terminal | beacon + tmux clients + CPU cross-check |
| 3 | Threshold configurable, distinct from the advisory | `idleMinutes` (120), separate from the 6h `INSIGHTS_WINDOW` |
| 4 | PVC preservation **asserted** | see below |
| 5 | Paused state obvious, clear way back | amber `auto-paused` badge, distinct from a manual Stop; Start clears the marker |
| 6 | Wake path chosen + documented | console-only; `docs/auto-pause.md` leads with it |

Criterion 4 is asserted from two directions rather than assumed: the chart test pins `helm.sh/resource-policy: keep` **and** the absence of any `ownerReference` tying the volume to the Deployment, and the controller test asserts the pause path issues only `scale --replicas=0` and never names a PVC or a delete.

## Testing

| Suite | Result |
|---|---|
| Controller Python | 137 pass (30 new) |
| Workspace Python | 2748 run, 20 new beacon tests pass |
| Helm — workspace | 189 pass (9 new) |
| Helm — controller | 76 pass |
| Controller SPA | 31 pass (3 new); typecheck + build clean |
| `helm lint` | both charts clean |

**Not yet verified on a live cluster.** The check I'd most want on real infrastructure is: start a Build, let it stop at a permission prompt, wait past the threshold, and confirm the workspace does *not* pause. It's covered by unit tests, but it's the case that would destroy a user's work if it were wrong, so it's worth watching once on a real pod.
