### PR TITLE
fix(build): stop the host's node_modules leaking into the image build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,52 @@
+# Build-context exclusions for the image builds in this repo (devlaptop,
+# provisioner, browser-dockerfile). All of them use the repo root as their
+# context — see the `build`/`push` targets in the Makefile and
+# scripts/buildx-push.sh — so this file governs every one of them.
+#
+# The important entry is node_modules. devlaptop/Dockerfile builds the
+# dashboard SPA by installing from the lockfile and THEN copying the source
+# tree over it:
+#
+#     RUN  yarn install --frozen-lockfile      # installs for linux/<target arch>
+#     COPY charts/workspace/web/ ./            # <-- used to bring the host's
+#                                              #     node_modules along too
+#
+# COPY merges into the existing directory, so a developer's local
+# node_modules would overwrite the freshly installed one file-by-file while
+# the container's platform binaries survived — leaving a tree whose halves
+# came from two different installs. That is not hypothetical: the v1.58.2
+# build failed with
+#
+#     Cannot start service: Host version "0.25.12" does not match binary
+#     version "0.28.2"
+#
+# after a Renovate bump moved the esbuild pin, because the host's stale
+# node_modules/esbuild landed on top of the container's @esbuild/linux-x64.
+# Excluding node_modules makes the dependency install depend only on
+# package.json + yarn.lock, which is what --frozen-lockfile is supposed to
+# guarantee.
+**/node_modules
+
+# Build output. The SPA dist/ that ships in the image is produced inside the
+# dashboard-builder stage and taken via `COPY --from=`; a host dist/ is never
+# read, and copying one in only risks masking a stale build.
+**/dist
+**/build
+
+# Never referenced by any COPY, and large enough to be worth not shipping to
+# the daemon on every build.
+.git
+mobile/
+docs/
+
+# Local gitops checkout of the private users repo (`make users-sync`). Nothing
+# in any image needs it, and it holds per-workspace deployment config that has
+# no business inside a build context.
+.users/
+
+# Local/editor noise.
+.DS_Store
+*.log
+.venv/
+__pycache__/
+*.pyc


### PR DESCRIPTION
## The problem

The repo has no `.dockerignore`, so every image build ships the entire working tree to the builder. `devlaptop/Dockerfile` installs the dashboard SPA's dependencies from the lockfile and then copies the source tree over them:

```dockerfile
RUN  yarn install --frozen-lockfile      # installs for the target arch
COPY charts/workspace/web/ ./            # ...and brought host node_modules with it
```

`COPY` merges into the existing directory rather than replacing it. So the developer's local `node_modules` overwrote the freshly installed one file by file, while the container's platform binaries survived underneath — a tree with halves from two different installs, in which `--frozen-lockfile` no longer determined what got built.

## How it surfaced

This broke the **v1.58.2** release build. Renovate moved the esbuild pin 0.25.12 → 0.28.2 (#631); the lockfile was coherent, every esbuild entry agreed, and the build still failed:

```
✘ [ERROR] Cannot start service: Host version "0.25.12" does not match binary version "0.28.2"
```

`0.25.12` was the stale copy sitting on the release machine. `@esbuild/linux-x64@0.28.2` was what the container had just installed. Nothing in the repo was wrong — the build was reading a file that was never meant to be an input.

Any machine whose local `node_modules` happened to match the pin built fine, which is why this stayed hidden through every release up to now. It is the same class of failure as the v1.35.0 esbuild breakage, and it will recur on the next pin change without this.

## The fix

Exclude `node_modules`, which makes the dependency install a function of `package.json` + `yarn.lock` alone — what `--frozen-lockfile` is supposed to guarantee.

The remaining entries are paths that no `COPY` in any of the three Dockerfiles references (all of them build from the repo root, via the Makefile `build`/`push` targets and `scripts/buildx-push.sh`): in-stage build output that ships via `COPY --from=`, `.git`, `mobile/`, `docs/`, and the `.users` gitops checkout — which carries per-workspace deployment config and has no business inside a build context.

## Verification

A probe image that copies `charts/workspace/web/` and reports what arrived:

| | context transferred | `node_modules` | sources |
|---|---|---|---|
| before | 162.45 MB | present, 215 entries | present |
| after | 26.43 kB | absent | `package.json`, `yarn.lock`, `src/` all present |

A full `make build` of `devlaptop/Dockerfile` passes with the file in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
