### PR TITLE
chore(mobile): bump app version to 1.4 for the push notifications build

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -57,7 +57,7 @@ export function buildConfig(): ExpoConfig {
   return {
     name: 'kube-coder',
     slug: 'kube-coder-mobile',
-    version: '1.3',
+    version: '1.4',
     orientation: 'portrait',
     icon: './assets/icon.png',
     scheme: 'kubecoder',


### PR DESCRIPTION
One line: `mobile/app.config.ts` `version: '1.3'` → `'1.4'`.

#646 landed `expo-notifications`, which needs a new marketing version before it can ship: push cannot reach any existing install until users update to a build that actually contains the module. This is the version that TestFlight build goes out under.

### Why only `version`

`buildNumber` (iOS) and `versionCode` (Android) are deliberately untouched. `eas.json` sets `appVersionSource: "remote"` with `autoIncrement: true` on the production profile, so EAS owns those remotely and the local values in `app.config.ts` are inert — bumping them here would be noise that drifts from what EAS actually stamps.

Matches the last bump (db03608, `1.2` → `1.3`), which was the same single-line change.

### Verified

`tsc --noEmit` clean, 116 mobile tests pass.

### Still manual, before the build

Attaching an APNs push key to the EAS project (`eas credentials` → iOS → Push Key) — the `expo-notifications` config plugin already adds the `aps-environment` entitlement, so there's no manifest work, but the key itself can only come from the Apple account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TFMqFf6YizPLq9XUk3TcV