### PR TITLE
fix(assistants): list entries whose provider key was set in Settings

### DIFF
--- a/charts/workspace/server.py
+++ b/charts/workspace/server.py
@@ -2203,6 +2203,24 @@ class ClaudeTaskManager:
     }
 
     @staticmethod
+    def _provider_keys():
+        """Provider keys as the dropdown should see them: a key the user set in
+        Settings counts exactly as much as one baked into the pod env.
+
+        ProviderKeysManager persists self-service keys on the PVC and applies
+        them at every CLI spawn, but nothing ever copies them into this
+        process's environ. Gating the dropdown on os.environ alone therefore
+        hid every self-service entry — the user set a DeepSeek key, the key was
+        used correctly the moment a turn ran, but the assistant never appeared
+        to be selectable in the first place. A stored key wins over the pod
+        env, matching env_overlay's own override semantics.
+        """
+        merged = {k: v for k, v in os.environ.items()
+                  if k in ProviderKeysManager.ALLOWED}
+        merged.update(ProviderKeysManager.env_overlay())
+        return merged
+
+    @staticmethod
     def available_assistants():
         # Claude is always first-listed and always installed, but it is no
         # longer hard-flagged as the default — the configured workspace default
@@ -2210,6 +2228,8 @@ class ClaudeTaskManager:
         # default=True and sorts to the front. See _apply_default_flag below.
         out = [dict(ClaudeTaskManager.ASSISTANTS['claude'])]
         out.append(dict(ClaudeTaskManager.ASSISTANTS['ante']))
+        # Self-service keys (Settings) count the same as pod-env keys here.
+        keys = ClaudeTaskManager._provider_keys()
         # Antigravity — listed only when its `agy` CLI is actually resolvable
         # (older images predate it; /usr/local/bin/agy is a symlink to a PVC path
         # start.sh seeds). Auth is OAuth (`agy` login once in the pod), so there's
@@ -2233,7 +2253,7 @@ class ClaudeTaskManager:
         # with an API key, so listing it without one would offer an entry whose
         # every turn fails with "Authentication Fails". An older image without
         # the binary simply doesn't list it — nothing else is affected.
