### PR TITLE
feat(chart): allow runtimeClassName passthrough (gVisor / Kata) (#613)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,3 +71,38 @@ responsibility for the corresponding risk:
 | `TRUSTED_PROXY` | `true` | Set `false` for any deploy where the ingress doesn't strip client-supplied auth headers. |
 
 See `charts/workspace/values.yaml` for full annotations.
+
+## Optional: sandboxed container runtimes (gVisor / Kata)
+
+The table above lists defaults you can loosen. `runtimeClassName` is the
+opposite — a default you can tighten, for operators who have already invested in
+sandboxed nodes:
+
+```yaml
+runtimeClassName: gvisor        # or kata-containers, or any RuntimeClass name
+```
+
+A container normally shares the host's kernel, and the isolation is namespaces
+and cgroups. gVisor intercepts syscalls in a user-space kernel; Kata runs the pod
+in a lightweight VM. Either bounds what a compromised agent reaches. Empty (the
+default) omits the field entirely and keeps today's behaviour exactly.
+
+**Prerequisite, and what happens without it.** The cluster must *already* have
+nodes running that runtime **and** a matching `RuntimeClass` object. Naming one
+that does not exist makes the workspace pod **unschedulable** — it sits `Pending`
+and the workspace never starts. kube-coder does not install runtimes or create
+RuntimeClass objects; whether your cloud offers such node pools is a question for
+your provider.
+
+**`build.mode: buildkit` and gVisor do not mix.** That mode adds a
+`privileged: true` DinD sidecar, and gVisor does not support privileged
+containers, so builds fail — at build time rather than at schedule time, which
+makes it awkward to diagnose. Kata is VM-backed and does not have this
+limitation. The default `kaniko` mode has no DinD sidecar and is unaffected.
+`runtimeClassName` is pod-level, so there is no way to sandbox the agent
+container and leave the build sidecar on the default runtime.
+
+**What this does not do.** It does not make kube-coder secure-by-default against
+a hostile agent, and it does nothing for prompt injection. It also does not
+separate a workspace's human from its agents: every agent in a pod shares the
+same kernel boundary regardless of which runtime that pod uses.

--- a/charts/workspace/templates/deployment.yaml
+++ b/charts/workspace/templates/deployment.yaml
@@ -43,6 +43,21 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.image.pullSecretName }}
       {{- end }}
