### PR TITLE
fix(hypervisor): keep the chat pinned when a completing turn swaps the transcript

### DIFF
--- a/charts/workspace/web/src/routes/hypervisor/Chat.scroll.test.tsx
+++ b/charts/workspace/web/src/routes/hypervisor/Chat.scroll.test.tsx
@@ -25,7 +25,14 @@ vi.mock('../../store/hypervisor', async (importOriginal) => {
 });
 
 import { Chat } from './Chat';
-import { events, activeThreadId, activeStatus, sending, config } from '../../store/hypervisor';
+import {
+  events,
+  activeThreadId,
+  activeStatus,
+  sending,
+  config,
+  transcriptSource,
+} from '../../store/hypervisor';
 
 const BLOCK_H = 100;
 const realFetch = globalThis.fetch;
@@ -91,6 +98,7 @@ beforeEach(() => {
   };
   activeThreadId.value = 't1';
   activeStatus.value = 'idle';
+  transcriptSource.value = 'capture';
   sending.value = false;
   // Long enough that the transcript actually scrolls under the fake layout.
   events.value = [
@@ -107,6 +115,7 @@ afterEach(() => {
   globalThis.fetch = realFetch;
   events.value = [];
   activeThreadId.value = null;
+  transcriptSource.value = null;
   sending.value = false;
   config.value = null;
 });
@@ -191,5 +200,104 @@ describe('Chat transcript pinning (#530)', () => {
     fireEvent.scroll(el);
     events.value = [...events.value, msg(7, 'assistant', 'still following')];
     await waitFor(() => expect(layout.fromBottom()).toBe(0));
+  });
+});
+
+
+describe('Chat transcript pinning across a source flip (#644)', () => {
+  /** What the server hands back once the turn completes: the same conversation
+   *  re-stamped from Claude Code's JSONL, carrying the structured tool detail
+   *  the live capture never showed — so it is *longer* than what it replaces. */
+  const sessionLog = () => [
+    msg(1, 'user', 'hello'),
+    msg(2, 'assistant', 'hi there'),
+    msg(3, 'user', 'and then?'),
+    msg(4, 'assistant', 'this and that'),
+    msg(5, 'user', 'go on'),
+    msg(6, 'assistant', 'more still'),
+    msg(7, 'assistant', 'ran a tool'),
+    msg(8, 'assistant', 'read a file'),
+    msg(9, 'assistant', 'THE FINAL ANSWER'),
+  ];
+
+  it('lands on the new answer when a completing turn swaps in the session log', async () => {
+    activeStatus.value = 'running';
+    const { container } = render(<Chat />);
+    const el = container.querySelector('.hv-transcript') as HTMLElement;
+    const layout = fakeLayout(el);
+    await waitFor(() => expect(layout.fromBottom()).toBe(0));
+
+    // The turn completes: source flips and every event is replaced.
+    transcriptSource.value = 'session_log';
+    events.value = sessionLog();
+    activeStatus.value = 'idle';
+    await settle();
+
+    expect(layout.fromBottom()).toBe(0);
+  });
+
+  it('survives the reflow scroll the swap fires — the reader never moved', async () => {
+    // The regression. Re-laying out a wholesale-replaced transcript makes the
+    // browser clamp scrollTop and fire a `scroll`; read as a gesture, it unpins
+    // a reader who never touched the page, stranding them up in older messages
+    // because the session log is longer than the capture it replaced.
+    activeStatus.value = 'running';
+    const { container } = render(<Chat />);
+    const el = container.querySelector('.hv-transcript') as HTMLElement;
+    const layout = fakeLayout(el);
+    await waitFor(() => expect(layout.fromBottom()).toBe(0));
+
+    transcriptSource.value = 'session_log';
+    events.value = sessionLog();
+    activeStatus.value = 'idle';
+    // Commit the swap first — a browser cannot clamp before the new content
+    // exists — then let the reflow fire its scroll.
+    await nextFrame();
+    layout.scrollTo(200);
+    await settle();
+
+    expect(layout.fromBottom()).toBe(0);
+  });
+
+  it('still leaves a reader who scrolled up alone across the flip', async () => {
+    // The hold must not become "always follow": someone reading history when
+    // the turn completes keeps their place.
+    activeStatus.value = 'running';
+    const { container } = render(<Chat />);
+    const el = container.querySelector('.hv-transcript') as HTMLElement;
+    const layout = fakeLayout(el);
+    await settle();
+
+    layout.scrollTo(0); // deliberately reading history — unpins
+    await settle();
+
+    transcriptSource.value = 'session_log';
+    events.value = sessionLog();
+    activeStatus.value = 'idle';
+    await settle();
+
+    expect(el.scrollTop).toBe(0);
+  });
+
+  it('unpins normally again once the swap has settled', async () => {
+    // The hold is scoped to the flip: a genuine scroll away afterwards still
+    // stops the poll from yanking the reader down.
+    activeStatus.value = 'running';
+    const { container } = render(<Chat />);
+    const el = container.querySelector('.hv-transcript') as HTMLElement;
+    const layout = fakeLayout(el);
+    await waitFor(() => expect(layout.fromBottom()).toBe(0));
+
+    transcriptSource.value = 'session_log';
+    events.value = sessionLog();
+    activeStatus.value = 'idle';
+    await settle();
+
+    layout.scrollTo(0);
+    await settle();
+    events.value = [...events.value, msg(10, 'assistant', 'a later poll result')];
+    await settle();
+
+    expect(el.scrollTop).toBe(0);
   });
 });