-        if shutil.which('dsh') and os.environ.get('DEEPSEEK_API_KEY'):
+        if shutil.which('dsh') and keys.get('DEEPSEEK_API_KEY'):
             out.append(dict(
                 ClaudeTaskManager.ASSISTANTS['deepseek-harness'],
                 model=os.environ.get('KC_DSH_MODEL', _DSH_DEFAULT_MODEL),
@@ -2244,12 +2264,12 @@ class ClaudeTaskManager:
         # dead option.
         if shutil.which('librefang'):
             out.append(dict(ClaudeTaskManager.ASSISTANTS['librefang']))
-        if os.environ.get('OPENROUTER_API_KEY'):
+        if keys.get('OPENROUTER_API_KEY'):
             out.append(dict(
                 ClaudeTaskManager.ASSISTANTS['opencode-openrouter'],
                 model=os.environ.get('KC_OPENROUTER_MODEL', 'anthropic/claude-sonnet-4'),
             ))
-        if os.environ.get('DEEPSEEK_API_KEY'):
+        if keys.get('DEEPSEEK_API_KEY'):
             out.append(dict(
                 ClaudeTaskManager.ASSISTANTS['opencode-deepseek'],
                 model=os.environ.get('KC_DEEPSEEK_MODEL', 'deepseek-chat'),
@@ -2259,7 +2279,7 @@ class ClaudeTaskManager:
         # auto-discovered provider: start.sh writes an explicit opencode.json
         # provider stanza when OPENCODE_API_KEY is set (a per-user or a shared
         # platform key), which is the same signal we gate the dropdown on here.
-        if os.environ.get('OPENCODE_API_KEY'):
+        if keys.get('OPENCODE_API_KEY'):
             out.append(dict(
                 ClaudeTaskManager.ASSISTANTS['opencode-zen'],
                 model=os.environ.get('KC_OPENCODE_ZEN_MODEL', _OPENCODE_ZEN_DEFAULT_MODEL),

--- a/charts/workspace/tests/dsh_assistant_test.py
+++ b/charts/workspace/tests/dsh_assistant_test.py
@@ -30,14 +30,20 @@ def _ids(assistants):
 
 
 class _GateBase(unittest.TestCase):
-    """available_assistants() reads os.environ and PATH; pin both."""
+    """available_assistants() reads PATH, os.environ and the stored provider
+    keys; pin all three. `stored` is what the user set in Settings, which
+    ProviderKeysManager persists on the PVC — it must be stubbed rather than
+    left to the real file, or a run inside a workspace pod would read that
+    pod's keys and stop testing anything."""
 
     # A workspace with nothing else configured, so the assertions are about
     # `dsh` alone rather than about whatever this machine happens to have set.
     BASE_ENV = {}
 
-    def listed(self, env, which):
+    def listed(self, env, which, stored=None):
         with mock.patch.dict(os.environ, env, clear=True), \
+                mock.patch.object(server.ProviderKeysManager, 'env_overlay',
+                                  return_value=dict(stored or {})), \
                 mock.patch.object(server.shutil, 'which',
                                   side_effect=lambda n: '/usr/local/bin/' + n
                                   if n in which else None):
@@ -97,6 +103,44 @@ class GatingTest(_GateBase):
         self.assertEqual(entry['models'][0], 'deepseek-v4-pro')
         # …and is not duplicated further down the list.
         self.assertEqual(entry['models'].count('deepseek-v4-pro'), 1)
+
+
+class SelfServiceKeyTest(_GateBase):
+    """A key set in Settings must enable the entry exactly like a pod-env one.
+
+    ProviderKeysManager persists self-service keys on the PVC and applies them
+    at CLI spawn, but never copies them into the server's own environ. The
+    dropdown gated on os.environ alone, so a user could set a DeepSeek key,
+    have it work the moment a turn ran, and still never be offered the
+    assistant — which is how it presented on a workspace running v1.60.0.
+    """
+
+    def test_stored_key_lists_the_harness(self):
+        out = self.listed({}, {'dsh'}, stored={'DEEPSEEK_API_KEY': 'sk-x'})
+        self.assertIn(DSH, _ids(out))
+
+    def test_stored_key_lists_the_opencode_deepseek_entry(self):
+        out = self.listed({}, set(), stored={'DEEPSEEK_API_KEY': 'sk-x'})
+        self.assertIn('opencode-deepseek', _ids(out))
+
+    def test_stored_key_still_needs_the_binary(self):
+        out = self.listed({}, set(), stored={'DEEPSEEK_API_KEY': 'sk-x'})
+        self.assertNotIn(DSH, _ids(out))
+
+    def test_stored_openrouter_and_zen_keys_list_their_entries(self):
+        out = _ids(self.listed({}, set(), stored={
+            'OPENROUTER_API_KEY': 'sk-or', 'OPENCODE_API_KEY': 'sk-oc'}))
+        self.assertIn('opencode-openrouter', out)
+        self.assertIn('opencode-zen', out)
+
+    def test_stored_key_overrides_the_pod_env(self):
+        out = self.listed({'DEEPSEEK_API_KEY': 'sk-pod'}, {'dsh'},
+                          stored={'DEEPSEEK_API_KEY': 'sk-user'})
+        self.assertIn(DSH, _ids(out))
+
+    def test_no_key_anywhere_still_hides_it(self):
+        out = self.listed({}, {'dsh'}, stored={})
+        self.assertNotIn(DSH, _ids(out))
 
 
 class ModelListTest(unittest.TestCase):


### PR DESCRIPTION
## Symptom

On a workspace running v1.60.0 with `dsh` installed **and** a DeepSeek key set, **DeepSeek Harness did not appear** in the AI CTO, Chat, or Builds pickers.

## Cause

`ProviderKeysManager` persists self-service keys to `/home/dev/.claude-tasks/provider-keys.json` and applies them at every CLI spawn via `env_overlay()` — but **nothing ever copies them into the server process's own `os.environ`**.

`available_assistants()` gated on `os.environ` alone:

```python
if shutil.which('dsh') and os.environ.get('DEEPSEEK_API_KEY'):
```

So a key set from Settings — the documented "no redeploy" self-service path — satisfied the *spawn* but never the *dropdown*. The assistant stayed invisible while the key it needed sat on disk. `_resolve_assistant` would also have rejected it as "not enabled" if anything requested it by id.

Verified on a live workspace: `dsh` at `/usr/local/bin/dsh`, `DEEPSEEK_API_KEY` present in `provider-keys.json`, absent from the server process's `/proc/<pid>/environ`.

## Fix

Resolve provider keys through a merged view — stored key wins over pod env, matching `env_overlay`'s own override semantics.

**Four gates shared this bug:** `deepseek-harness`, `opencode-deepseek`, `opencode-openrouter`, `opencode-zen`. Only the first is new in v1.60.0; the other three have been wrong for as long as Settings has offered those keys. Nobody hit it until an assistant shipped whose *only* auth path is an API key — `agy`/`codex` gate on binary presence because they use OAuth.

## Scope

All surfaces read the same `available_assistants()` (`/api/claude/assistants` and `/api/hypervisor/config`), so this is **one fix, not four**. The mobile app fetches the same endpoint — its static lists are a pre-load fallback and demo-mode mock data and correctly need no change.

## Tests

`SelfServiceKeyTest` — stored key lists the harness; still requires the binary; covers OpenRouter/Zen; stored key overrides pod env; no key anywhere still hides it.

Existing gating tests now stub `ProviderKeysManager.env_overlay` rather than letting it read the real file — otherwise a run inside a workspace pod would read that pod's keys and stop testing anything.

`python-tests`: 2945 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hspp7AaiC9Sp2gUDenuxCs