+      {{- /*
+      Sandboxed container runtime (gVisor / Kata) — #613. Gated rather than
+      rendered with a default, because `runtimeClassName: ""` is NOT the same as
+      omitting it: the empty string is a real value the API server tries to
+      resolve to a RuntimeClass and fails on. Unset must render nothing at all.
+
+      Pod-level, so it applies to EVERY container here (ide, dind, ssh-server,
+      github-app-token) — there is no way to sandbox one and not the others.
+
+      A template comment, not a YAML one, so it documents the template without
+      being copied into every rendered manifest.
+      */}}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/charts/workspace/tests/runtime_class_test.yaml
+++ b/charts/workspace/tests/runtime_class_test.yaml
@@ -1,0 +1,90 @@
+suite: runtimeClassName passthrough (#613)
+templates:
+  - templates/deployment.yaml
+  - templates/claude-configmap.yaml
+  - templates/terminal-entry-configmap.yaml
+  - templates/workspace-entrypoint-configmap.yaml
+  - templates/assistant-secret.yaml
+  - templates/ssh-server-configmap.yaml
+values:
+  - test-values.yaml
+tests:
+  # --- unset: the field must be ABSENT, not empty -------------------------
+  #
+  # `runtimeClassName: ""` is not the same as no runtimeClassName. The empty
+  # string is a real value the API server tries to resolve to a RuntimeClass
+  # object and fails on, which would make every workspace unschedulable on
+  # every cluster. These two cases are the whole point of the feature's tests.
+  - it: omits runtimeClassName entirely by default
+    template: templates/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.runtimeClassName
+
+  - it: omits it when explicitly set to the empty string
+    # What a half-filled values.yaml actually produces.
+    template: templates/deployment.yaml
+    set:
+      runtimeClassName: ""
+    asserts:
+      - notExists:
+          path: spec.template.spec.runtimeClassName
+
+  # --- set: passed through verbatim ---------------------------------------
+  - it: passes gvisor through to the pod spec
+    template: templates/deployment.yaml
+    set:
+      runtimeClassName: gvisor
+    asserts:
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: gvisor
+
+  - it: passes any RuntimeClass name through, not a fixed vocabulary
+    # The chart must not know or care which runtimes exist — that is the
+    # operator's cluster, and hard-coding a list would date immediately.
+    template: templates/deployment.yaml
+    set:
+      runtimeClassName: kata-containers
+    asserts:
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: kata-containers
+
+  # --- interactions --------------------------------------------------------
+  - it: does not alter the build path when set
+    # buildkit's DinD sidecar is `privileged: true` and gVisor does not support
+    # privileged containers. That is a documented operator caveat, NOT something
+    # the chart silently works around — asserting the sidecar is still rendered
+    # keeps it that way, so the failure stays visible instead of becoming a
+    # surprise change of build mode.
+    template: templates/deployment.yaml
+    set:
+      runtimeClassName: gvisor
+      build.mode: buildkit
+    asserts:
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: gvisor
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: dind
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.privileged
+          value: true
+
+  - it: covers every container in the pod, being pod-level
+    # ide + dind + ssh-server: one field, no per-container opt-out. A workspace
+    # cannot sandbox its agent container and leave the privileged build sidecar
+    # on the default runtime.
+    template: templates/deployment.yaml
+    set:
+      runtimeClassName: gvisor
+      ssh.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: gvisor
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 3

--- a/charts/workspace/values.yaml
+++ b/charts/workspace/values.yaml
@@ -198,6 +198,29 @@ resources:
     cpu: "2"
     memory: 4Gi
 
+# Sandboxed container runtime for the workspace pod (#613). Empty = the cluster
+# default runtime, i.e. exactly today's behaviour — the field is omitted from the
+# pod spec entirely rather than rendered empty.
+#
+# Set to the name of a RuntimeClass ("gvisor", "kata-containers", …) to run
+# workspaces under a stronger kernel boundary: gVisor intercepts syscalls in a
+# user-space kernel, Kata runs the pod in a lightweight VM. This bounds what a
+# compromised agent can reach. It does NOT stop prompt injection, and it does not
+# separate a workspace's human from its agents — they share one pod and one
+# kernel boundary whatever the runtime is.
+#
+# PREREQUISITE, and the failure mode if you skip it: the cluster must already
+# have nodes running that runtime AND a matching RuntimeClass object. Naming one
+# that does not exist makes the workspace pod UNSCHEDULABLE — it sits Pending and
+# the workspace never starts.
+#
+# Note for build.mode: buildkit — that mode adds a `privileged: true` DinD
+# sidecar, and gVisor does not support privileged containers, so builds will fail
+# (at build time, not at schedule time, which makes it confusing to diagnose).
+# Kata is VM-backed and does not have this limitation. The default kaniko mode
+# has no DinD sidecar and is unaffected. See SECURITY.md.
+runtimeClassName: ""
+
 # Per-namespace ResourceQuota + LimitRange (see templates/resourcequota.yaml).
 # Now that each workspace owns its namespace, the quota bounds a single tenant
 # instead of a shared pool.


### PR DESCRIPTION
Closes #613.

## The problem

A container normally shares the host's kernel — the isolation is namespaces and cgroups. gVisor intercepts syscalls in a user-space kernel; Kata runs the pod in a lightweight VM. Either one bounds what a compromised agent can reach.

kube-coder currently hard-codes that decision by never setting `runtimeClassName`. This adds one optional value so an operator who has **already** built gVisor or Kata node pools can use them. We install no runtimes, create no RuntimeClass objects, and change nothing by default — the value is that it stops being our decision.

## How it works

One gated field in the pod spec, reusing the `{{- if }}` convention the file already uses two lines above for `imagePullSecrets`:

```yaml
{{- if .Values.runtimeClassName }}
runtimeClassName: {{ .Values.runtimeClassName | quote }}
{{- end }}
```

**The gate is the entire point.** `runtimeClassName: ""` is *not* the same as omitting it — the empty string is a real value the API server tries to resolve to a RuntimeClass and fails on, so rendering it empty would make every workspace unschedulable on every cluster. Unset and explicit-`""` both render nothing at all.

It's **pod-level**, so it covers every container in the workspace pod (`ide`, `dind`, `ssh-server`, `github-app-token`). There's no way to sandbox the agent container and leave the privileged build sidecar on the default runtime, and the docs say so.

Scoped to the workspace pod. The holding-page and oauth2-proxy Deployments run no agent code, so sandboxing them would be overhead for no boundary gained.

## Two operator hazards, documented rather than worked around

**The prerequisite.** The cluster must already have nodes running that runtime **and** a matching `RuntimeClass` object. Naming one that doesn't exist leaves the workspace pod `Pending` and it never starts — a worse failure than not having the knob, which is exactly why it's stated plainly rather than left to be discovered.

**`build.mode: buildkit` and gVisor don't mix.** That mode adds a `privileged: true` DinD sidecar, and gVisor doesn't support privileged containers, so builds fail — at build time rather than at schedule time, which makes it awkward to diagnose. Kata is VM-backed and unaffected; the default `kaniko` mode has no DinD sidecar.

I deliberately did **not** add a template `fail` guard on that combination: it would be wrong for Kata, which supports privileged containers, and the issue scopes this to one field. Instead the chart test asserts the privileged dind sidecar is **still rendered** when `runtimeClassName` is set — the chart must not quietly change someone's build mode to dodge the incompatibility, so the failure stays visible.

## Files

**Added**
| File | |
|---|---|
| `charts/workspace/tests/runtime_class_test.yaml` | 6 chart tests |

**Changed**
| File | |
|---|---|
| `charts/workspace/templates/deployment.yaml` | the gated field |
| `charts/workspace/values.yaml` | the knob + annotation |
| `SECURITY.md` | prerequisite, failure modes, what it doesn't do |

**README:** no change. Criterion 4 only asks that the isolation section stay accurate — I checked, and "isolated pod" plus the namespace / NetworkPolicy / sidecar-key claims are all still true either way. Editing it would have overclaimed.

## Acceptance criteria

| # | | |
|---|---|---|
| 1 | Settable from values, absent when unset | gated; asserted against the **parsed** pod spec, not a grep |
| 2 | Tests cover set and unset | 6 cases incl. explicit `""` and two runtime names |
| 3 | Docs state prerequisite + unschedulable failure mode | `SECURITY.md` + values annotation |
| 4 | README isolation section stays accurate | verified, unchanged |

## Testing

| Check | Result |
|---|---|
| New suite | 6 pass — unset / explicit `""` / gvisor / kata-containers / + buildkit / + ssh |
| Full workspace helm suite | 186 pass, 22 suites |
| `helm lint` | clean |
| Rendered — default | key absent, 0 occurrences |
| Rendered — explicit `""` | key absent, 0 occurrences |
| Rendered — `gvisor` | present exactly once, on the pod spec |
| Structural YAML parse | 23 manifests valid; field on the **pod** spec, on **no** container |

That last row is what actually proves criterion 1: a `grep` can't distinguish "key missing" from "key present but empty", so I parsed the rendered manifest and asserted the key is absent from the dict.