--- a/charts/workspace/web/src/routes/hypervisor/Chat.tsx
+++ b/charts/workspace/web/src/routes/hypervisor/Chat.tsx
@@ -752,6 +752,10 @@ export function Chat({
   // closed the jiggle feedback loop (#348).
   const programmaticTopRef = useRef<number | null>(null);
   const pinRafRef = useRef(0);
+  // Set while a transcript *swap* is re-laying out, so the scroll events that
+  // reflow fires are not mistaken for the reader leaving the bottom (#644).
+  const swapEchoRef = useRef(false);
+  const swapRafRef = useRef(0);
 
   /** One scroll write: park the viewport on the newest message. */
   function writeBottom() {
@@ -795,6 +799,17 @@ export function Chat({
     ) {
       return;
     }
+    // Mid-swap the browser is re-laying out a transcript that was replaced
+    // wholesale, and clamping scrollTop as the flow's height changes under it.
+    // Those scrolls are the reflow talking, not the reader (#644) — keep the
+    // pin, and put the viewport back on the newest message, since the offset
+    // the clamp chose is meaningless in the document that just replaced it.
+    // This settles rather than loops: the write lands at the bottom, so the
+    // scroll it fires takes the `< 80` branch above.
+    if (swapEchoRef.current) {
+      pinToBottom();
+      return;
+    }
     pinnedRef.current = false;
   }
 
@@ -804,6 +819,48 @@ export function Chat({
     pinnedRef.current = true;
     setVisibleTurns(TURN_WINDOW);
   }, [active]);
+
+  // The transcript source flips from `capture` to `session_log` the moment a
+  // turn completes, and that swap replaces every event: seqs are re-stamped, so
+  // the whole flow re-renders and the browser clamps scrollTop while the new
+  // heights settle. The clamp fires a `scroll` event that onTranscriptScroll
+  // read as "the reader chose to leave the bottom", unpinning someone who never
+  // touched the page — and because the session log is the *fuller* record
+  // (structured tool runs the live capture never showed), the offset it strands
+  // them at sits well up in older messages. That is the reported jump: the view
+  // leaps backwards exactly when the answer they were waiting for arrives
+  // (#644).
+  //
+  // Raised during render rather than from an effect, for two reasons: the
+  // reflow's scroll can land before effects flush (by then the echo would have
+  // cleared the pin, and nothing could tell that reader from one who genuinely
+  // scrolled up), and the hold's lifetime must not depend on effect ordering —
+  // an effect that early-returns leaves it stuck on, which would pin the reader
+  // to the bottom for good.
+  const lastSourceRef = useRef(transcriptSource.value);
+  if (lastSourceRef.current !== transcriptSource.value) {
+    lastSourceRef.current = transcriptSource.value;
+    // A reader who had already scrolled up keeps their place — a swap is not a
+    // reason to yank them down.
+    if (pinnedRef.current) {
+      swapEchoRef.current = true;
+      if (typeof requestAnimationFrame === 'function') {
+        // Two frames: one for the swapped-in content to lay out and fire its
+        // clamp, one for our own follow-up pin write to land. Scoped to the
+        // flip, so a reader scrolling away mid-stream still unpins immediately.
+        cancelAnimationFrame(swapRafRef.current);
+        swapRafRef.current = requestAnimationFrame(() => {
+          swapRafRef.current = requestAnimationFrame(() => {
+            swapEchoRef.current = false;
+          });
+        });
+      } else {
+        swapEchoRef.current = false;
+      }
+    }
+  }
+
+  useEffect(() => () => cancelAnimationFrame(swapRafRef.current), []);
 
   function revealEarlier() {
     // Revealing older turns must not yank the view to the bottom — unpin so the


### PR DESCRIPTION
Closes #644.

## The bug

When a running task finished, the Chat viewport jumped **backwards** into older messages instead of landing on the new answer — exactly at the moment the reader was waiting for it.

## Root cause

The transcript has two sources: `capture` while a turn streams, and `session_log` — Claude Code's structured JSONL — the moment it completes. **Completion flips the source**, and that swap replaces every event; seqs are re-stamped, which is why `sameTranscript` already treats a flip as always-changed. The whole flow re-renders and the browser clamps `scrollTop` while the new heights settle.

That clamp fires a `scroll` event, and `onTranscriptScroll` read it as *"the reader chose to leave the bottom"* — unpinning someone who never touched the page. The existing `programmaticTopRef` echo guard (#348) doesn't catch it, because after a wholesale swap the clamp lands nowhere near the offset we last wrote.

The second half is what makes it look like a jump *upward*: the session log is the **fuller** record, carrying the structured tool runs the live capture never showed, so it is longer than what it replaced. The stale offset the reader is stranded at therefore sits well up in older messages — and with the pin gone, the 2s poll no longer follows.

## The fix

Hold the pin across the swap. While a flip is settling, a scroll is the reflow talking rather than a gesture, so keep the pin and re-park on the newest message — the offset the clamp chose is meaningless in the document that just replaced it. It settles rather than loops: the write lands at the bottom, so the scroll it fires takes the existing `< 80` branch.

Two deliberate design points:

- **Raised during render, not from an effect.** The reflow's scroll can land before effects flush; by then the echo would already have cleared the pin, and nothing could distinguish that reader from one who genuinely scrolled up.
- **Its lifetime does not depend on effect ordering.** An effect that early-returns would leave the hold stuck on, which would pin the reader to the bottom permanently — a worse bug than the one being fixed. It clears on a two-frame `requestAnimationFrame` chain scheduled at the point it is raised.

Scoped to a source flip, so a reader who scrolls away mid-stream still unpins immediately.

## Tests

Four new cases in `Chat.scroll.test.tsx`, including two that guard against over-correcting:

| Test | Guards |
|---|---|
| lands on the new answer across a flip | the basic fix |
| **survives the reflow scroll the swap fires** | **the regression — fails without the fix** |
| leaves a reader who scrolled up alone across the flip | the hold isn't "always follow" |
| unpins normally again once the swap has settled | the hold actually clears |

Verified the regression test fails on `main` and passes with the change.

Full SPA suite: **871 tests pass** (105 files), `tsc --noEmit` clean, `vite build` clean.

Mobile's chat uses `scrollToEnd` without this pin/echo machinery, so it is not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014TFMqFf6YizPLq9XUk3TcV